### PR TITLE
Add named collection recreate API for qdrant store

### DIFF
--- a/crates/autoagents-qdrant/README.md
+++ b/crates/autoagents-qdrant/README.md
@@ -7,5 +7,6 @@ Vector store index integration for [Qdrant](https://qdrant.tech/). This adapter 
 `autoagents-qdrant` supports Qdrant named vectors via the vector-store API:
 
 - Use `VectorStoreIndex::insert_documents_with_named_vectors(...)` to upsert points with multiple named vector spaces.
+- Use `QdrantVectorStore::recreate_collection_named(dimensions)` when you need an explicit collection reset with named vector configuration.
 - Use `VectorSearchRequest::builder().query_vector_name("symbol")` to select the vector space at query time.
 - Keep omitting `query_vector_name` (or use `"default"`) for backward-compatible single-vector behavior.

--- a/crates/autoagents-qdrant/src/lib.rs
+++ b/crates/autoagents-qdrant/src/lib.rs
@@ -87,17 +87,7 @@ impl QdrantVectorStore {
         &self,
         dimensions: &HashMap<String, u64>,
     ) -> Result<(), VectorStoreError> {
-        let mut config = VectorsConfigBuilder::default();
-        for (name, dimension) in dimensions {
-            config.add_named_vector_params(
-                name.clone(),
-                VectorParamsBuilder::new(*dimension, Distance::Cosine),
-            );
-        }
-
-        let request = CreateCollectionBuilder::new(self.collection_name.clone())
-            .vectors_config(config)
-            .build();
+        let request = Self::named_collection_request(&self.collection_name, dimensions);
 
         let result = self.client.create_collection(request).await;
         if let Err(err) = result {
@@ -108,6 +98,49 @@ impl QdrantVectorStore {
         }
 
         Ok(())
+    }
+
+    pub async fn recreate_named_collection(
+        &self,
+        dimensions: HashMap<String, u64>,
+    ) -> Result<(), VectorStoreError> {
+        let exists = self
+            .client
+            .collection_exists(self.collection_name.clone())
+            .await
+            .map_err(|err| VectorStoreError::DatastoreError(Box::new(err)))?;
+
+        if exists {
+            self.client
+                .delete_collection(self.collection_name.clone())
+                .await
+                .map_err(|err| VectorStoreError::DatastoreError(Box::new(err)))?;
+        }
+
+        let request = Self::named_collection_request(&self.collection_name, &dimensions);
+        self.client
+            .create_collection(request)
+            .await
+            .map_err(|err| VectorStoreError::DatastoreError(Box::new(err)))?;
+
+        Ok(())
+    }
+
+    fn named_collection_request(
+        collection_name: &str,
+        dimensions: &HashMap<String, u64>,
+    ) -> qdrant_client::qdrant::CreateCollection {
+        let mut config = VectorsConfigBuilder::default();
+        for (name, dimension) in dimensions {
+            config.add_named_vector_params(
+                name.clone(),
+                VectorParamsBuilder::new(*dimension, Distance::Cosine),
+            );
+        }
+
+        CreateCollectionBuilder::new(collection_name.to_string())
+            .vectors_config(config)
+            .build()
     }
 
     fn payload_for(doc: &PreparedDocument) -> Result<Payload, VectorStoreError> {


### PR DESCRIPTION
**Summary**
This PR adds explicit named-collection reset support to autoagents-qdrant
#169 

**What changed**

- Added QdrantVectorStore::recreate_collection_named(dimensions: HashMap<String, u64>) -> Result<(), VectorStoreError>.
- Implemented deterministic recreate flow: Check collection_exists. Delete collection when present.
- Recreate with named vector config from dimensions.
- Return typed VectorStoreError on failures.
- Updated autoagents-qdrant README to document the new API

**Why**
Downstream crates needed a clean, programmatic collection reset for diagnostics/latest-pass workflows without directly depending on qdrant-client.
This centralizes lifecycle logic in autoagents-qdrant, keeps abstraction boundaries intact, and avoids duplicated collection admin code.