### PR TITLE
docs: add FAQ section for common questions

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,6 +440,61 @@ AutoAgents is designed for high performance:
 
 ---
 
+
+## FAQ
+
+### General
+
+**What is AutoAgents?**
+AutoAgents is a production-grade, multi-agent framework written in Rust. It provides a modular architecture for building intelligent systems with type-safe agent models, structured tool calling, configurable memory, and pluggable LLM backends — designed for performance, safety, and composability across server and edge environments.
+
+**How does AutoAgents differ from other agent frameworks?**
+AutoAgents is Rust-first, offering memory safety, zero-cost abstractions, and high performance. It provides a unified interface for cloud and local LLM providers, built-in guardrails, optimization passes (cache/retry), and a WASM sandbox for tool execution — all in a single framework.
+
+**Is there a Python version?**
+Yes. AutoAgents provides Python bindings via `autoagents-py` on PyPI, enabling Python developers to leverage the Rust core with a familiar API.
+
+### Setup & Configuration
+
+**How do I install AutoAgents?**
+Install via Cargo: `cargo add autoagents`, or via PyPI for Python: `pip install autoagents-py`. See the [documentation](https://liquidos-ai.github.io/AutoAgents/) for detailed setup guides.
+
+**Which LLM providers are supported?**
+AutoAgents supports OpenAI, OpenRouter, Anthropic, DeepSeek, xAI, and local models via a unified interface. Configure your API keys in the environment or configuration file.
+
+**Can I use local models?**
+Yes. AutoAgents supports local LLM backends through its unified provider interface, enabling fully offline agent operation.
+
+### Agent Development
+
+**What is the ReAct executor?**
+The ReAct (Reasoning + Acting) executor is AutoAgents' primary agent execution model. It alternates between reasoning steps and tool calls, enabling agents to plan, execute, and observe results in a loop until the task is complete.
+
+**How does the tool system work?**
+Tools are defined using derive macros (`#[derive(Tool)]`) for type-safe input/output. AutoAgents also provides a sandboxed WASM runtime for executing untrusted tools securely.
+
+**What memory backends are available?**
+AutoAgents uses a sliding window memory model by default, with extensible backends for custom memory strategies — enabling fine-grained control over context management.
+
+### Multi-Agent Orchestration
+
+**How do agents communicate?**
+AutoAgents provides typed pub/sub communication between agents, enabling structured message passing with compile-time type safety. Agents can publish events and subscribe to topics in a decoupled architecture.
+
+**What is the environment system?**
+The environment system manages shared state and resources across multiple agents. It provides a controlled space where agents can interact, share observations, and coordinate actions.
+
+### Troubleshooting
+
+**Build fails with Rust version errors. What should I do?**
+AutoAgents requires Rust 1.75+. Run `rustup update` to get the latest stable version. Check the [documentation](https://liquidos-ai.github.io/AutoAgents/) for minimum version requirements.
+
+**Where can I get help?**
+- Documentation: https://liquidos-ai.github.io/AutoAgents/
+- Examples: `examples/` directory in the repository
+- DeepWiki: https://deepwiki.com/liquidos-ai/AutoAgents
+- GitHub Issues: https://github.com/liquidos-ai/AutoAgents/issues
+
 ## License
 
 AutoAgents is dual-licensed under:


### PR DESCRIPTION
## Summary
Add a comprehensive FAQ section to the README covering common questions about AutoAgents.

## FAQ Topics Covered
- **General**: What is AutoAgents, Rust-first advantages, Python bindings
- **Setup & Configuration**: Cargo/PyPI installation, LLM providers, local models
- **Agent Development**: ReAct executor, tool system (derive macros + WASM), memory backends
- **Multi-Agent Orchestration**: Typed pub/sub communication, environment system
- **Troubleshooting**: Rust version requirements, help resources

## Why FAQ?
New users frequently ask about AutoAgents' Rust-first architecture, installation methods, supported LLM providers, agent execution model, and multi-agent communication patterns. This FAQ provides quick answers without requiring users to navigate the full documentation.

## Checklist
- [x] Content is specific to AutoAgents (not generic)
- [x] FAQ is placed before License section (consistent with README structure)
- [x] Links to official docs/DeepWiki/GitHub are preserved
- [x] No existing FAQ section was overwritten