### PR TITLE
feat(chat): add fn model() default impl to ChatProvider + 8 backends

### DIFF
--- a/crates/autoagents-llm/src/backends/anthropic.rs
+++ b/crates/autoagents-llm/src/backends/anthropic.rs
@@ -812,6 +812,10 @@ impl ChatProvider for Anthropic {
 
         Ok(create_anthropic_tool_stream(response))
     }
+
+    fn model(&self) -> &str {
+        &self.model
+    }
 }
 
 /// Creates an SSE stream that parses Anthropic tool use events into StreamChunk.

--- a/crates/autoagents-llm/src/backends/azure_openai.rs
+++ b/crates/autoagents-llm/src/backends/azure_openai.rs
@@ -500,6 +500,10 @@ impl ChatProvider for AzureOpenAI {
     ) -> Result<Box<dyn ChatResponse>, LLMError> {
         self.chat_with_tools(messages, None, json_schema).await
     }
+
+    fn model(&self) -> &str {
+        &self.model
+    }
 }
 
 #[async_trait]

--- a/crates/autoagents-llm/src/backends/deepseek.rs
+++ b/crates/autoagents-llm/src/backends/deepseek.rs
@@ -170,6 +170,10 @@ impl ChatProvider for DeepSeek {
             .chat_stream_with_tools(messages, tools, json_schema)
             .await
     }
+
+    fn model(&self) -> &str {
+        self.provider.model()
+    }
 }
 
 #[async_trait]

--- a/crates/autoagents-llm/src/backends/google.rs
+++ b/crates/autoagents-llm/src/backends/google.rs
@@ -648,6 +648,10 @@ impl ChatProvider for Google {
             parse_google_sse_chunk,
         ))
     }
+
+    fn model(&self) -> &str {
+        &self.model
+    }
 }
 
 #[async_trait]

--- a/crates/autoagents-llm/src/backends/ollama.rs
+++ b/crates/autoagents-llm/src/backends/ollama.rs
@@ -594,6 +594,10 @@ impl ChatProvider for Ollama {
     ) -> Result<Box<dyn ChatResponse>, LLMError> {
         self.chat_with_tools(messages, tools, json_schema).await
     }
+
+    fn model(&self) -> &str {
+        &self.model
+    }
 }
 
 #[async_trait]

--- a/crates/autoagents-llm/src/backends/openai.rs
+++ b/crates/autoagents-llm/src/backends/openai.rs
@@ -759,6 +759,10 @@ impl ChatProvider for OpenAI {
             }
         }
     }
+
+    fn model(&self) -> &str {
+        self.provider.model()
+    }
 }
 
 #[async_trait]

--- a/crates/autoagents-llm/src/backends/phind.rs
+++ b/crates/autoagents-llm/src/backends/phind.rs
@@ -233,6 +233,10 @@ impl ChatProvider for Phind {
     ) -> Result<Box<dyn ChatResponse>, LLMError> {
         unimplemented!("TODO: Yet to be implented")
     }
+
+    fn model(&self) -> &str {
+        &self.model
+    }
 }
 
 /// Implementation of completion functionality for Phind.

--- a/crates/autoagents-llm/src/backends/xai.rs
+++ b/crates/autoagents-llm/src/backends/xai.rs
@@ -508,6 +508,10 @@ impl ChatProvider for XAI {
     ) -> Result<Box<dyn ChatResponse>, LLMError> {
         unimplemented!("XAI Doesn't support tools yet")
     }
+
+    fn model(&self) -> &str {
+        &self.model
+    }
 }
 
 #[async_trait]

--- a/crates/autoagents-llm/src/chat/mod.rs
+++ b/crates/autoagents-llm/src/chat/mod.rs
@@ -1253,4 +1253,81 @@ mod model_accessor_tests {
         let arc: Arc<dyn ChatProvider> = Arc::new(ollama);
         assert_eq!(arc.model(), "qwen2.5:14b");
     }
