### PR TITLE
feat(llm): surface usage tokens for Ollama and Google backends

### DIFF
--- a/crates/autoagents-llm/src/backends/google.rs
+++ b/crates/autoagents-llm/src/backends/google.rs
@@ -126,13 +126,35 @@ struct GoogleGenerationConfig {
 struct GoogleChatResponse {
     /// Generated completion candidates
     candidates: Vec<GoogleCandidate>,
+    /// Token usage metadata per Gemini API spec (always present on
+    /// non-streaming responses; present on the terminal streaming chunk).
+    #[serde(rename = "usageMetadata", default)]
+    usage_metadata: Option<GoogleUsageMetadata>,
 }
 
-/// Response from the streaming chat completion API
+/// Response from the streaming chat completion API.
+///
+/// Note: Gemini surfaces `usageMetadata` on the terminal streaming chunk too,
+/// but the current SSE path (`parse_google_sse_chunk`) only extracts text.
+/// Streaming usage tracking would require accumulating the terminal chunk —
+/// out of scope for the initial usage() patch; tracked separately.
 #[derive(Deserialize, Debug)]
 struct GoogleStreamResponse {
     /// Generated completion candidates
     candidates: Option<Vec<GoogleCandidate>>,
+}
+
+/// Token accounting fields from the Gemini API response.
+/// See <https://ai.google.dev/api/generate-content#UsageMetadata>.
+#[derive(Deserialize, Debug, Default, Clone)]
+#[serde(rename_all = "camelCase")]
+struct GoogleUsageMetadata {
+    #[serde(default)]
+    prompt_token_count: u32,
+    #[serde(default)]
+    candidates_token_count: u32,
+    #[serde(default)]
+    total_token_count: u32,
 }
 
 impl std::fmt::Display for GoogleChatResponse {
@@ -234,6 +256,23 @@ impl ChatResponse for GoogleChatResponse {
                     }]
                 })
             }
+        })
+    }
+
+    fn usage(&self) -> Option<crate::chat::Usage> {
+        self.usage_metadata.as_ref().map(|u| crate::chat::Usage {
+            prompt_tokens: u.prompt_token_count,
+            completion_tokens: u.candidates_token_count,
+            // Prefer Gemini's reported total (covers thinking tokens, etc).
+            // Fall back to sum if the API ever omits it.
+            total_tokens: if u.total_token_count > 0 {
+                u.total_token_count
+            } else {
+                u.prompt_token_count
+                    .saturating_add(u.candidates_token_count)
+            },
+            completion_tokens_details: None,
+            prompt_tokens_details: None,
         })
     }
 }
@@ -964,6 +1003,7 @@ mod tests {
                     function_calls: None,
                 },
             }],
+            usage_metadata: None,
         };
 
         assert_eq!(response.text(), Some("hi".to_string()));
@@ -989,6 +1029,7 @@ mod tests {
                     }]),
                 },
             }],
+            usage_metadata: None,
         };
 
         let calls = response.tool_calls().unwrap();
@@ -1110,5 +1151,84 @@ mod tests {
         let tools = build_google_tools(Some(&[tool])).unwrap();
         assert_eq!(tools.len(), 1);
         assert_eq!(tools[0].function_declarations.len(), 1);
+    }
+
+    #[test]
+    fn test_google_usage_returns_none_when_metadata_absent() {
+        let response = GoogleChatResponse {
+            candidates: vec![],
+            usage_metadata: None,
+        };
+        assert!(response.usage().is_none());
+    }
+
+    #[test]
+    fn test_google_usage_maps_metadata_to_usage() {
+        let response = GoogleChatResponse {
+            candidates: vec![],
+            usage_metadata: Some(GoogleUsageMetadata {
+                prompt_token_count: 12,
+                candidates_token_count: 34,
+                total_token_count: 46,
+            }),
+        };
+        let usage = response.usage().expect("usage populated");
+        assert_eq!(usage.prompt_tokens, 12);
+        assert_eq!(usage.completion_tokens, 34);
+        assert_eq!(usage.total_tokens, 46);
+    }
+
+    #[test]
+    fn test_google_usage_falls_back_to_sum_when_total_zero() {
+        // Defensive — if Gemini ever returns the components without total.
+        let response = GoogleChatResponse {
+            candidates: vec![],
+            usage_metadata: Some(GoogleUsageMetadata {
+                prompt_token_count: 5,
+                candidates_token_count: 7,
+                total_token_count: 0,
+            }),
+        };
+        let usage = response.usage().expect("usage populated");
+        assert_eq!(usage.total_tokens, 12);
+    }
+
+    #[test]
+    fn test_google_chat_response_deserializes_usage_metadata_from_api_payload() {
+        // Sample non-streaming generateContent response per Gemini API docs.
+        // See https://ai.google.dev/api/generate-content#UsageMetadata
+        let payload = json!({
+            "candidates": [{
+                "content": {
+                    "parts": [{ "text": "Hello!" }]
+                }
+            }],
+            "usageMetadata": {
+                "promptTokenCount": 11,
+                "candidatesTokenCount": 22,
+                "totalTokenCount": 33
+            }
+        });
+        let response: GoogleChatResponse =
+            serde_json::from_value(payload).expect("realistic Gemini payload must deserialize");
+        let usage = response
+            .usage()
+            .expect("usage_metadata must populate Usage");
+        assert_eq!(usage.prompt_tokens, 11);
+        assert_eq!(usage.completion_tokens, 22);
+        assert_eq!(usage.total_tokens, 33);
+    }
+
+    #[test]
+    fn test_google_chat_response_deserializes_without_usage_metadata() {
+        // Legacy / cached responses may omit usageMetadata; must not fail.
+        let payload = json!({
+            "candidates": [{
+                "content": { "parts": [{ "text": "ok" }] }
+            }]
+        });
+        let response: GoogleChatResponse = serde_json::from_value(payload)
+            .expect("response without usageMetadata must still deserialize");
+        assert!(response.usage().is_none());
     }
 }

