### PR TITLE
[FEATURE]: Named Vectors Support in autoagents-qdrant

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ syn = { version = "2.0.98", features = ["full"] }
 tokio = { version = "1.43.0", features = ["full"] }
 async-trait = "0.1.86"
 reqwest = { version = "0.12.12", features = ["json", "stream"] }
-serde = { version = "1.0.225", features = ["derive"], default-features = false }
+serde = { version = "1.0.225", features = ["derive", "rc"], default-features = false }
 serde_json = "1.0.145"
 strum = { version = "0.27.1", features = ["derive", "strum_macros"] }
 strum_macros = "0.27.1"

--- a/crates/autoagents-core/src/embeddings/mod.rs
+++ b/crates/autoagents-core/src/embeddings/mod.rs
@@ -9,16 +9,19 @@ use crate::one_or_many::OneOrMany;
 pub mod distance;
 
 pub type SharedEmbeddingProvider = Arc<dyn EmbeddingProvider + Send + Sync>;
+pub type VecArc = Arc<[f32]>;
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct Embedding {
     pub document: String,
-    pub vec: Vec<f32>,
+    pub vec: VecArc,
 }
 
 impl distance::VectorDistance for Embedding {
     fn cosine_similarity(&self, other: &Self, normalize: bool) -> f32 {
-        self.vec.cosine_similarity(&other.vec, normalize)
+        self.vec
+            .as_ref()
+            .cosine_similarity(other.vec.as_ref(), normalize)
     }
 }
 
@@ -141,7 +144,7 @@ where
                 .enumerate()
                 .map(|(offset, vector)| Embedding {
                     document: texts[start + offset].clone(),
-                    vec: vector.clone(),
+                    vec: vector.clone().into(),
                 })
                 .collect();
             cursor += len;

--- a/crates/autoagents-core/src/vector_store/request.rs
+++ b/crates/autoagents-core/src/vector_store/request.rs
@@ -6,6 +6,7 @@ use super::VectorStoreError;
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct VectorSearchRequest<F = Filter<serde_json::Value>> {
     query: String,
+    query_vector_name: Option<String>,
     samples: u64,
     threshold: Option<f64>,
     additional_params: Option<serde_json::Value>,
@@ -19,6 +20,10 @@ impl<Filter> VectorSearchRequest<Filter> {
 
     pub fn query(&self) -> &str {
         &self.query
+    }
+
+    pub fn query_vector_name(&self) -> Option<&str> {
+        self.query_vector_name.as_deref()
     }
 
     pub fn samples(&self) -> u64 {
@@ -39,6 +44,7 @@ impl<Filter> VectorSearchRequest<Filter> {
     {
         VectorSearchRequest {
             query: self.query,
+            query_vector_name: self.query_vector_name,
             samples: self.samples,
             threshold: self.threshold,
             additional_params: self.additional_params,
@@ -167,6 +173,7 @@ impl Filter<serde_json::Value> {
 #[derive(Clone, Serialize, Deserialize, Debug)]
 pub struct VectorSearchRequestBuilder<F = Filter<serde_json::Value>> {
     query: Option<String>,
+    query_vector_name: Option<String>,
     samples: Option<u64>,
     threshold: Option<f64>,
     additional_params: Option<serde_json::Value>,
@@ -177,6 +184,7 @@ impl<F> Default for VectorSearchRequestBuilder<F> {
     fn default() -> Self {
         Self {
             query: None,
+            query_vector_name: None,
             samples: None,
             threshold: None,
             additional_params: None,
@@ -199,6 +207,14 @@ where
 
     pub fn samples(mut self, samples: u64) -> Self {
         self.samples = Some(samples);
+        self
+    }
+
+    pub fn query_vector_name<T>(mut self, name: T) -> Self
+    where
+        T: Into<String>,
+    {
+        self.query_vector_name = Some(name.into());
         self
     }
 
@@ -246,6 +262,7 @@ where
 
         Ok(VectorSearchRequest {
             query,
+            query_vector_name: self.query_vector_name,
             samples,
             threshold: self.threshold,
             additional_params,

--- a/crates/autoagents-qdrant/README.md
+++ b/crates/autoagents-qdrant/README.md
@@ -1,3 +1,11 @@
 # AutoAgents Qdrant
 
 Vector store index integration for [Qdrant](https://qdrant.tech/). This adapter works with AutoAgents embedding providers and supports dense retrieval as well as Qdrant's [hybrid queries](https://qdrant.tech/documentation/concepts/hybrid-queries/).
+
+## Named vectors
+
+`autoagents-qdrant` supports Qdrant named vectors via the vector-store API:
+
+- Use `VectorStoreIndex::insert_documents_with_named_vectors(...)` to upsert points with multiple named vector spaces.
+- Use `VectorSearchRequest::builder().query_vector_name("symbol")` to select the vector space at query time.
+- Keep omitting `query_vector_name` (or use `"default"`) for backward-compatible single-vector behavior.


### PR DESCRIPTION
**Summary**
This PR adds first-class named vectors support for autoagents-qdrant and the core vector-store abstraction, while preserving backward compatibility with existing single-vector workflows.
#146 

It enables:
- Creating/using Qdrant collections with named vectors
- Upserting points with multiple named vectors
- Selecting query vector by name at search time
- Keeping existing payload behavior (source_id, raw) and deterministic point-id mapping
- Keeping legacy single-vector flow working via default behavior

**What changed**
**autoagents-core**
Extended VectorSearchRequest with optional query-time vector selection:
- Added query_vector_name: Option<String>
- Added builder method .query_vector_name(...)
- Added a default vector name constant:
- DEFAULT_VECTOR_NAME = "default"

Extended VectorStoreIndex trait with named-vector upsert:
- insert_documents_with_named_vectors(...)

Added named-vector document types and embedding pipeline:
- NamedVectorDocument<T>
- PreparedNamedVectorDocument
- embed_named_documents(...)

**autoagents-qdrant**

- Added named collection creation support using VectorsConfigBuilder

- Added named-vector upsert path:

  - Accepts multiple named vectors per point
  - Preserves payload shape (raw, source_id)
  - Preserves deterministic UUIDv5 point-id mapping from logical/source ID

Added named-vector query selection:
- Uses VectorSearchRequest.query_vector_name()
- Falls back to default/single-vector behavior when not set (or set to "default")

**autoagents-core in-memory store**
- Added support for inserting named vectors
- Added support for query-time vector-name routing
- Preserved legacy scoring behavior for existing single-vector data

**Docs**
- Updated README.md with named-vector usage notes

**Backward compatibility**
- Existing insert_documents(...) / insert_documents_with_ids(...) continue to work unchanged
- Existing searches without query_vector_name keep current behavior
- Payload and point-id semantics are unchanged

**Validation**
cargo fmt --all
cargo check -p autoagents-core -p autoagents-qdrant
cargo check -p vector-store-in-memory -p vector-store-qdrant -p rust-copilot-daemon
cargo check -p rust-copilot-daemon
All checks pass locally.

Local test with Qdrant and default vectors.
Local test with Qdrant and named vectors

<img width="1464" height="874" alt="image" src="https://github.com/user-attachments/assets/b54b1a1c-a041-42be-bbaa-52a5e23d76b5" />


Notes
If a Qdrant collection already exists with legacy single-vector schema, named-vector upserts may require creating a new collection or migrating schema depending on Qdrant constraints.