+
+    /// Integration test: ChatProvider::model() returns the configured string AND a subsequent
+    /// chat_with_tools call observes the same model in the outgoing request body.
+    ///
+    /// Uses httpmock so no live Ollama server is required. The mock asserts that
+    /// the POST body contains the model name reported by `.model()`, closing the
+    /// loop between the accessor and the actual wire format.
+    ///
+    /// Opt-in gate: set `OLLAMA_MODEL_INTEGRATION=1` to run (prevents accidental
+    /// execution in stock CI that has no Ollama server configured).
+    ///
+    /// Run manually:
+    /// ```sh
+    /// OLLAMA_MODEL_INTEGRATION=1 cargo test -p autoagents-llm --features ollama \
+    ///   --lib -- model_accessor_tests::model_accessor_wires_to_chat_request --ignored --nocapture
+    /// ```
+    #[cfg(all(feature = "ollama", not(target_arch = "wasm32")))]
+    #[tokio::test]
+    #[ignore]
+    async fn model_accessor_wires_to_chat_request() {
+        use httpmock::{Method::POST, MockServer};
+        use serde_json::json;
+
+        let configured_model = "qwen2.5:14b";
+        let server = MockServer::start();
+
+        let provider = crate::backends::ollama::Ollama::new(
+            server.base_url(),
+            None,
+            Some(configured_model.to_string()),
+            Some(128),
+            Some(0.0),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        );
+
+        // AC: model() returns the configured string.
+        assert_eq!(provider.model(), configured_model);
+
+        // Set up mock to verify the same model string appears in the wire request.
+        let model_in_body = format!("\"model\":\"{configured_model}\"");
+        let chat_mock = server.mock(|when, then| {
+            when.method(POST)
+                .path("/api/chat")
+                .body_includes(model_in_body.as_str());
+            then.status(200).json_body(json!({
+                "message": {
+                    "content": "mock reply",
+                    "tool_calls": null
+                }
+            }));
+        });
+
+        let messages = vec![ChatMessage::user().content("ping").build()];
+        let response = provider
+            .chat_with_tools(&messages, None, None)
+            .await
+            .expect("Mock-backed chat_with_tools must succeed");
+
+        // AC: the response comes back correctly (proves the full call path ran).
+        assert!(response.text().is_some(), "Response must contain text");
+
+        // AC: mock was hit exactly once — the model string reached the wire.
+        chat_mock.assert();
+    }
 }

--- a/crates/autoagents-llm/src/chat/mod.rs
+++ b/crates/autoagents-llm/src/chat/mod.rs
@@ -1148,15 +1148,12 @@ mod tests {
     }
 }
 
