### PR TITLE
feat(protocol): add app_meta field to Task for app-provided metadata

### DIFF
--- a/bindings/python/autoagents/autoagents_py/task.py
+++ b/bindings/python/autoagents/autoagents_py/task.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Optional, Union
 
-from .types import TaskImagePayload, TaskPayload
+from .types import JsonObject, TaskImagePayload, TaskPayload
 
 
 class ImageMime(str, Enum):
@@ -31,6 +31,7 @@ class Task:
     prompt: str
     image: Optional[TaskImage] = None
     system_prompt: Optional[str] = None
+    app_meta: Optional[JsonObject] = None
 
     def to_payload(self) -> TaskPayload:
         payload: TaskPayload = {"prompt": self.prompt}
@@ -38,4 +39,6 @@ class Task:
             payload["system_prompt"] = self.system_prompt
         if self.image is not None:
             payload["image"] = self.image.to_payload()
+        if self.app_meta is not None:
+            payload["app_meta"] = self.app_meta
         return payload

--- a/bindings/python/autoagents/autoagents_py/types.py
+++ b/bindings/python/autoagents/autoagents_py/types.py
@@ -33,6 +33,7 @@ class TaskPayload(TypedDict, total=False):
     prompt: str
     system_prompt: str
     image: TaskImagePayload
+    app_meta: Optional[JsonObject]
 
 
 class ExecutorTask(TypedDict, total=False):
@@ -41,6 +42,7 @@ class ExecutorTask(TypedDict, total=False):
     submission_id: str
     completed: bool
     result_json: Optional[str]
+    app_meta: Optional[JsonObject]
 
 
 class ChatMessagePayload(TypedDict, total=False):

--- a/bindings/python/autoagents/src/agent/builder.rs
+++ b/bindings/python/autoagents/src/agent/builder.rs
@@ -3,7 +3,7 @@ use crate::agent::py_agent::{
     AgentOutputStream, BuildActorResult, BuildDirectResult, HookErrorState, PyAgentDef,
     PyAgentOutput, PyExecutorBuildable, PyRunnable,
 };
-use crate::convert::json_value_to_py;
+use crate::convert::{json_value_to_py, py_any_to_json_value};
 use crate::events::{PyEventStream, PySharedEventStream};
 use crate::llm::builder::extract_llm_provider;
 use crate::memory::PyMemoryProvider;
@@ -428,6 +428,14 @@ fn py_task_to_rust_task(task_obj: &Bound<'_, PyAny>) -> PyResult<Task> {
         task = task.with_system_prompt(system_prompt);
     }
 
+    if let Some(app_meta_any) = dict.get_item("app_meta")?
+        && !app_meta_any.is_none()
+    {
+        let app_meta = py_any_to_json_value(&app_meta_any)
+            .map_err(|_| PyRuntimeError::new_err("task.app_meta must be JSON-serializable"))?;
+        task = task.with_app_meta(app_meta);
+    }
+
     if let Some(image_any) = dict.get_item("image")?
         && !image_any.is_none()
     {
@@ -847,7 +855,8 @@ mod tests {
                     "image": {
                         "mime": "png",
                         "data": [137, 80, 78, 71]
-                    }
+                    },
+                    "app_meta": {"session_id": "s1", "chat_id": "c1"}
                 }),
             )
             .expect("dict should convert");
