### PR TITLE
Decoupled logical id from Qdrant point id + point deletion

### DIFF
--- a/crates/autoagents-qdrant/Cargo.toml
+++ b/crates/autoagents-qdrant/Cargo.toml
@@ -15,7 +15,7 @@ async-trait = { workspace = true }
 serde_json = { workspace = true }
 serde = { workspace = true }
 qdrant-client = { workspace = true }
-uuid = { workspace = true, features = ["v4"] }
+uuid = { workspace = true, features = ["v4", "v5"] }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread"] }


### PR DESCRIPTION
Related to:
#147 
#149 

In this PR I am proposing a way to decouple the logic id of the document from the Qdrant point id.
A point in Qdrant looks like this:
<img width="1464" height="681" alt="image" src="https://github.com/user-attachments/assets/3fd0a150-9bb7-4d82-b99c-b9a427c52f37" />
With a proper UUIDv5 id.

As this activity was preparation work for implementing deletion capabilities, I added also the method `delete_documents_by_ids` which can remove batches of points.

Please let me know what you think. The deletion part probably would need its own issue for tracking purposes.

Thanks and best regards