-/// P7a RED — tests for `ChatProvider::fn model(&self) -> &str`
-///
-/// These tests must FAIL until the Green phase adds the method to the trait
-/// and each concrete backend override.
+/// Tests for `ChatProvider::fn model(&self) -> &str`.
 #[cfg(test)]
 mod model_accessor_tests {
     use super::*;
 
-    /// AC1: Default impl returns empty string for impls that don't override.
+    /// Default impl returns empty string for impls that don't override.
     /// A minimal mock that only satisfies `chat_with_tools` gets `""` for free.
     #[test]
     fn default_impl_returns_empty_string() {
@@ -1176,7 +1173,7 @@ mod model_accessor_tests {
         assert_eq!(mock.model(), "");
     }
 
-    /// AC2: Concrete Ollama backend exposes its configured model string.
+    /// Concrete Ollama backend exposes its configured model string.
     #[cfg(all(feature = "ollama", not(target_arch = "wasm32")))]
     #[test]
     fn ollama_backend_exposes_model_string() {
@@ -1204,7 +1201,7 @@ mod model_accessor_tests {
         assert_eq!(ollama.model(), "qwen2.5:14b");
     }
 
-    /// AC2: Concrete Anthropic backend exposes its configured model string.
+    /// Concrete Anthropic backend exposes its configured model string.
     #[cfg(all(feature = "anthropic", not(target_arch = "wasm32")))]
     #[test]
     fn anthropic_backend_exposes_model_string() {
@@ -1223,7 +1220,7 @@ mod model_accessor_tests {
         assert_eq!(anthropic.model(), "claude-haiku-4-5-20251001");
     }
 
-    /// AC4: `Arc<dyn ChatProvider>` dispatches `.model()` to the inner impl via
+    /// `Arc<dyn ChatProvider>` dispatches `.model()` to the inner impl via
     /// `Deref` coercion. Note: there is no blanket `impl ChatProvider for Arc<T>` —
     /// this test exercises method dispatch on `dyn ChatProvider` through `Arc`,
     /// not a trait impl on `Arc<T>` itself.
@@ -1301,7 +1298,7 @@ mod model_accessor_tests {
             None,
         );
 
-        // AC: model() returns the configured string.
+        // model() returns the configured string.
         assert_eq!(provider.model(), configured_model);
 
         // Set up mock to verify the same model string appears in the wire request.
@@ -1324,10 +1321,10 @@ mod model_accessor_tests {
             .await
             .expect("Mock-backed chat_with_tools must succeed");
 
-        // AC: the response comes back correctly (proves the full call path ran).
+        // Response comes back correctly (proves the full call path ran).
         assert!(response.text().is_some(), "Response must contain text");
 
-        // AC: mock was hit exactly once — the model string reached the wire.
+        // Mock was hit exactly once — the model string reached the wire.
         chat_mock.assert();
     }
 }

--- a/crates/autoagents-llm/src/chat/mod.rs
+++ b/crates/autoagents-llm/src/chat/mod.rs
@@ -1223,11 +1223,13 @@ mod model_accessor_tests {
         assert_eq!(anthropic.model(), "claude-haiku-4-5-20251001");
     }
 
-    /// AC4: Arc<dyn ChatProvider> delegates `.model()` to the inner impl.
-    /// Uses Ollama as the inner concrete type.
+    /// AC4: `Arc<dyn ChatProvider>` dispatches `.model()` to the inner impl via
+    /// `Deref` coercion. Note: there is no blanket `impl ChatProvider for Arc<T>` —
+    /// this test exercises method dispatch on `dyn ChatProvider` through `Arc`,
+    /// not a trait impl on `Arc<T>` itself.
     #[cfg(all(feature = "ollama", not(target_arch = "wasm32")))]
     #[test]
-    fn arc_chat_provider_delegates_model_to_inner() {
+    fn arc_dyn_chat_provider_dispatches_model_via_deref() {
         use std::sync::Arc;
         let ollama = crate::backends::ollama::Ollama::new(
             "http://localhost:11434",
@@ -1259,14 +1261,12 @@ mod model_accessor_tests {
     ///
     /// Uses httpmock so no live Ollama server is required. The mock asserts that
     /// the POST body contains the model name reported by `.model()`, closing the
-    /// loop between the accessor and the actual wire format.
-    ///
-    /// Opt-in gate: set `OLLAMA_MODEL_INTEGRATION=1` to run (prevents accidental
-    /// execution in stock CI that has no Ollama server configured).
+    /// loop between the accessor and the actual wire format. Gated only by
+    /// `#[ignore]` — run with `cargo test -- --ignored`.
     ///
     /// Run manually:
     /// ```sh
-    /// OLLAMA_MODEL_INTEGRATION=1 cargo test -p autoagents-llm --features ollama \
+    /// cargo test -p autoagents-llm --features ollama \
     ///   --lib -- model_accessor_tests::model_accessor_wires_to_chat_request --ignored --nocapture
     /// ```
     #[cfg(all(feature = "ollama", not(target_arch = "wasm32")))]

--- a/crates/autoagents-llm/src/chat/mod.rs
+++ b/crates/autoagents-llm/src/chat/mod.rs
@@ -681,6 +681,17 @@ pub trait ChatProvider: Sync + Send {
         let _ = sampling;
         self.chat_stream_struct(messages, tools, json_schema).await
     }
+
+    /// Returns the model identifier this provider was configured with.
+    ///
+    /// Default returns an empty string for backwards compatibility with impls
+    /// that predate this trait method. Concrete backends should override to
+    /// return their configured model string so consumers can route requests
+    /// based on backend model identity (e.g. selecting grammar-based vs
+    /// prompt-based structured output, or capability-aware fallback ladders).
+    fn model(&self) -> &str {
+        ""
+    }
 }
 
 impl fmt::Display for ReasoningEffort {
@@ -1134,5 +1145,112 @@ mod tests {
         let http_response = http::Response::builder().status(200).body(body).unwrap();
 
         http_response.into()
+    }
+}
+
+/// P7a RED — tests for `ChatProvider::fn model(&self) -> &str`
+///
+/// These tests must FAIL until the Green phase adds the method to the trait
+/// and each concrete backend override.
+#[cfg(test)]
+mod model_accessor_tests {
+    use super::*;
+
+    /// AC1: Default impl returns empty string for impls that don't override.
+    /// A minimal mock that only satisfies `chat_with_tools` gets `""` for free.
+    #[test]
+    fn default_impl_returns_empty_string() {
+        struct MinimalMock;
+        #[async_trait]
+        impl ChatProvider for MinimalMock {
+            async fn chat_with_tools(
+                &self,
+                _messages: &[ChatMessage],
+                _tools: Option<&[Tool]>,
+                _json_schema: Option<StructuredOutputFormat>,
+            ) -> Result<Box<dyn ChatResponse>, crate::error::LLMError> {
+                unimplemented!()
+            }
+        }
+        let mock = MinimalMock;
+        assert_eq!(mock.model(), "");
+    }
+
+    /// AC2: Concrete Ollama backend exposes its configured model string.
+    #[cfg(all(feature = "ollama", not(target_arch = "wasm32")))]
+    #[test]
+    fn ollama_backend_exposes_model_string() {
+        let ollama = crate::backends::ollama::Ollama::new(
+            "http://localhost:11434",        // base_url
+            None,                            // api_key
+            Some("qwen2.5:14b".to_string()), // model
+            None,                            // max_tokens
+            None,                            // temperature
+            None,                            // timeout_seconds
+            None,                            // top_p
+            None,                            // top_k
+            None,                            // keep_alive
+            None,                            // system
+            None,                            // think
+            None,                            // stop
+            None,                            // seed
+            None,                            // presence_penalty
+            None,                            // frequency_penalty
+            None,                            // num_ctx
+            None,                            // repeat_penalty
+            None,                            // repeat_last_n
+            None,                            // min_p
+        );
+        assert_eq!(ollama.model(), "qwen2.5:14b");
+    }
+
+    /// AC2: Concrete Anthropic backend exposes its configured model string.
+    #[cfg(all(feature = "anthropic", not(target_arch = "wasm32")))]
+    #[test]
+    fn anthropic_backend_exposes_model_string() {
+        let anthropic = crate::backends::anthropic::Anthropic::new(
+            "test-key",                                    // api_key
+            Some("claude-haiku-4-5-20251001".to_string()), // model
+            None,                                          // max_tokens
+            None,                                          // temperature
+            None,                                          // timeout_seconds
+            None,                                          // top_p
+            None,                                          // top_k
+            None,                                          // tool_choice
+            None,                                          // reasoning
+            None,                                          // thinking_budget_tokens
+        );
+        assert_eq!(anthropic.model(), "claude-haiku-4-5-20251001");
+    }
+
+    /// AC4: Arc<dyn ChatProvider> delegates `.model()` to the inner impl.
+    /// Uses Ollama as the inner concrete type.
+    #[cfg(all(feature = "ollama", not(target_arch = "wasm32")))]
+    #[test]
+    fn arc_chat_provider_delegates_model_to_inner() {
+        use std::sync::Arc;
+        let ollama = crate::backends::ollama::Ollama::new(
+            "http://localhost:11434",
+            None,
+            Some("qwen2.5:14b".to_string()),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        );
+        let arc: Arc<dyn ChatProvider> = Arc::new(ollama);
+        assert_eq!(arc.model(), "qwen2.5:14b");
     }
 }

--- a/crates/autoagents-llm/src/optim/cache.rs
+++ b/crates/autoagents-llm/src/optim/cache.rs
@@ -733,6 +733,10 @@ impl ChatProvider for InMemoryCacheLayer {
         // Web results are time-sensitive — always delegate.
         self.inner.chat_with_web_search(input).await
     }
+
+    fn model(&self) -> &str {
+        self.inner.model()
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/autoagents-llm/src/optim/fallback.rs
+++ b/crates/autoagents-llm/src/optim/fallback.rs
@@ -296,6 +296,10 @@ impl ChatProvider for FallbackProvider {
         })
         .await
     }
+
+    fn model(&self) -> &str {
+        self.providers.first().map_or("", |p| p.model())
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/autoagents-llm/src/optim/fallback.rs
+++ b/crates/autoagents-llm/src/optim/fallback.rs
@@ -297,6 +297,12 @@ impl ChatProvider for FallbackProvider {
         .await
     }
 
+    /// Returns the primary (first-configured) provider's model identifier
+    /// unconditionally — `FallbackProvider` does not track which inner provider
+    /// is currently handling a request, so this accessor is safe for
+    /// capability-based routing and trait-bound generics but **not** for
+    /// telemetry attribution under active failover. If your use case requires
+    /// per-request attribution, query the underlying provider directly.
     fn model(&self) -> &str {
         self.providers.first().map_or("", |p| p.model())
     }

--- a/crates/autoagents-llm/src/optim/retry.rs
+++ b/crates/autoagents-llm/src/optim/retry.rs
@@ -319,6 +319,10 @@ impl ChatProvider for RetryProvider {
         })
         .await
     }
+
+    fn model(&self) -> &str {
+        self.inner.model()
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/autoagents-llm/src/providers/openai_compatible.rs
+++ b/crates/autoagents-llm/src/providers/openai_compatible.rs
@@ -715,6 +715,10 @@ impl<T: OpenAIProviderConfig> ChatProvider for OpenAICompatibleProvider<T> {
 
         Ok(create_openai_tool_stream(response))
     }
+
+    fn model(&self) -> &str {
+        &self.model
+    }
 }
 
 /// State for tracking tool use blocks during OpenAI-compatible streaming


### PR DESCRIPTION

**Title (≤72 chars):**
```
feat(chat): add fn model() default impl to ChatProvider + 8 backends
```

**Summary:**

Consumers of `ChatProvider` currently have no way to inspect which model a
backend was configured with without downcasting to the concrete type. This PR
adds `fn model(&self) -> &str` as a default method on the `ChatProvider` trait
(returning `""` for impls that don't override) and implements it on all eight
backend types that carry a `model: String` field, plus the three middleware
layers (`RetryProvider`, `InMemoryCacheLayer`, `FallbackProvider`). Enables
capability-aware routing decisions (e.g. structured-output path selection,
fallback ladders) and trait-bound generics that need to inspect the configured
model without breaking existing `dyn ChatProvider` consumers.

**Changes:**

- `ChatProvider` trait: new default method `fn model(&self) -> &str { "" }` — backward-compatible; existing impls continue to compile
- Backend overrides returning `&self.model` (or delegating to the inner provider) added to:
  - `Anthropic`
  - `Ollama`
  - `OpenAI` (delegates to `OpenAICompatibleProvider`)
  - `DeepSeek` (delegates to `OpenAICompatibleProvider`)
  - `Groq` / `OpenRouter` / `MiniMax` (covered by the `OpenAICompatibleProvider` impl)
  - `XAI`
  - `Google`
  - `AzureOpenAI`
- Middleware passes:
  - `RetryProvider` → delegates to `self.inner.model()`
  - `InMemoryCacheLayer` → delegates to `self.inner.model()`
  - `FallbackProvider` → returns the primary (first-configured) provider's model unconditionally. The accessor is suitable for capability-based routing and trait-bound generics but **not** for telemetry attribution under active failover, since the wrapper does not track which inner provider handled a request. Documented inline.

**Test coverage:**

| Test | Layer | CI |
|---|---|---|
| `default_impl_returns_empty_string` | Unit | Auto |
| `ollama_backend_exposes_model_string` | Unit (`feature = "ollama"`) | Auto |
| `anthropic_backend_exposes_model_string` | Unit (`feature = "anthropic"`) | Auto |
| `arc_dyn_chat_provider_dispatches_model_via_deref` | Unit (`Arc<dyn ChatProvider>` via Deref) | Auto |
| `model_accessor_wires_to_chat_request` | Mock integration (httpmock, no credentials) | `#[ignore]` |

Note on the `Arc` test: there is no blanket `impl ChatProvider for Arc<T>` —
method dispatch on `Arc<dyn ChatProvider>` works through `Deref` coercion to
`dyn ChatProvider`. If a blanket impl is desirable for generic bounds
(`T: ChatProvider`), happy to add it in a follow-up; it was not required to
satisfy the listed use cases.

**Migration notes:**

None. Default impl returns `""` — a zero-length string is a safe no-op for any
existing consumer. The method is additive; no trait method is removed or renamed.
Callers that want to guard should check `!provider.model().is_empty()`.

**Linked issues:**

Contributes to #102 (improve code coverage to above 80%).