--- a/crates/autoagents-llm/src/backends/ollama.rs
+++ b/crates/autoagents-llm/src/backends/ollama.rs
@@ -118,11 +118,22 @@ struct OllamaChatMessage<'a> {
 }
 
 /// Response from Ollama's API endpoints.
-#[derive(Deserialize, Debug)]
+///
+/// Per Ollama's API docs (`/api/chat` + `/api/generate`), `prompt_eval_count`
+/// and `eval_count` appear in the final response object (both streaming and
+/// non-streaming). These map to `Usage::prompt_tokens` and
+/// `Usage::completion_tokens` respectively for OTel GenAI SemConv compatibility.
+#[derive(Deserialize, Debug, Default)]
 struct OllamaResponse {
     content: Option<String>,
     response: Option<String>,
     message: Option<OllamaChatResponseMessage>,
+    /// Number of tokens evaluated from the prompt (input tokens).
+    #[serde(default)]
+    prompt_eval_count: Option<u32>,
+    /// Number of tokens generated in the response (output tokens).
+    #[serde(default)]
+    eval_count: Option<u32>,
 }
 
 impl std::fmt::Display for OllamaResponse {
@@ -179,6 +190,23 @@ impl ChatResponse for OllamaResponse {
                     .collect()
             })
         })
+    }
+
+    fn usage(&self) -> Option<crate::chat::Usage> {
+        // Ollama returns prompt_eval_count + eval_count only in the final
+        // response chunk. Treat absence as "no usage available" rather than
+        // synthesising zeros so callers can distinguish streaming-mid-chunks
+        // from the terminal chunk.
+        match (self.prompt_eval_count, self.eval_count) {
+            (Some(p), Some(c)) => Some(crate::chat::Usage {
+                prompt_tokens: p,
+                completion_tokens: c,
+                total_tokens: p.saturating_add(c),
+                completion_tokens_details: None,
+                prompt_tokens_details: None,
+            }),
+            _ => None,
+        }
     }
 }
 
@@ -813,6 +841,7 @@ mod tests {
                 content: "message".to_string(),
                 tool_calls: None,
             }),
+            ..Default::default()
         };
         assert_eq!(response.text(), Some("content".to_string()));
 
@@ -823,6 +852,7 @@ mod tests {
                 content: "message".to_string(),
                 tool_calls: None,
             }),
+            ..Default::default()
         };
         assert_eq!(response.text(), Some("response".to_string()));
 
@@ -833,6 +863,7 @@ mod tests {
                 content: "message".to_string(),
                 tool_calls: None,
             }),
+            ..Default::default()
         };
         assert_eq!(response.text(), Some("message".to_string()));
     }
@@ -851,6 +882,7 @@ mod tests {
                     },
                 }]),
             }),
+            ..Default::default()
         };
         let calls = response.tool_calls().unwrap();
         assert_eq!(calls.len(), 1);
@@ -872,6 +904,7 @@ mod tests {
                     },
                 }]),
             }),
+            ..Default::default()
         };
         let output = format!("{response}");
         assert!(output.contains("lookup"));
@@ -1109,5 +1142,59 @@ mod tests {
             matches!(err, LLMError::ProviderError(message) if message == "No answer returned by Ollama")
         );
         mock.assert();
