### PR TITLE
[BUG]: Remove named-collection recreate API and reset collection by delete-only flow

### DIFF
--- a/crates/autoagents-qdrant/README.md
+++ b/crates/autoagents-qdrant/README.md
@@ -7,6 +7,6 @@ Vector store index integration for [Qdrant](https://qdrant.tech/). This adapter 
 `autoagents-qdrant` supports Qdrant named vectors via the vector-store API:
 
 - Use `VectorStoreIndex::insert_documents_with_named_vectors(...)` to upsert points with multiple named vector spaces.
-- Use `QdrantVectorStore::recreate_collection_named(dimensions)` when you need an explicit collection reset with named vector configuration.
+- Use `QdrantVectorStore::delete_collection_if_exists()` when you need an explicit collection reset before first upsert defines dimensions.
 - Use `VectorSearchRequest::builder().query_vector_name("symbol")` to select the vector space at query time.
 - Keep omitting `query_vector_name` (or use `"default"`) for backward-compatible single-vector behavior.


### PR DESCRIPTION
**Summary**
#178 
This PR removes the explicit named-collection recreate path from autoagents-qdrant and standardizes diagnostics reset behavior to a simpler delete-only flow before first upsert.

**What changed**
Removed recreate_named_collection(...) from lib.rs.
Added [delete_collection_if_exists(...)] as the explicit reset API.
Updated README.md.

**Why**
The recreate method was accepting embedding dimensions as an input parameter.
Hardcoded or precomputed recreate dimensions are brittle and can diverge from actual embedding output.
Delete-only reset is cleaner:
- no hardcoded dimension assumptions
- no probe embedding call required
- first real upsert defines dimensions via normal ensure_named_collection(...) behavior


Validation
Run tests and integrated our side.