### PR TITLE
[FEATURE] Enable recursive directory traversal in search_file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -713,6 +713,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "toml 0.9.11+spec-1.1.0",
+ "walkdir",
 ]
 
 [[package]]
@@ -7198,6 +7199,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rust-copilot-daemon"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "autoagents-core",
+ "autoagents-llm",
+ "autoagents-qdrant",
+ "serde",
+ "serde_json",
+ "tokio",
+ "walkdir",
+]
+
+[[package]]
 name = "rust-mcp-schema"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7812,6 +7827,12 @@ dependencies = [
  "cpufeatures",
  "digest",
 ]
+
+[[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
 
 [[package]]
 name = "sha2"
@@ -9497,6 +9518,7 @@ dependencies = [
  "getrandom 0.3.4",
  "js-sys",
  "serde_core",
+ "sha1_smol",
  "wasm-bindgen",
 ]
 

--- a/crates/autoagents-toolkit/Cargo.toml
+++ b/crates/autoagents-toolkit/Cargo.toml
@@ -25,6 +25,7 @@ reqwest = { workspace = true, optional = true }
 log = { workspace = true }
 once_cell = { workspace = true, optional = true }
 base64 = { workspace = true }
+walkdir = { workspace = true }
 toml = { version = "0.9.11", optional = true }
 thiserror = { workspace = true }
 rmcp = { workspace = true, optional = true, features = [

--- a/examples/coding_agent/src/agent.rs
+++ b/examples/coding_agent/src/agent.rs
@@ -47,7 +47,7 @@ As a ReAct agent, you follow this pattern for each task:
 
 Remember: You are a systematic problem solver. Think through each step, use your tools effectively, and provide clear, actionable results.",
     tools = [
-        SearchFile::new(),
+        SearchFile::new(100),
         GrepTool,
         ReadFile::new(),
         WriteFile::new(),


### PR DESCRIPTION
**PR Description**
This PR updates search_file to walk nested directories instead of only scanning the top-level folder.
#151 

**What changed**
- Replaced the single read_dir pass with an iterative directory traversal using pending_dirs: Vec<PathBuf>
- Added PathBuf import to support the traversal queue
- Switched _recursive to recursive and used it to control whether subdirectories are enqueued
- Kept existing behavior for filename matching, case sensitivity, and max results

**Why**
search_file was effectively non-recursive, which prevented it from finding matches inside nested folders. This change restores recursive search behavior and aligns runtime behavior with expected file-search semantics.

**Scope / limitations**
recursive is still internally set to true (not user-configurable via input args yet).
Content search remains disabled (search_content = false).
? wildcard matching is still not implemented (only * behavior is present).

**Test**
Tested running example coding_agent.
Now the search file tool can handle prompts like:

> search for all .js files in docs

<img width="868" height="675" alt="image" src="https://github.com/user-attachments/assets/b07861b7-1aa3-4da5-98d8-d35dc414f55a" />

