### PR TITLE
[BUG]: fix BasicAgent memory recall policy

### DIFF
--- a/crates/autoagents-core/src/agent/executor/memory_policy.rs
+++ b/crates/autoagents-core/src/agent/executor/memory_policy.rs
@@ -35,12 +35,12 @@ pub struct MemoryPolicy {
 impl MemoryPolicy {
     pub fn basic() -> Self {
         Self {
-            recall: false,
-            recall_query: RecallQuery::Empty,
+            recall: true,
+            recall_query: RecallQuery::Prompt,
             recall_limit: None,
             store_user: true,
             store_assistant: true,
-            store_tool_interactions: false,
+            store_tool_interactions: true,
         }
     }
 
@@ -53,6 +53,22 @@ impl MemoryPolicy {
             store_assistant: true,
             store_tool_interactions: true,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{MemoryPolicy, RecallQuery};
+
+    #[test]
+    fn test_basic_memory_policy_enables_recall_and_tool_interactions() {
+        let policy = MemoryPolicy::basic();
+
+        assert!(policy.recall);
+        assert!(matches!(policy.recall_query, RecallQuery::Prompt));
+        assert!(policy.store_user);
+        assert!(policy.store_assistant);
+        assert!(policy.store_tool_interactions);
     }
 }
 
@@ -160,7 +176,7 @@ impl MemoryAdapter {
             .remember(&ChatMessage {
                 role: ChatRole::Tool,
                 message_type: MessageType::ToolResult(result_tool_calls),
-                content: String::new(),
+                content: String::default(),
             })
             .await;
     }


### PR DESCRIPTION
Bug : 
The current Basic Executor just uses user prompt and System message so because of this it lacks previous history and context

Steps to Reproduce : 
Use Basic agent and ask first couple of questions, and final ask it to tell the first question the agent wont have memory

Fixed Behavior : 
Agent now has memory regarding previous context 

Testing : 
- Added unit test
- Verified Manually to see if agent is able to recall a value from first prompt in second prompt.