+    }
+
+    #[test]
+    fn test_ollama_usage_returns_some_when_token_counts_present() {
+        let response = OllamaResponse {
+            prompt_eval_count: Some(42),
+            eval_count: Some(17),
+            ..Default::default()
+        };
+        let usage = response
+            .usage()
+            .expect("usage should be Some when both counts present");
+        assert_eq!(usage.prompt_tokens, 42);
+        assert_eq!(usage.completion_tokens, 17);
+        assert_eq!(usage.total_tokens, 59);
+        assert!(usage.completion_tokens_details.is_none());
+        assert!(usage.prompt_tokens_details.is_none());
+    }
+
+    #[test]
+    fn test_ollama_usage_returns_none_when_counts_absent() {
+        let response = OllamaResponse::default();
+        assert!(response.usage().is_none());
+
+        // Partial — only prompt_eval_count present, eval_count absent → still None
+        let partial = OllamaResponse {
+            prompt_eval_count: Some(10),
+            eval_count: None,
+            ..Default::default()
+        };
+        assert!(partial.usage().is_none(), "partial counts must return None");
+    }
+
+    #[test]
+    fn test_ollama_response_deserializes_token_counts_from_api_payload() {
+        // Sample non-streaming /api/chat response per Ollama API docs.
+        // See https://github.com/ollama/ollama/blob/main/docs/api.md
+        let payload = json!({
+            "model": "llama3.2",
+            "created_at": "2024-08-04T08:52:19.385406455-07:00",
+            "message": {
+                "role": "assistant",
+                "content": "Hello!"
+            },
+            "done": true,
+            "prompt_eval_count": 26,
+            "eval_count": 298
+        });
+        let response: OllamaResponse =
+            serde_json::from_value(payload).expect("realistic Ollama payload must deserialize");
+        let usage = response.usage().expect("usage must be populated");
+        assert_eq!(usage.prompt_tokens, 26);
+        assert_eq!(usage.completion_tokens, 298);
+        assert_eq!(usage.total_tokens, 324);
     }
 }


### PR DESCRIPTION
## Summary

Override `ChatResponse::usage()` for the Ollama and Google (Gemini) backends so consumers can read prompt + completion token counts from the existing `Usage` trait method — matching the parity that OpenAI and Anthropic backends already have.

Both providers DO return token counts in their HTTP response bodies; the response structs just didn't deserialize the fields or override `usage()`.

## Why

`ChatResponse::usage()` is the canonical surface for token observability (OTel GenAI SemConv, cost dashboards, rate-limit budgeting). Default trait impl returns `None`. Today only `openai.rs` and `anthropic.rs` override it. Downstream consumers building cost tracking against `autoagents-llm` (e.g. emitting `*_tokens_total` counters) get 0 counts for Ollama / Gemini even though both providers ship the data.

## Ollama changes

- Add `prompt_eval_count` + `eval_count` (both `Option<u32>`, `#[serde(default)]`) to `OllamaResponse`. Ollama's API docs document these fields appearing in the final response object for both `/api/chat` and `/api/generate`, streaming and non-streaming.
- Implement `usage()` returning `Some(Usage { ... })` only when both counts are present; partial or streaming-mid-chunk responses return `None` so callers can distinguish "no usage yet" from "usage is zero".
- Derive `Default` on `OllamaResponse` so existing tests use `..Default::default()` and don't have to enumerate the new fields.

## Google changes

- Add `usage_metadata: Option<GoogleUsageMetadata>` to `GoogleChatResponse` with `#[serde(rename = \"usageMetadata\", default)]` for the Gemini API's camelCase field name.
- New `GoogleUsageMetadata { prompt_token_count, candidates_token_count, total_token_count }` struct (`#[serde(rename_all = \"camelCase\")]`).
- Implement `usage()` mapping to `Usage`. Prefers `totalTokenCount` from the API; falls back to `prompt + candidates` defensively if the field ever returns 0.
- `GoogleStreamResponse` left untouched — streaming usage tracking would require accumulating the terminal SSE chunk and is documented as out of scope here.

## Tests added (8 unit tests, all in `#[cfg(test)] mod tests`)

**Ollama** (`backends::ollama::tests`):
- `test_ollama_usage_returns_some_when_token_counts_present` — both counts → `Some(Usage)` with correct totals
- `test_ollama_usage_returns_none_when_counts_absent` — neither, or partial (only one) → `None`
- `test_ollama_response_deserializes_token_counts_from_api_payload` — realistic `/api/chat` JSON payload per Ollama's API docs

**Google** (`backends::google::tests`):
- `test_google_usage_returns_none_when_metadata_absent`
- `test_google_usage_maps_metadata_to_usage`
- `test_google_usage_falls_back_to_sum_when_total_zero`
- `test_google_chat_response_deserializes_usage_metadata_from_api_payload` — realistic `generateContent` payload per Gemini docs
- `test_google_chat_response_deserializes_without_usage_metadata` — confirms backward compat for responses without the field

## Compatibility

**No behavior change** for any caller that doesn't read `usage()`. Existing tests pass unchanged (some struct-literal sites updated to `..Default::default()` for ergonomics).

## Gates

- `cargo check -p autoagents-llm --features full` — clean
- `cargo clippy -p autoagents-llm --features full --lib --tests -- -D warnings` — clean
- `cargo test -p autoagents-llm --features \"ollama google\" --lib` — 291 passed (266 baseline + 25 ollama/google feature tests including the 8 new)
- `cargo fmt -p autoagents-llm --check` — clean

## References

- Ollama API: https://github.com/ollama/ollama/blob/main/docs/api.md (search for \`prompt_eval_count\` + \`eval_count\`)
- Gemini API: https://ai.google.dev/api/generate-content#UsageMetadata