@@ -855,6 +864,11 @@ mod tests {
             assert_eq!(task.prompt, "image task");
             assert_eq!(task.system_prompt.as_deref(), Some("system"));
             assert!(matches!(task.image, Some((ImageMime::PNG, _))));
+            let app_meta = task
+                .app_meta
+                .expect("app_meta should round-trip from python payload");
+            assert_eq!(app_meta.get("session_id").and_then(|v| v.as_str()), Some("s1"));
+            assert_eq!(app_meta.get("chat_id").and_then(|v| v.as_str()), Some("c1"));
 
             let err = py_task_to_rust_task(
                 json_value_to_py(

--- a/bindings/python/autoagents/src/agent/py_agent.rs
+++ b/bindings/python/autoagents/src/agent/py_agent.rs
@@ -723,6 +723,11 @@ pub(crate) fn task_to_py(task: &Task, py: Python<'_>) -> PyResult<Py<PyAny>> {
     d.set_item("submission_id", task.submission_id.to_string())?;
     d.set_item("completed", task.completed)?;
     d.set_item("result_json", task.result.as_ref().map(|v| v.to_string()))?;
+    let app_meta = match &task.app_meta {
+        Some(value) => json_value_to_py(py, value)?,
+        None => py.None(),
+    };
+    d.set_item("app_meta", app_meta)?;
     Ok(d.into_any().unbind())
 }
 
@@ -1808,12 +1813,15 @@ mod tests {
     fn serialization_helpers_convert_expected_values() {
         init_python();
         Python::attach(|py| {
-            let task = Task::new("inspect me").with_system_prompt("system prompt");
+            let task = Task::new("inspect me")
+                .with_system_prompt("system prompt")
+                .with_app_meta(json!({"session_id": "s1"}));
             let task_value = task_to_py(&task, py).expect("task should convert");
             let task_json =
                 py_any_to_json_value(task_value.bind(py)).expect("task json should convert");
             assert_eq!(task_json["prompt"], json!("inspect me"));
             assert_eq!(task_json["system_prompt"], json!("system prompt"));
+            assert_eq!(task_json["app_meta"]["session_id"], json!("s1"));
 
             let tool_call = ToolCall {
                 id: "call_1".to_string(),

--- a/crates/autoagents-protocol/src/task.rs
+++ b/crates/autoagents-protocol/src/task.rs
@@ -94,4 +94,13 @@ mod tests {
         let back: Task = serde_json::from_value(v).unwrap();
         assert!(back.app_meta.is_none());
     }
+
+    #[test]
+    fn with_app_meta_builder_sets_field() {
+        let task = Task::new("hi")
+            .with_app_meta(serde_json::json!({"session_id": "s1", "chat_id": "c1"}));
+        let meta = task.app_meta.expect("with_app_meta should set app_meta");
+        assert_eq!(meta.get("session_id").and_then(|v| v.as_str()), Some("s1"));
+        assert_eq!(meta.get("chat_id").and_then(|v| v.as_str()), Some("c1"));
+    }
 }

--- a/crates/autoagents-protocol/src/task.rs
+++ b/crates/autoagents-protocol/src/task.rs
@@ -14,6 +14,9 @@ pub struct Task {
     pub submission_id: SubmissionId,
     pub completed: bool,
     pub result: Option<Value>,
+    /// Arbitrary application-provided metadata (session/chat isolation, app context, anything the app threads through).
+    #[serde(default)]
+    pub app_meta: Option<Value>,
 }
 
 impl Task {
@@ -26,6 +29,7 @@ impl Task {
             submission_id: Uuid::new_v4(),
             completed: false,
             result: None,
+            app_meta: None,
         }
     }
 
@@ -42,11 +46,52 @@ impl Task {
             submission_id: Uuid::new_v4(),
             completed: false,
             result: None,
+            app_meta: None,
         }
     }
 
     pub fn with_system_prompt<T: Into<String>>(mut self, prompt: T) -> Self {
         self.system_prompt = Some(prompt.into());
         self
+    }
+
+    /// Attach arbitrary application metadata (a JSON value, typically an object).
+    pub fn with_app_meta(mut self, meta: Value) -> Self {
+        self.app_meta = Some(meta);
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn app_meta_roundtrip() {
+        let mut task = Task::new("hello");
+        task.app_meta = Some(serde_json::json!({
+            "session_id": "s1",
+            "chat_id": "c1",
+            "extra": { "nested": [1, 2, 3] },
+        }));
+        let back: Task = serde_json::from_str(&serde_json::to_string(&task).unwrap()).unwrap();
+        let meta = back
+            .app_meta
+            .expect("app_meta preserved across serde roundtrip");
+        assert_eq!(meta.get("session_id").and_then(|v| v.as_str()), Some("s1"));
+        assert_eq!(meta.get("chat_id").and_then(|v| v.as_str()), Some("c1"));
+        assert!(
+            meta.get("extra").is_some(),
+            "arbitrary nested app data preserved"
+        );
+    }
+
+    #[test]
+    fn app_meta_defaults_to_none_when_absent() {
+        // Back-compat: a payload serialized before app_meta existed must still deserialize.
+        let mut v = serde_json::to_value(Task::new("legacy")).unwrap();
+        v.as_object_mut().unwrap().remove("app_meta");
+        let back: Task = serde_json::from_value(v).unwrap();
+        assert!(back.app_meta.is_none());
     }
 }


### PR DESCRIPTION
Add an optional `app_meta: Option<Value>` to `Task` so applications can thread arbitrary metadata through the agent pipeline — session_id / chat_id for multi-session isolation, app context, feature flags, etc. The field carries any JSON the app needs, not just session identifiers.

- `#[serde(default)]` keeps deserialization backward-compatible with payloads serialized before the field existed.
- Constructors `new` and `new_with_image` default it to `None`.
- `with_app_meta` builder mirrors the existing `with_system_prompt`.
- Add serde roundtrip and backward-compat unit tests.