### PR TITLE
[BUG]: Harden Environment runtime lookup and actor streaming execution

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -403,6 +403,7 @@ Beiträge sind willkommen. Siehe [Contribution Guidelines](CONTRIBUTING.md) und 
 ## Dokumentation
 
 - **[API-Dokumentation](https://liquidos-ai.github.io/AutoAgents)**: vollständige Framework-Dokumentation
+- **[FAQ](https://liquidos-ai.github.io/AutoAgents/faq)**: häufige Fragen und Fehlerbehebung
 - **[Beispiele](examples/)**: praxisnahe Implementierungen
 
 ---
@@ -428,57 +429,7 @@ AutoAgents ist auf hohe Performance ausgelegt:
 
 ## FAQ
 
-### Allgemein
-
-**Was ist AutoAgents?**
-AutoAgents ist ein produktionsreifes Multi-Agenten-Framework in Rust. Es bietet eine modulare Architektur für intelligente Systeme mit typsicheren Agentenmodellen, strukturierten Tool-Aufrufen, konfigurierbarem Speicher und austauschbaren LLM-Backends — ausgelegt für Performance, Sicherheit und Komponierbarkeit auf Servern und Edge-Umgebungen.
-
-**Wie unterscheidet sich AutoAgents von anderen Agent-Frameworks?**
-AutoAgents ist Rust-first und bietet Speichersicherheit, Zero-Cost-Abstraktionen und hohe Performance. Es stellt eine einheitliche Schnittstelle für Cloud- und lokale LLM-Provider bereit, integrierte Guardrails, Optimierungspasses (Cache/Retry) und eine WASM-Sandbox für Tool-Ausführung — alles in einem Framework.
-
-**Gibt es eine Python-Version?**
-Ja. AutoAgents bietet Python-Bindings über `autoagents-py` auf PyPI, sodass Python-Entwickler den Rust-Kern mit einer vertrauten API nutzen können.
-
-### Setup & Konfiguration
-
-**Wie installiere ich AutoAgents?**
-Installation über Cargo: `cargo add autoagents`, oder über PyPI für Python: `pip install autoagents-py`. Siehe die [Dokumentation](https://liquidos-ai.github.io/AutoAgents/) für detaillierte Setup-Anleitungen.
-
-**Welche LLM-Provider werden unterstützt?**
-AutoAgents unterstützt OpenAI, OpenRouter, Anthropic, DeepSeek, xAI und lokale Modelle über eine einheitliche Schnittstelle. Konfigurieren Sie Ihre API-Schlüssel in der Umgebung oder in der Konfigurationsdatei.
-
-**Kann ich lokale Modelle verwenden?**
-Ja. AutoAgents unterstützt lokale LLM-Backends über seine einheitliche Provider-Schnittstelle und ermöglicht vollständig offline Agent-Betrieb.
-
-### Agent-Entwicklung
-
-**Was ist der ReAct-Executor?**
-Der ReAct-Executor (Reasoning + Acting) ist das primäre Ausführungsmodell von AutoAgents. Er wechselt zwischen Reasoning-Schritten und Tool-Aufrufen, sodass Agenten planen, ausführen und Ergebnisse in einer Schleife beobachten können, bis die Aufgabe abgeschlossen ist.
-
-**Wie funktioniert das Tool-System?**
-Tools werden mit Derive-Makros (`#[derive(Tool)]`) für typsichere Ein-/Ausgabe definiert. AutoAgents bietet außerdem eine sandboxed WASM-Runtime zur sicheren Ausführung nicht vertrauenswürdiger Tools.
-
-**Welche Speicher-Backends sind verfügbar?**
-AutoAgents verwendet standardmäßig ein Sliding-Window-Speichermodell mit erweiterbaren Backends für benutzerdefinierte Speicherstrategien — für feingranulare Kontrolle über das Context-Management.
-
-### Multi-Agenten-Orchestrierung
-
-**Wie kommunizieren Agenten miteinander?**
-AutoAgents bietet typisierte Pub/Sub-Kommunikation zwischen Agenten mit strukturiertem Nachrichtenaustausch und Compile-Time-Typsicherheit. Agenten können Events veröffentlichen und Topics in einer entkoppelten Architektur abonnieren.
-
-**Was ist das Environment-System?**
-Das Environment-System verwaltet gemeinsamen Zustand und Ressourcen über mehrere Agenten hinweg. Es bietet einen kontrollierten Raum, in dem Agenten interagieren, Beobachtungen teilen und Aktionen koordinieren können. Registrieren Sie Runtimes mit `register_runtime`, starten Sie sie mit `run()`, warten Sie mit `wait().await` auf Abschluss oder beenden Sie sie mit `shutdown().await?`. Siehe die [Actor Agents docs](https://liquidos-ai.github.io/AutoAgents/core-concepts/actor_agents#environment-lifecycle) für Lifecycle-Muster.
-
-### Fehlerbehebung
-
-**Der Build schlägt mit Rust-Versionsfehlern fehl. Was soll ich tun?**
-AutoAgents erfordert Rust 1.75+. Führen Sie `rustup update` aus, um die neueste stabile Version zu erhalten. Prüfen Sie die [Dokumentation](https://liquidos-ai.github.io/AutoAgents/) für Mindestversionsanforderungen.
-
-**Wo erhalte ich Hilfe?**
-- Dokumentation: https://liquidos-ai.github.io/AutoAgents/
-- Beispiele: `examples/`-Verzeichnis im Repository
-- DeepWiki: https://deepwiki.com/liquidos-ai/AutoAgents
-- GitHub Issues: https://github.com/liquidos-ai/AutoAgents/issues
+Siehe die [FAQ](https://liquidos-ai.github.io/AutoAgents/faq) in der Dokumentation zu Installation, Providern, Executors, Environment-Lifecycle und Fehlerbehebung.
 
 ## Lizenz
 

--- a/README.de.md
+++ b/README.de.md
@@ -426,6 +426,60 @@ AutoAgents ist auf hohe Performance ausgelegt:
 
 ---
 
+## FAQ
+
+### Allgemein
+
+**Was ist AutoAgents?**
+AutoAgents ist ein produktionsreifes Multi-Agenten-Framework in Rust. Es bietet eine modulare Architektur für intelligente Systeme mit typsicheren Agentenmodellen, strukturierten Tool-Aufrufen, konfigurierbarem Speicher und austauschbaren LLM-Backends — ausgelegt für Performance, Sicherheit und Komponierbarkeit auf Servern und Edge-Umgebungen.
+
+**Wie unterscheidet sich AutoAgents von anderen Agent-Frameworks?**
+AutoAgents ist Rust-first und bietet Speichersicherheit, Zero-Cost-Abstraktionen und hohe Performance. Es stellt eine einheitliche Schnittstelle für Cloud- und lokale LLM-Provider bereit, integrierte Guardrails, Optimierungspasses (Cache/Retry) und eine WASM-Sandbox für Tool-Ausführung — alles in einem Framework.
+
+**Gibt es eine Python-Version?**
+Ja. AutoAgents bietet Python-Bindings über `autoagents-py` auf PyPI, sodass Python-Entwickler den Rust-Kern mit einer vertrauten API nutzen können.
+
+### Setup & Konfiguration
+
+**Wie installiere ich AutoAgents?**
+Installation über Cargo: `cargo add autoagents`, oder über PyPI für Python: `pip install autoagents-py`. Siehe die [Dokumentation](https://liquidos-ai.github.io/AutoAgents/) für detaillierte Setup-Anleitungen.
+
+**Welche LLM-Provider werden unterstützt?**
+AutoAgents unterstützt OpenAI, OpenRouter, Anthropic, DeepSeek, xAI und lokale Modelle über eine einheitliche Schnittstelle. Konfigurieren Sie Ihre API-Schlüssel in der Umgebung oder in der Konfigurationsdatei.
+
+**Kann ich lokale Modelle verwenden?**
+Ja. AutoAgents unterstützt lokale LLM-Backends über seine einheitliche Provider-Schnittstelle und ermöglicht vollständig offline Agent-Betrieb.
+
+### Agent-Entwicklung
+
+**Was ist der ReAct-Executor?**
+Der ReAct-Executor (Reasoning + Acting) ist das primäre Ausführungsmodell von AutoAgents. Er wechselt zwischen Reasoning-Schritten und Tool-Aufrufen, sodass Agenten planen, ausführen und Ergebnisse in einer Schleife beobachten können, bis die Aufgabe abgeschlossen ist.
+
+**Wie funktioniert das Tool-System?**
+Tools werden mit Derive-Makros (`#[derive(Tool)]`) für typsichere Ein-/Ausgabe definiert. AutoAgents bietet außerdem eine sandboxed WASM-Runtime zur sicheren Ausführung nicht vertrauenswürdiger Tools.
+
+**Welche Speicher-Backends sind verfügbar?**
+AutoAgents verwendet standardmäßig ein Sliding-Window-Speichermodell mit erweiterbaren Backends für benutzerdefinierte Speicherstrategien — für feingranulare Kontrolle über das Context-Management.
+
+### Multi-Agenten-Orchestrierung
+
+**Wie kommunizieren Agenten miteinander?**
+AutoAgents bietet typisierte Pub/Sub-Kommunikation zwischen Agenten mit strukturiertem Nachrichtenaustausch und Compile-Time-Typsicherheit. Agenten können Events veröffentlichen und Topics in einer entkoppelten Architektur abonnieren.
+
+**Was ist das Environment-System?**
+Das Environment-System verwaltet gemeinsamen Zustand und Ressourcen über mehrere Agenten hinweg. Es bietet einen kontrollierten Raum, in dem Agenten interagieren, Beobachtungen teilen und Aktionen koordinieren können. Registrieren Sie Runtimes mit `register_runtime`, starten Sie sie mit `run()`, warten Sie mit `wait().await` auf Abschluss oder beenden Sie sie mit `shutdown().await?`. Siehe die [Actor Agents docs](https://liquidos-ai.github.io/AutoAgents/core-concepts/actor_agents#environment-lifecycle) für Lifecycle-Muster.
+
+### Fehlerbehebung
+
+**Der Build schlägt mit Rust-Versionsfehlern fehl. Was soll ich tun?**
+AutoAgents erfordert Rust 1.75+. Führen Sie `rustup update` aus, um die neueste stabile Version zu erhalten. Prüfen Sie die [Dokumentation](https://liquidos-ai.github.io/AutoAgents/) für Mindestversionsanforderungen.
+
+**Wo erhalte ich Hilfe?**
+- Dokumentation: https://liquidos-ai.github.io/AutoAgents/
+- Beispiele: `examples/`-Verzeichnis im Repository
+- DeepWiki: https://deepwiki.com/liquidos-ai/AutoAgents
+- GitHub Issues: https://github.com/liquidos-ai/AutoAgents/issues
+
 ## Lizenz
 
 AutoAgents ist dual-lizenziert:

--- a/README.es.md
+++ b/README.es.md
@@ -426,6 +426,60 @@ AutoAgents está diseñado para alto rendimiento:
 
 ---
 
+## FAQ
+
+### General
+
+**¿Qué es AutoAgents?**
+AutoAgents es un framework multiagente de grado de producción escrito en Rust. Proporciona una arquitectura modular para construir sistemas inteligentes con modelos de agentes tipados, llamadas a herramientas estructuradas, memoria configurable y backends LLM intercambiables — diseñado para rendimiento, seguridad y composabilidad en entornos de servidor y edge.
+
+**¿En qué se diferencia AutoAgents de otros frameworks de agentes?**
+AutoAgents es Rust-first, ofreciendo seguridad de memoria, abstracciones de costo cero y alto rendimiento. Proporciona una interfaz unificada para proveedores LLM en la nube y locales, guardrails integrados, pasadas de optimización (caché/reintento) y un sandbox WASM para ejecución de herramientas — todo en un solo framework.
+
+**¿Existe una versión en Python?**
+Sí. AutoAgents proporciona bindings de Python vía `autoagents-py` en PyPI, permitiendo a los desarrolladores Python aprovechar el núcleo Rust con una API familiar.
+
+### Configuración
+
+**¿Cómo instalo AutoAgents?**
+Instala vía Cargo: `cargo add autoagents`, o vía PyPI para Python: `pip install autoagents-py`. Consulta la [documentación](https://liquidos-ai.github.io/AutoAgents/) para guías detalladas.
+
+**¿Qué proveedores LLM están soportados?**
+AutoAgents soporta OpenAI, OpenRouter, Anthropic, DeepSeek, xAI y modelos locales mediante una interfaz unificada. Configura tus claves API en el entorno o archivo de configuración.
+
+**¿Puedo usar modelos locales?**
+Sí. AutoAgents soporta backends LLM locales a través de su interfaz unificada de proveedores, permitiendo operación de agentes completamente offline.
+
+### Desarrollo de agentes
+
+**¿Qué es el executor ReAct?**
+El executor ReAct (Reasoning + Acting) es el modelo de ejecución principal de AutoAgents. Alterna entre pasos de razonamiento y llamadas a herramientas, permitiendo que los agentes planifiquen, ejecuten y observen resultados en un bucle hasta completar la tarea.
+
+**¿Cómo funciona el sistema de herramientas?**
+Las herramientas se definen con macros derive (`#[derive(Tool)]`) para entrada/salida tipada. AutoAgents también proporciona un runtime WASM sandboxed para ejecutar herramientas no confiables de forma segura.
+
+**¿Qué backends de memoria están disponibles?**
+AutoAgents usa por defecto un modelo de memoria de ventana deslizante, con backends extensibles para estrategias personalizadas — permitiendo control granular del contexto.
+
+### Orquestación multiagente
+
+**¿Cómo se comunican los agentes?**
+AutoAgents proporciona comunicación pub/sub tipada entre agentes, con paso de mensajes estructurado y seguridad de tipos en tiempo de compilación. Los agentes pueden publicar eventos y suscribirse a topics en una arquitectura desacoplada.
+
+**¿Qué es el sistema de entorno (environment)?**
+El sistema de entorno gestiona estado compartido y recursos entre múltiples agentes. Proporciona un espacio controlado donde los agentes interactúan, comparten observaciones y coordinan acciones. Registra runtimes con `register_runtime`, inícialos con `run()`, espera la finalización con `wait().await`, o deténlos con `shutdown().await?`. Consulta la [documentación de Actor Agents](https://liquidos-ai.github.io/AutoAgents/core-concepts/actor_agents#environment-lifecycle) para patrones de ciclo de vida.
+
+### Solución de problemas
+
+**La compilación falla con errores de versión de Rust. ¿Qué debo hacer?**
+AutoAgents requiere Rust 1.75+. Ejecuta `rustup update` para obtener la última versión estable. Consulta la [documentación](https://liquidos-ai.github.io/AutoAgents/) para requisitos de versión mínima.
+
+**¿Dónde puedo obtener ayuda?**
+- Documentación: https://liquidos-ai.github.io/AutoAgents/
+- Ejemplos: directorio `examples/` en el repositorio
+- DeepWiki: https://deepwiki.com/liquidos-ai/AutoAgents
+- GitHub Issues: https://github.com/liquidos-ai/AutoAgents/issues
+
 ## Licencia
 
 AutoAgents tiene doble licencia:

--- a/README.es.md
+++ b/README.es.md
@@ -403,6 +403,7 @@ Damos la bienvenida a las contribuciones. Consulta [Guía de contribución](CONT
 ## Documentación
 
 - **[Documentación API](https://liquidos-ai.github.io/AutoAgents)**: documentación completa del framework
+- **[FAQ](https://liquidos-ai.github.io/AutoAgents/faq)**: preguntas frecuentes y solución de problemas
 - **[Ejemplos](examples/)**: implementaciones prácticas
 
 ---
@@ -428,57 +429,7 @@ AutoAgents está diseñado para alto rendimiento:
 
 ## FAQ
 
-### General
-
-**¿Qué es AutoAgents?**
-AutoAgents es un framework multiagente de grado de producción escrito en Rust. Proporciona una arquitectura modular para construir sistemas inteligentes con modelos de agentes tipados, llamadas a herramientas estructuradas, memoria configurable y backends LLM intercambiables — diseñado para rendimiento, seguridad y composabilidad en entornos de servidor y edge.
-
-**¿En qué se diferencia AutoAgents de otros frameworks de agentes?**
-AutoAgents es Rust-first, ofreciendo seguridad de memoria, abstracciones de costo cero y alto rendimiento. Proporciona una interfaz unificada para proveedores LLM en la nube y locales, guardrails integrados, pasadas de optimización (caché/reintento) y un sandbox WASM para ejecución de herramientas — todo en un solo framework.
-
-**¿Existe una versión en Python?**
-Sí. AutoAgents proporciona bindings de Python vía `autoagents-py` en PyPI, permitiendo a los desarrolladores Python aprovechar el núcleo Rust con una API familiar.
-
-### Configuración
-
-**¿Cómo instalo AutoAgents?**
-Instala vía Cargo: `cargo add autoagents`, o vía PyPI para Python: `pip install autoagents-py`. Consulta la [documentación](https://liquidos-ai.github.io/AutoAgents/) para guías detalladas.
-
-**¿Qué proveedores LLM están soportados?**
-AutoAgents soporta OpenAI, OpenRouter, Anthropic, DeepSeek, xAI y modelos locales mediante una interfaz unificada. Configura tus claves API en el entorno o archivo de configuración.
-
-**¿Puedo usar modelos locales?**
-Sí. AutoAgents soporta backends LLM locales a través de su interfaz unificada de proveedores, permitiendo operación de agentes completamente offline.
-
-### Desarrollo de agentes
-
-**¿Qué es el executor ReAct?**
-El executor ReAct (Reasoning + Acting) es el modelo de ejecución principal de AutoAgents. Alterna entre pasos de razonamiento y llamadas a herramientas, permitiendo que los agentes planifiquen, ejecuten y observen resultados en un bucle hasta completar la tarea.
-
-**¿Cómo funciona el sistema de herramientas?**
-Las herramientas se definen con macros derive (`#[derive(Tool)]`) para entrada/salida tipada. AutoAgents también proporciona un runtime WASM sandboxed para ejecutar herramientas no confiables de forma segura.
-
-**¿Qué backends de memoria están disponibles?**
-AutoAgents usa por defecto un modelo de memoria de ventana deslizante, con backends extensibles para estrategias personalizadas — permitiendo control granular del contexto.
-
-### Orquestación multiagente
-
-**¿Cómo se comunican los agentes?**
-AutoAgents proporciona comunicación pub/sub tipada entre agentes, con paso de mensajes estructurado y seguridad de tipos en tiempo de compilación. Los agentes pueden publicar eventos y suscribirse a topics en una arquitectura desacoplada.
-
-**¿Qué es el sistema de entorno (environment)?**
-El sistema de entorno gestiona estado compartido y recursos entre múltiples agentes. Proporciona un espacio controlado donde los agentes interactúan, comparten observaciones y coordinan acciones. Registra runtimes con `register_runtime`, inícialos con `run()`, espera la finalización con `wait().await`, o deténlos con `shutdown().await?`. Consulta la [documentación de Actor Agents](https://liquidos-ai.github.io/AutoAgents/core-concepts/actor_agents#environment-lifecycle) para patrones de ciclo de vida.
-
-### Solución de problemas
-
-**La compilación falla con errores de versión de Rust. ¿Qué debo hacer?**
-AutoAgents requiere Rust 1.75+. Ejecuta `rustup update` para obtener la última versión estable. Consulta la [documentación](https://liquidos-ai.github.io/AutoAgents/) para requisitos de versión mínima.
-
-**¿Dónde puedo obtener ayuda?**
-- Documentación: https://liquidos-ai.github.io/AutoAgents/
-- Ejemplos: directorio `examples/` en el repositorio
-- DeepWiki: https://deepwiki.com/liquidos-ai/AutoAgents
-- GitHub Issues: https://github.com/liquidos-ai/AutoAgents/issues
+Consulta las [FAQ](https://liquidos-ai.github.io/AutoAgents/faq) en la documentación sobre instalación, proveedores, executors, ciclo de vida del entorno y solución de problemas.
 
 ## Licencia
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -426,6 +426,60 @@ AutoAgents est conçu pour de hautes performances :
 
 ---
 
+## FAQ
+
+### Général
+
+**Qu'est-ce qu'AutoAgents ?**
+AutoAgents est un framework multi-agents de qualité production écrit en Rust. Il fournit une architecture modulaire pour construire des systèmes intelligents avec des modèles d'agents typés, des appels d'outils structurés, une mémoire configurable et des backends LLM interchangeables — conçu pour la performance, la sécurité et la composabilité sur serveur et edge.
+
+**En quoi AutoAgents diffère-t-il des autres frameworks d'agents ?**
+AutoAgents est Rust-first, offrant la sécurité mémoire, des abstractions sans coût et de hautes performances. Il fournit une interface unifiée pour les fournisseurs LLM cloud et locaux, des guardrails intégrés, des passes d'optimisation (cache/retry) et un sandbox WASM pour l'exécution d'outils — le tout dans un seul framework.
+
+**Existe-t-il une version Python ?**
+Oui. AutoAgents fournit des bindings Python via `autoagents-py` sur PyPI, permettant aux développeurs Python d'utiliser le cœur Rust avec une API familière.
+
+### Installation et configuration
+
+**Comment installer AutoAgents ?**
+Installez via Cargo : `cargo add autoagents`, ou via PyPI pour Python : `pip install autoagents-py`. Consultez la [documentation](https://liquidos-ai.github.io/AutoAgents/) pour les guides détaillés.
+
+**Quels fournisseurs LLM sont pris en charge ?**
+AutoAgents prend en charge OpenAI, OpenRouter, Anthropic, DeepSeek, xAI et les modèles locaux via une interface unifiée. Configurez vos clés API dans l'environnement ou le fichier de configuration.
+
+**Puis-je utiliser des modèles locaux ?**
+Oui. AutoAgents prend en charge les backends LLM locaux via son interface unifiée, permettant un fonctionnement d'agents entièrement hors ligne.
+
+### Développement d'agents
+
+**Qu'est-ce que l'exécuteur ReAct ?**
+L'exécuteur ReAct (Reasoning + Acting) est le modèle d'exécution principal d'AutoAgents. Il alterne entre des étapes de raisonnement et des appels d'outils, permettant aux agents de planifier, exécuter et observer les résultats en boucle jusqu'à la fin de la tâche.
+
+**Comment fonctionne le système d'outils ?**
+Les outils sont définis avec des macros derive (`#[derive(Tool)]`) pour des entrées/sorties typées. AutoAgents fournit aussi un runtime WASM sandboxé pour exécuter des outils non fiables en toute sécurité.
+
+**Quels backends mémoire sont disponibles ?**
+AutoAgents utilise par défaut un modèle de mémoire à fenêtre glissante, avec des backends extensibles pour des stratégies personnalisées — permettant un contrôle fin du contexte.
+
+### Orchestration multi-agents
+
+**Comment les agents communiquent-ils ?**
+AutoAgents fournit une communication pub/sub typée entre agents, avec passage de messages structuré et sûreté de types à la compilation. Les agents peuvent publier des événements et s'abonner à des topics dans une architecture découplée.
+
+**Qu'est-ce que le système d'environnement ?**
+Le système d'environnement gère l'état partagé et les ressources entre plusieurs agents. Il fournit un espace contrôlé où les agents interagissent, partagent des observations et coordonnent leurs actions. Enregistrez les runtimes avec `register_runtime`, démarrez-les avec `run()`, attendez la fin avec `wait().await`, ou arrêtez-les avec `shutdown().await?`. Consultez la [documentation Actor Agents](https://liquidos-ai.github.io/AutoAgents/core-concepts/actor_agents#environment-lifecycle) pour les modèles de cycle de vie.
+
+### Dépannage
+
+**La compilation échoue avec des erreurs de version Rust. Que faire ?**
+AutoAgents nécessite Rust 1.75+. Exécutez `rustup update` pour obtenir la dernière version stable. Consultez la [documentation](https://liquidos-ai.github.io/AutoAgents/) pour les exigences de version minimale.
+
+**Où obtenir de l'aide ?**
+- Documentation : https://liquidos-ai.github.io/AutoAgents/
+- Exemples : répertoire `examples/` du dépôt
+- DeepWiki : https://deepwiki.com/liquidos-ai/AutoAgents
+- GitHub Issues : https://github.com/liquidos-ai/AutoAgents/issues
+
 ## Licence
 
 AutoAgents est sous double licence :

--- a/README.fr.md
+++ b/README.fr.md
@@ -403,6 +403,7 @@ Nous accueillons les contributions. Voir le [Guide de contribution](CONTRIBUTING
 ## Documentation
 
 - **[Documentation API](https://liquidos-ai.github.io/AutoAgents)** : documentation complète du framework
+- **[FAQ](https://liquidos-ai.github.io/AutoAgents/faq)** : questions fréquentes et dépannage
 - **[Exemples](examples/)** : implémentations pratiques
 
 ---
@@ -428,57 +429,7 @@ AutoAgents est conçu pour de hautes performances :
 
 ## FAQ
 
-### Général
-
-**Qu'est-ce qu'AutoAgents ?**
-AutoAgents est un framework multi-agents de qualité production écrit en Rust. Il fournit une architecture modulaire pour construire des systèmes intelligents avec des modèles d'agents typés, des appels d'outils structurés, une mémoire configurable et des backends LLM interchangeables — conçu pour la performance, la sécurité et la composabilité sur serveur et edge.
-
-**En quoi AutoAgents diffère-t-il des autres frameworks d'agents ?**
-AutoAgents est Rust-first, offrant la sécurité mémoire, des abstractions sans coût et de hautes performances. Il fournit une interface unifiée pour les fournisseurs LLM cloud et locaux, des guardrails intégrés, des passes d'optimisation (cache/retry) et un sandbox WASM pour l'exécution d'outils — le tout dans un seul framework.
-
-**Existe-t-il une version Python ?**
-Oui. AutoAgents fournit des bindings Python via `autoagents-py` sur PyPI, permettant aux développeurs Python d'utiliser le cœur Rust avec une API familière.
-
-### Installation et configuration
-
-**Comment installer AutoAgents ?**
-Installez via Cargo : `cargo add autoagents`, ou via PyPI pour Python : `pip install autoagents-py`. Consultez la [documentation](https://liquidos-ai.github.io/AutoAgents/) pour les guides détaillés.
-
-**Quels fournisseurs LLM sont pris en charge ?**
-AutoAgents prend en charge OpenAI, OpenRouter, Anthropic, DeepSeek, xAI et les modèles locaux via une interface unifiée. Configurez vos clés API dans l'environnement ou le fichier de configuration.
-
-**Puis-je utiliser des modèles locaux ?**
-Oui. AutoAgents prend en charge les backends LLM locaux via son interface unifiée, permettant un fonctionnement d'agents entièrement hors ligne.
-
-### Développement d'agents
-
-**Qu'est-ce que l'exécuteur ReAct ?**
-L'exécuteur ReAct (Reasoning + Acting) est le modèle d'exécution principal d'AutoAgents. Il alterne entre des étapes de raisonnement et des appels d'outils, permettant aux agents de planifier, exécuter et observer les résultats en boucle jusqu'à la fin de la tâche.
-
-**Comment fonctionne le système d'outils ?**
-Les outils sont définis avec des macros derive (`#[derive(Tool)]`) pour des entrées/sorties typées. AutoAgents fournit aussi un runtime WASM sandboxé pour exécuter des outils non fiables en toute sécurité.
-
-**Quels backends mémoire sont disponibles ?**
-AutoAgents utilise par défaut un modèle de mémoire à fenêtre glissante, avec des backends extensibles pour des stratégies personnalisées — permettant un contrôle fin du contexte.
-
-### Orchestration multi-agents
-
-**Comment les agents communiquent-ils ?**
-AutoAgents fournit une communication pub/sub typée entre agents, avec passage de messages structuré et sûreté de types à la compilation. Les agents peuvent publier des événements et s'abonner à des topics dans une architecture découplée.
-
-**Qu'est-ce que le système d'environnement ?**
-Le système d'environnement gère l'état partagé et les ressources entre plusieurs agents. Il fournit un espace contrôlé où les agents interagissent, partagent des observations et coordonnent leurs actions. Enregistrez les runtimes avec `register_runtime`, démarrez-les avec `run()`, attendez la fin avec `wait().await`, ou arrêtez-les avec `shutdown().await?`. Consultez la [documentation Actor Agents](https://liquidos-ai.github.io/AutoAgents/core-concepts/actor_agents#environment-lifecycle) pour les modèles de cycle de vie.
-
-### Dépannage
-
-**La compilation échoue avec des erreurs de version Rust. Que faire ?**
-AutoAgents nécessite Rust 1.75+. Exécutez `rustup update` pour obtenir la dernière version stable. Consultez la [documentation](https://liquidos-ai.github.io/AutoAgents/) pour les exigences de version minimale.
-
-**Où obtenir de l'aide ?**
-- Documentation : https://liquidos-ai.github.io/AutoAgents/
-- Exemples : répertoire `examples/` du dépôt
-- DeepWiki : https://deepwiki.com/liquidos-ai/AutoAgents
-- GitHub Issues : https://github.com/liquidos-ai/AutoAgents/issues
+Consultez la [FAQ](https://liquidos-ai.github.io/AutoAgents/faq) dans la documentation pour l'installation, les fournisseurs, les exécuteurs, le cycle de vie de l'environnement et le dépannage.
 
 ## Licence
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -402,6 +402,7 @@ cargo bench -p autoagents-core --bench agent_runtime
 ## ドキュメント
 
 - **[API ドキュメント](https://liquidos-ai.github.io/AutoAgents)**：フレームワークの完全なドキュメント
+- **[FAQ](https://liquidos-ai.github.io/AutoAgents/faq)**：よくある質問とトラブルシューティング
 - **[例](examples/)**：実用的な実装例
 
 ---
@@ -427,57 +428,7 @@ AutoAgents は高性能を目指して設計されています：
 
 ## FAQ
 
-### 一般
-
-**AutoAgents とは？**
-AutoAgents は Rust で書かれた本番品質のマルチエージェントフレームワークです。型安全なエージェントモデル、構造化されたツール呼び出し、設定可能なメモリ、プラグ可能な LLM バックエンドを備えたモジュラーアーキテクチャを提供し、サーバーとエッジ環境の両方で性能、安全性、合成可能性を重視して設計されています。
-
-**他のエージェントフレームワークとの違いは？**
-AutoAgents は Rust ファーストで、メモリ安全性、ゼロコスト抽象化、高い性能を提供します。クラウドとローカルの LLM プロバイダー向けの統一インターフェース、組み込みガードレール、最適化パス（キャッシュ/リトライ）、ツール実行用 WASM サンドボックスを単一フレームワークで提供します。
-
-**Python 版はありますか？**
-はい。AutoAgents は PyPI の `autoagents-py` 経由で Python バインディングを提供し、Python 開発者が馴染みのある API で Rust コアを利用できます。
-
-### セットアップと設定
-
-**AutoAgents のインストール方法は？**
-Cargo で `cargo add autoagents`、Python では PyPI で `pip install autoagents-py` です。詳細は [ドキュメント](https://liquidos-ai.github.io/AutoAgents/) を参照してください。
-
-**サポートされている LLM プロバイダーは？**
-AutoAgents は OpenAI、OpenRouter、Anthropic、DeepSeek、xAI、ローカルモデルを統一インターフェースでサポートします。API キーは環境変数または設定ファイルで設定します。
-
-**ローカルモデルは使えますか？**
-はい。統一プロバイダーインターフェース経由でローカル LLM バックエンドをサポートし、完全オフラインのエージェント運用が可能です。
-
-### エージェント開発
-
-**ReAct エグゼキューターとは？**
-ReAct（Reasoning + Acting）エグゼキューターは AutoAgents の主要な実行モデルです。推論ステップとツール呼び出しを交互に行い、タスク完了まで計画・実行・結果観察をループします。
-
-**ツールシステムの仕組みは？**
-ツールは derive マクロ（`#[derive(Tool)]`）で型安全な入出力として定義します。AutoAgents は信頼できないツールを安全に実行するサンドボックス化 WASM ランタイムも提供します。
-
-**利用可能なメモリバックエンドは？**
-AutoAgents はデフォルトでスライディングウィンドウメモリモデルを使用し、カスタムメモリ戦略用の拡張可能なバックエンドでコンテキスト管理を細かく制御できます。
-
-### マルチエージェント編成
-
-**エージェント間の通信方法は？**
-AutoAgents は型付き pub/sub 通信を提供し、コンパイル時型安全な構造化メッセージングを実現します。エージェントはイベントを公開し、疎結合アーキテクチャでトピックを購読できます。
-
-**環境（environment）システムとは？**
-環境システムは複数エージェント間の共有状態とリソースを管理します。エージェントが相互作用し、観測を共有し、行動を調整する制御された空間を提供します。`register_runtime` でランタイムを登録し、`run()` で起動、`wait().await` で完了待ち、`shutdown().await?` で停止します。ライフサイクルパターンは [Actor Agents ドキュメント](https://liquidos-ai.github.io/AutoAgents/core-concepts/actor_agents#environment-lifecycle) を参照してください。
-
-### トラブルシューティング
-
-**Rust バージョンエラーでビルドが失敗します。どうすれば？**
-AutoAgents には Rust 1.75+ が必要です。`rustup update` で最新安定版を取得してください。最小バージョン要件は [ドキュメント](https://liquidos-ai.github.io/AutoAgents/) を確認してください。
-
-**ヘルプはどこで得られますか？**
-- ドキュメント: https://liquidos-ai.github.io/AutoAgents/
-- 例: リポジトリの `examples/` ディレクトリ
-- DeepWiki: https://deepwiki.com/liquidos-ai/AutoAgents
-- GitHub Issues: https://github.com/liquidos-ai/AutoAgents/issues
+インストール、プロバイダー、エグゼキューター、環境ライフサイクル、トラブルシューティングについては、ドキュメントの [FAQ](https://liquidos-ai.github.io/AutoAgents/faq) を参照してください。
 
 ## ライセンス
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -425,6 +425,60 @@ AutoAgents は高性能を目指して設計されています：
 
 ---
 
+## FAQ
+
+### 一般
+
+**AutoAgents とは？**
+AutoAgents は Rust で書かれた本番品質のマルチエージェントフレームワークです。型安全なエージェントモデル、構造化されたツール呼び出し、設定可能なメモリ、プラグ可能な LLM バックエンドを備えたモジュラーアーキテクチャを提供し、サーバーとエッジ環境の両方で性能、安全性、合成可能性を重視して設計されています。
+
+**他のエージェントフレームワークとの違いは？**
+AutoAgents は Rust ファーストで、メモリ安全性、ゼロコスト抽象化、高い性能を提供します。クラウドとローカルの LLM プロバイダー向けの統一インターフェース、組み込みガードレール、最適化パス（キャッシュ/リトライ）、ツール実行用 WASM サンドボックスを単一フレームワークで提供します。
+
+**Python 版はありますか？**
+はい。AutoAgents は PyPI の `autoagents-py` 経由で Python バインディングを提供し、Python 開発者が馴染みのある API で Rust コアを利用できます。
+
+### セットアップと設定
+
+**AutoAgents のインストール方法は？**
+Cargo で `cargo add autoagents`、Python では PyPI で `pip install autoagents-py` です。詳細は [ドキュメント](https://liquidos-ai.github.io/AutoAgents/) を参照してください。
+
+**サポートされている LLM プロバイダーは？**
+AutoAgents は OpenAI、OpenRouter、Anthropic、DeepSeek、xAI、ローカルモデルを統一インターフェースでサポートします。API キーは環境変数または設定ファイルで設定します。
+
+**ローカルモデルは使えますか？**
+はい。統一プロバイダーインターフェース経由でローカル LLM バックエンドをサポートし、完全オフラインのエージェント運用が可能です。
+
+### エージェント開発
+
+**ReAct エグゼキューターとは？**
+ReAct（Reasoning + Acting）エグゼキューターは AutoAgents の主要な実行モデルです。推論ステップとツール呼び出しを交互に行い、タスク完了まで計画・実行・結果観察をループします。
+
+**ツールシステムの仕組みは？**
+ツールは derive マクロ（`#[derive(Tool)]`）で型安全な入出力として定義します。AutoAgents は信頼できないツールを安全に実行するサンドボックス化 WASM ランタイムも提供します。
+
+**利用可能なメモリバックエンドは？**
+AutoAgents はデフォルトでスライディングウィンドウメモリモデルを使用し、カスタムメモリ戦略用の拡張可能なバックエンドでコンテキスト管理を細かく制御できます。
+
+### マルチエージェント編成
+
+**エージェント間の通信方法は？**
+AutoAgents は型付き pub/sub 通信を提供し、コンパイル時型安全な構造化メッセージングを実現します。エージェントはイベントを公開し、疎結合アーキテクチャでトピックを購読できます。
+
+**環境（environment）システムとは？**
+環境システムは複数エージェント間の共有状態とリソースを管理します。エージェントが相互作用し、観測を共有し、行動を調整する制御された空間を提供します。`register_runtime` でランタイムを登録し、`run()` で起動、`wait().await` で完了待ち、`shutdown().await?` で停止します。ライフサイクルパターンは [Actor Agents ドキュメント](https://liquidos-ai.github.io/AutoAgents/core-concepts/actor_agents#environment-lifecycle) を参照してください。
+
+### トラブルシューティング
+
+**Rust バージョンエラーでビルドが失敗します。どうすれば？**
+AutoAgents には Rust 1.75+ が必要です。`rustup update` で最新安定版を取得してください。最小バージョン要件は [ドキュメント](https://liquidos-ai.github.io/AutoAgents/) を確認してください。
+
+**ヘルプはどこで得られますか？**
+- ドキュメント: https://liquidos-ai.github.io/AutoAgents/
+- 例: リポジトリの `examples/` ディレクトリ
+- DeepWiki: https://deepwiki.com/liquidos-ai/AutoAgents
+- GitHub Issues: https://github.com/liquidos-ai/AutoAgents/issues
+
 ## ライセンス
 
 AutoAgents はデュアルライセンスです：

--- a/README.ko.md
+++ b/README.ko.md
@@ -402,6 +402,7 @@ cargo bench -p autoagents-core --bench agent_runtime
 ## 문서
 
 - **[API 문서](https://liquidos-ai.github.io/AutoAgents)**: 전체 프레임워크 문서
+- **[FAQ](https://liquidos-ai.github.io/AutoAgents/faq)**: 자주 묻는 질문 및 문제 해결
 - **[예제](examples/)**: 실용적인 구현 예시
 
 ---
@@ -427,57 +428,7 @@ AutoAgents는 고성능을 목표로 설계되었습니다:
 
 ## FAQ
 
-### 일반
-
-**AutoAgents란?**
-AutoAgents는 Rust로 작성된 프로덕션급 멀티 에이전트 프레임워크입니다. 타입 안전한 에이전트 모델, 구조화된 도구 호출, 구성 가능한 메모리, 플러그형 LLM 백엔드를 갖춘 모듈식 아키텍처를 제공하며, 서버와 엣지 환경 모두에서 성능, 안전성, 합성 가능성을 목표로 설계되었습니다.
-
-**다른 에이전트 프레임워크와의 차이점은?**
-AutoAgents는 Rust 우선으로 메모리 안전성, 제로 코스트 추상화, 고성능을 제공합니다. 클라우드 및 로컬 LLM 프로바이더를 위한 통합 인터페이스, 내장 가드레일, 최적화 패스(캐시/재시도), 도구 실행용 WASM 샌드박스를 단일 프레임워크에서 제공합니다.
-
-**Python 버전이 있나요?**
-네. AutoAgents는 PyPI의 `autoagents-py`를 통해 Python 바인딩을 제공하여 Python 개발자가 익숙한 API로 Rust 코어를 활용할 수 있습니다.
-
-### 설정
-
-**AutoAgents 설치 방법은?**
-Cargo로 `cargo add autoagents`, Python은 PyPI로 `pip install autoagents-py`입니다. 자세한 내용은 [문서](https://liquidos-ai.github.io/AutoAgents/)를 참조하세요.
-
-**지원되는 LLM 프로바이더는?**
-AutoAgents는 OpenAI, OpenRouter, Anthropic, DeepSeek, xAI 및 로컬 모델을 통합 인터페이스로 지원합니다. API 키는 환경 변수 또는 설정 파일에 구성하세요.
-
-**로컬 모델을 사용할 수 있나요?**
-네. 통합 프로바이더 인터페이스를 통해 로컬 LLM 백엔드를 지원하여 완전 오프라인 에이전트 운영이 가능합니다.
-
-### 에이전트 개발
-
-**ReAct 실행기란?**
-ReAct(Reasoning + Acting) 실행기는 AutoAgents의 주요 에이전트 실행 모델입니다. 추론 단계와 도구 호출을 번갈아 수행하여 작업이 완료될 때까지 계획, 실행, 결과 관찰을 반복합니다.
-
-**도구 시스템은 어떻게 동작하나요?**
-도구는 derive 매크로(`#[derive(Tool)]`)로 타입 안전한 입출력을 정의합니다. AutoAgents는 신뢰할 수 없는 도구를 안전하게 실행하는 샌드박스 WASM 런타임도 제공합니다.
-
-**사용 가능한 메모리 백엔드는?**
-AutoAgents는 기본적으로 슬라이딩 윈도우 메모리 모델을 사용하며, 사용자 정의 메모리 전략을 위한 확장 가능한 백엔드로 컨텍스트 관리를 세밀하게 제어할 수 있습니다.
-
-### 멀티 에이전트 오케스트레이션
-
-**에이전트는 어떻게 통신하나요?**
-AutoAgents는 타입 기반 pub/sub 통신을 제공하여 컴파일 타임 타입 안전성을 갖춘 구조화된 메시지 전달을 가능하게 합니다. 에이전트는 이벤트를 게시하고 느슨한 결합 아키텍처에서 토픽을 구독할 수 있습니다.
-
-**환경(environment) 시스템이란?**
-환경 시스템은 여러 에이전트 간 공유 상태와 리소스를 관리합니다. 에이전트가 상호작용하고 관찰을 공유하며 행동을 조율하는 제어된 공간을 제공합니다. `register_runtime`으로 런타임을 등록하고, `run()`으로 시작하며, `wait().await`로 완료를 기다리거나, `shutdown().await?`로 중지합니다. 라이프사이클 패턴은 [Actor Agents 문서](https://liquidos-ai.github.io/AutoAgents/core-concepts/actor_agents#environment-lifecycle)를 참조하세요.
-
-### 문제 해결
-
-**Rust 버전 오류로 빌드가 실패합니다. 어떻게 해야 하나요?**
-AutoAgents는 Rust 1.75+가 필요합니다. `rustup update`로 최신 안정 버전을 받으세요. 최소 버전 요구 사항은 [문서](https://liquidos-ai.github.io/AutoAgents/)를 확인하세요.
-
-**도움은 어디서 받을 수 있나요?**
-- 문서: https://liquidos-ai.github.io/AutoAgents/
-- 예제: 저장소의 `examples/` 디렉터리
-- DeepWiki: https://deepwiki.com/liquidos-ai/AutoAgents
-- GitHub Issues: https://github.com/liquidos-ai/AutoAgents/issues
+설치, 프로바이더, 실행기, 환경 라이프사이클, 문제 해결은 문서의 [FAQ](https://liquidos-ai.github.io/AutoAgents/faq)를 참조하세요.
 
 ## 라이선스
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -425,6 +425,60 @@ AutoAgents는 고성능을 목표로 설계되었습니다:
 
 ---
 
+## FAQ
+
+### 일반
+
+**AutoAgents란?**
+AutoAgents는 Rust로 작성된 프로덕션급 멀티 에이전트 프레임워크입니다. 타입 안전한 에이전트 모델, 구조화된 도구 호출, 구성 가능한 메모리, 플러그형 LLM 백엔드를 갖춘 모듈식 아키텍처를 제공하며, 서버와 엣지 환경 모두에서 성능, 안전성, 합성 가능성을 목표로 설계되었습니다.
+
+**다른 에이전트 프레임워크와의 차이점은?**
+AutoAgents는 Rust 우선으로 메모리 안전성, 제로 코스트 추상화, 고성능을 제공합니다. 클라우드 및 로컬 LLM 프로바이더를 위한 통합 인터페이스, 내장 가드레일, 최적화 패스(캐시/재시도), 도구 실행용 WASM 샌드박스를 단일 프레임워크에서 제공합니다.
+
+**Python 버전이 있나요?**
+네. AutoAgents는 PyPI의 `autoagents-py`를 통해 Python 바인딩을 제공하여 Python 개발자가 익숙한 API로 Rust 코어를 활용할 수 있습니다.
+
+### 설정
+
+**AutoAgents 설치 방법은?**
+Cargo로 `cargo add autoagents`, Python은 PyPI로 `pip install autoagents-py`입니다. 자세한 내용은 [문서](https://liquidos-ai.github.io/AutoAgents/)를 참조하세요.
+
+**지원되는 LLM 프로바이더는?**
+AutoAgents는 OpenAI, OpenRouter, Anthropic, DeepSeek, xAI 및 로컬 모델을 통합 인터페이스로 지원합니다. API 키는 환경 변수 또는 설정 파일에 구성하세요.
+
+**로컬 모델을 사용할 수 있나요?**
+네. 통합 프로바이더 인터페이스를 통해 로컬 LLM 백엔드를 지원하여 완전 오프라인 에이전트 운영이 가능합니다.
+
+### 에이전트 개발
+
+**ReAct 실행기란?**
+ReAct(Reasoning + Acting) 실행기는 AutoAgents의 주요 에이전트 실행 모델입니다. 추론 단계와 도구 호출을 번갈아 수행하여 작업이 완료될 때까지 계획, 실행, 결과 관찰을 반복합니다.
+
+**도구 시스템은 어떻게 동작하나요?**
+도구는 derive 매크로(`#[derive(Tool)]`)로 타입 안전한 입출력을 정의합니다. AutoAgents는 신뢰할 수 없는 도구를 안전하게 실행하는 샌드박스 WASM 런타임도 제공합니다.
+
+**사용 가능한 메모리 백엔드는?**
+AutoAgents는 기본적으로 슬라이딩 윈도우 메모리 모델을 사용하며, 사용자 정의 메모리 전략을 위한 확장 가능한 백엔드로 컨텍스트 관리를 세밀하게 제어할 수 있습니다.
+
+### 멀티 에이전트 오케스트레이션
+
+**에이전트는 어떻게 통신하나요?**
+AutoAgents는 타입 기반 pub/sub 통신을 제공하여 컴파일 타임 타입 안전성을 갖춘 구조화된 메시지 전달을 가능하게 합니다. 에이전트는 이벤트를 게시하고 느슨한 결합 아키텍처에서 토픽을 구독할 수 있습니다.
+
+**환경(environment) 시스템이란?**
+환경 시스템은 여러 에이전트 간 공유 상태와 리소스를 관리합니다. 에이전트가 상호작용하고 관찰을 공유하며 행동을 조율하는 제어된 공간을 제공합니다. `register_runtime`으로 런타임을 등록하고, `run()`으로 시작하며, `wait().await`로 완료를 기다리거나, `shutdown().await?`로 중지합니다. 라이프사이클 패턴은 [Actor Agents 문서](https://liquidos-ai.github.io/AutoAgents/core-concepts/actor_agents#environment-lifecycle)를 참조하세요.
+
+### 문제 해결
+
+**Rust 버전 오류로 빌드가 실패합니다. 어떻게 해야 하나요?**
+AutoAgents는 Rust 1.75+가 필요합니다. `rustup update`로 최신 안정 버전을 받으세요. 최소 버전 요구 사항은 [문서](https://liquidos-ai.github.io/AutoAgents/)를 확인하세요.
+
+**도움은 어디서 받을 수 있나요?**
+- 문서: https://liquidos-ai.github.io/AutoAgents/
+- 예제: 저장소의 `examples/` 디렉터리
+- DeepWiki: https://deepwiki.com/liquidos-ai/AutoAgents
+- GitHub Issues: https://github.com/liquidos-ai/AutoAgents/issues
+
 ## 라이선스
 
 AutoAgents는 이중 라이선스를 사용합니다:

--- a/README.md
+++ b/README.md
@@ -492,7 +492,7 @@ AutoAgents uses a sliding window memory model by default, with extensible backen
 AutoAgents provides typed pub/sub communication between agents, enabling structured message passing with compile-time type safety. Agents can publish events and subscribe to topics in a decoupled architecture.
 
 **What is the environment system?**
-The environment system manages shared state and resources across multiple agents. It provides a controlled space where agents can interact, share observations, and coordinate actions.
+The environment system manages shared state and resources across multiple agents. It provides a controlled space where agents can interact, share observations, and coordinate actions. Register runtimes with `register_runtime`, start them with `run()`, await completion with `wait().await`, or stop them with `shutdown().await`. See the [Actor Agents docs](https://liquidos-ai.github.io/AutoAgents/core-concepts/actor_agents#environment-lifecycle) for lifecycle patterns.
 
 ### Troubleshooting
 

--- a/README.md
+++ b/README.md
@@ -427,6 +427,7 @@ and [Code of Conduct](CODE_OF_CONDUCT.md) for details.
 ## Documentation
 
 - **[API Documentation](https://liquidos-ai.github.io/AutoAgents)**: Complete framework docs
+- **[FAQ](https://liquidos-ai.github.io/AutoAgents/faq)**: Common questions and troubleshooting
 - **[Examples](examples/)**: Practical implementation examples
 
 ---
@@ -453,57 +454,7 @@ AutoAgents is designed for high performance:
 
 ## FAQ
 
-### General
-
-**What is AutoAgents?**
-AutoAgents is a production-grade, multi-agent framework written in Rust. It provides a modular architecture for building intelligent systems with type-safe agent models, structured tool calling, configurable memory, and pluggable LLM backends — designed for performance, safety, and composability across server and edge environments.
-
-**How does AutoAgents differ from other agent frameworks?**
-AutoAgents is Rust-first, offering memory safety, zero-cost abstractions, and high performance. It provides a unified interface for cloud and local LLM providers, built-in guardrails, optimization passes (cache/retry), and a WASM sandbox for tool execution — all in a single framework.
-
-**Is there a Python version?**
-Yes. AutoAgents provides Python bindings via `autoagents-py` on PyPI, enabling Python developers to leverage the Rust core with a familiar API.
-
-### Setup & Configuration
-
-**How do I install AutoAgents?**
-Install via Cargo: `cargo add autoagents`, or via PyPI for Python: `pip install autoagents-py`. See the [documentation](https://liquidos-ai.github.io/AutoAgents/) for detailed setup guides.
-
-**Which LLM providers are supported?**
-AutoAgents supports OpenAI, OpenRouter, Anthropic, DeepSeek, xAI, and local models via a unified interface. Configure your API keys in the environment or configuration file.
-
-**Can I use local models?**
-Yes. AutoAgents supports local LLM backends through its unified provider interface, enabling fully offline agent operation.
-
-### Agent Development
-
-**What is the ReAct executor?**
-The ReAct (Reasoning + Acting) executor is AutoAgents' primary agent execution model. It alternates between reasoning steps and tool calls, enabling agents to plan, execute, and observe results in a loop until the task is complete.
-
-**How does the tool system work?**
-Tools are defined using derive macros (`#[derive(Tool)]`) for type-safe input/output. AutoAgents also provides a sandboxed WASM runtime for executing untrusted tools securely.
-
-**What memory backends are available?**
-AutoAgents uses a sliding window memory model by default, with extensible backends for custom memory strategies — enabling fine-grained control over context management.
-
-### Multi-Agent Orchestration
-
-**How do agents communicate?**
-AutoAgents provides typed pub/sub communication between agents, enabling structured message passing with compile-time type safety. Agents can publish events and subscribe to topics in a decoupled architecture.
-
-**What is the environment system?**
-The environment system manages shared state and resources across multiple agents. It provides a controlled space where agents can interact, share observations, and coordinate actions. Register runtimes with `register_runtime`, start them with `run()`, await completion with `wait().await`, or stop them with `shutdown().await?`. See the [Actor Agents docs](https://liquidos-ai.github.io/AutoAgents/core-concepts/actor_agents#environment-lifecycle) for lifecycle patterns.
-
-### Troubleshooting
-
-**Build fails with Rust version errors. What should I do?**
-AutoAgents requires Rust 1.75+. Run `rustup update` to get the latest stable version. Check the [documentation](https://liquidos-ai.github.io/AutoAgents/) for minimum version requirements.
-
-**Where can I get help?**
-- Documentation: https://liquidos-ai.github.io/AutoAgents/
-- Examples: `examples/` directory in the repository
-- DeepWiki: https://deepwiki.com/liquidos-ai/AutoAgents
-- GitHub Issues: https://github.com/liquidos-ai/AutoAgents/issues
+See the [FAQ](https://liquidos-ai.github.io/AutoAgents/faq) in the documentation for installation, providers, executors, environment lifecycle, and troubleshooting.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -492,7 +492,7 @@ AutoAgents uses a sliding window memory model by default, with extensible backen
 AutoAgents provides typed pub/sub communication between agents, enabling structured message passing with compile-time type safety. Agents can publish events and subscribe to topics in a decoupled architecture.
 
 **What is the environment system?**
-The environment system manages shared state and resources across multiple agents. It provides a controlled space where agents can interact, share observations, and coordinate actions. Register runtimes with `register_runtime`, start them with `run()`, await completion with `wait().await`, or stop them with `shutdown().await`. See the [Actor Agents docs](https://liquidos-ai.github.io/AutoAgents/core-concepts/actor_agents#environment-lifecycle) for lifecycle patterns.
+The environment system manages shared state and resources across multiple agents. It provides a controlled space where agents can interact, share observations, and coordinate actions. Register runtimes with `register_runtime`, start them with `run()`, await completion with `wait().await`, or stop them with `shutdown().await?`. See the [Actor Agents docs](https://liquidos-ai.github.io/AutoAgents/core-concepts/actor_agents#environment-lifecycle) for lifecycle patterns.
 
 ### Troubleshooting
 

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -403,6 +403,7 @@ Contribuições são bem-vindas. Consulte o [Guia de Contribuição](CONTRIBUTIN
 ## Documentação
 
 - **[Documentação da API](https://liquidos-ai.github.io/AutoAgents)**: documentação completa do framework
+- **[FAQ](https://liquidos-ai.github.io/AutoAgents/faq)**: perguntas frequentes e solução de problemas
 - **[Exemplos](examples/)**: implementações práticas
 
 ---
@@ -428,57 +429,7 @@ AutoAgents é projetado para alto desempenho:
 
 ## FAQ
 
-### Geral
-
-**O que é AutoAgents?**
-AutoAgents é um framework multiagente de nível de produção escrito em Rust. Oferece uma arquitetura modular para construir sistemas inteligentes com modelos de agentes tipados, chamadas de ferramentas estruturadas, memória configurável e backends LLM plugáveis — projetado para desempenho, segurança e composabilidade em ambientes de servidor e edge.
-
-**Como o AutoAgents difere de outros frameworks de agentes?**
-AutoAgents é Rust-first, oferecendo segurança de memória, abstrações de custo zero e alto desempenho. Fornece uma interface unificada para provedores LLM na nuvem e locais, guardrails integrados, passes de otimização (cache/retry) e um sandbox WASM para execução de ferramentas — tudo em um único framework.
-
-**Existe uma versão Python?**
-Sim. O AutoAgents fornece bindings Python via `autoagents-py` no PyPI, permitindo que desenvolvedores Python aproveitem o núcleo Rust com uma API familiar.
-
-### Configuração
-
-**Como instalar o AutoAgents?**
-Instale via Cargo: `cargo add autoagents`, ou via PyPI para Python: `pip install autoagents-py`. Consulte a [documentação](https://liquidos-ai.github.io/AutoAgents/) para guias detalhados.
-
-**Quais provedores LLM são suportados?**
-O AutoAgents suporta OpenAI, OpenRouter, Anthropic, DeepSeek, xAI e modelos locais via uma interface unificada. Configure suas chaves de API no ambiente ou arquivo de configuração.
-
-**Posso usar modelos locais?**
-Sim. O AutoAgents suporta backends LLM locais por meio de sua interface unificada de provedores, permitindo operação de agentes totalmente offline.
-
-### Desenvolvimento de agentes
-
-**O que é o executor ReAct?**
-O executor ReAct (Reasoning + Acting) é o modelo de execução principal do AutoAgents. Alterna entre etapas de raciocínio e chamadas de ferramentas, permitindo que agentes planejem, executem e observem resultados em loop até a tarefa ser concluída.
-
-**Como funciona o sistema de ferramentas?**
-As ferramentas são definidas com macros derive (`#[derive(Tool)]`) para entrada/saída tipada. O AutoAgents também fornece um runtime WASM sandboxed para executar ferramentas não confiáveis com segurança.
-
-**Quais backends de memória estão disponíveis?**
-O AutoAgents usa por padrão um modelo de memória de janela deslizante, com backends extensíveis para estratégias personalizadas — permitindo controle granular do contexto.
-
-### Orquestração multiagente
-
-**Como os agentes se comunicam?**
-O AutoAgents fornece comunicação pub/sub tipada entre agentes, com passagem de mensagens estruturada e segurança de tipos em tempo de compilação. Agentes podem publicar eventos e assinar tópicos em uma arquitetura desacoplada.
-
-**O que é o sistema de ambiente (environment)?**
-O sistema de ambiente gerencia estado compartilhado e recursos entre múltiplos agentes. Fornece um espaço controlado onde agentes interagem, compartilham observações e coordenam ações. Registre runtimes com `register_runtime`, inicie com `run()`, aguarde conclusão com `wait().await` ou pare com `shutdown().await?`. Consulte a [documentação Actor Agents](https://liquidos-ai.github.io/AutoAgents/core-concepts/actor_agents#environment-lifecycle) para padrões de ciclo de vida.
-
-### Solução de problemas
-
-**A compilação falha com erros de versão do Rust. O que fazer?**
-O AutoAgents requer Rust 1.75+. Execute `rustup update` para obter a versão estável mais recente. Consulte a [documentação](https://liquidos-ai.github.io/AutoAgents/) para requisitos de versão mínima.
-
-**Onde posso obter ajuda?**
-- Documentação: https://liquidos-ai.github.io/AutoAgents/
-- Exemplos: diretório `examples/` no repositório
-- DeepWiki: https://deepwiki.com/liquidos-ai/AutoAgents
-- GitHub Issues: https://github.com/liquidos-ai/AutoAgents/issues
+Consulte as [FAQ](https://liquidos-ai.github.io/AutoAgents/faq) na documentação sobre instalação, provedores, executors, ciclo de vida do ambiente e solução de problemas.
 
 ## Licença
 

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -426,6 +426,60 @@ AutoAgents é projetado para alto desempenho:
 
 ---
 
+## FAQ
+
+### Geral
+
+**O que é AutoAgents?**
+AutoAgents é um framework multiagente de nível de produção escrito em Rust. Oferece uma arquitetura modular para construir sistemas inteligentes com modelos de agentes tipados, chamadas de ferramentas estruturadas, memória configurável e backends LLM plugáveis — projetado para desempenho, segurança e composabilidade em ambientes de servidor e edge.
+
+**Como o AutoAgents difere de outros frameworks de agentes?**
+AutoAgents é Rust-first, oferecendo segurança de memória, abstrações de custo zero e alto desempenho. Fornece uma interface unificada para provedores LLM na nuvem e locais, guardrails integrados, passes de otimização (cache/retry) e um sandbox WASM para execução de ferramentas — tudo em um único framework.
+
+**Existe uma versão Python?**
+Sim. O AutoAgents fornece bindings Python via `autoagents-py` no PyPI, permitindo que desenvolvedores Python aproveitem o núcleo Rust com uma API familiar.
+
+### Configuração
+
+**Como instalar o AutoAgents?**
+Instale via Cargo: `cargo add autoagents`, ou via PyPI para Python: `pip install autoagents-py`. Consulte a [documentação](https://liquidos-ai.github.io/AutoAgents/) para guias detalhados.
+
+**Quais provedores LLM são suportados?**
+O AutoAgents suporta OpenAI, OpenRouter, Anthropic, DeepSeek, xAI e modelos locais via uma interface unificada. Configure suas chaves de API no ambiente ou arquivo de configuração.
+
+**Posso usar modelos locais?**
+Sim. O AutoAgents suporta backends LLM locais por meio de sua interface unificada de provedores, permitindo operação de agentes totalmente offline.
+
+### Desenvolvimento de agentes
+
+**O que é o executor ReAct?**
+O executor ReAct (Reasoning + Acting) é o modelo de execução principal do AutoAgents. Alterna entre etapas de raciocínio e chamadas de ferramentas, permitindo que agentes planejem, executem e observem resultados em loop até a tarefa ser concluída.
+
+**Como funciona o sistema de ferramentas?**
+As ferramentas são definidas com macros derive (`#[derive(Tool)]`) para entrada/saída tipada. O AutoAgents também fornece um runtime WASM sandboxed para executar ferramentas não confiáveis com segurança.
+
+**Quais backends de memória estão disponíveis?**
+O AutoAgents usa por padrão um modelo de memória de janela deslizante, com backends extensíveis para estratégias personalizadas — permitindo controle granular do contexto.
+
+### Orquestração multiagente
+
+**Como os agentes se comunicam?**
+O AutoAgents fornece comunicação pub/sub tipada entre agentes, com passagem de mensagens estruturada e segurança de tipos em tempo de compilação. Agentes podem publicar eventos e assinar tópicos em uma arquitetura desacoplada.
+
+**O que é o sistema de ambiente (environment)?**
+O sistema de ambiente gerencia estado compartilhado e recursos entre múltiplos agentes. Fornece um espaço controlado onde agentes interagem, compartilham observações e coordenam ações. Registre runtimes com `register_runtime`, inicie com `run()`, aguarde conclusão com `wait().await` ou pare com `shutdown().await?`. Consulte a [documentação Actor Agents](https://liquidos-ai.github.io/AutoAgents/core-concepts/actor_agents#environment-lifecycle) para padrões de ciclo de vida.
+
+### Solução de problemas
+
+**A compilação falha com erros de versão do Rust. O que fazer?**
+O AutoAgents requer Rust 1.75+. Execute `rustup update` para obter a versão estável mais recente. Consulte a [documentação](https://liquidos-ai.github.io/AutoAgents/) para requisitos de versão mínima.
+
+**Onde posso obter ajuda?**
+- Documentação: https://liquidos-ai.github.io/AutoAgents/
+- Exemplos: diretório `examples/` no repositório
+- DeepWiki: https://deepwiki.com/liquidos-ai/AutoAgents
+- GitHub Issues: https://github.com/liquidos-ai/AutoAgents/issues
+
 ## Licença
 
 AutoAgents é dual-licenciado:

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -425,6 +425,60 @@ AutoAgents 面向高性能设计：
 
 ---
 
+## 常见问题
+
+### 概述
+
+**什么是 AutoAgents？**
+AutoAgents 是一个用 Rust 编写的生产级多智能体框架。它提供模块化架构，支持类型安全的智能体模型、结构化工具调用、可配置内存和可插拔 LLM 后端——专为服务器和边缘环境的性能、安全性和可组合性而设计。
+
+**AutoAgents 与其他智能体框架有何不同？**
+AutoAgents 以 Rust 为先，提供内存安全、零成本抽象和高性能。它在单一框架中提供云和本地 LLM 提供商的统一接口、内置护栏、优化通道（缓存/重试）以及用于工具执行的 WASM 沙箱。
+
+**有 Python 版本吗？**
+有。AutoAgents 通过 PyPI 上的 `autoagents-py` 提供 Python 绑定，让 Python 开发者可以使用熟悉的 API 调用 Rust 核心。
+
+### 安装与配置
+
+**如何安装 AutoAgents？**
+通过 Cargo 安装：`cargo add autoagents`；Python 用户：`pip install autoagents-py`。详细指南请参阅[文档](https://liquidos-ai.github.io/AutoAgents/)。
+
+**支持哪些 LLM 提供商？**
+AutoAgents 通过统一接口支持 OpenAI、OpenRouter、Anthropic、DeepSeek、xAI 及本地模型。请在环境变量或配置文件中设置 API 密钥。
+
+**可以使用本地模型吗？**
+可以。AutoAgents 通过统一的提供商接口支持本地 LLM 后端，实现完全离线的智能体运行。
+
+### 智能体开发
+
+**什么是 ReAct 执行器？**
+ReAct（推理 + 行动）执行器是 AutoAgents 的主要智能体执行模型。它在推理步骤和工具调用之间交替，使智能体能够循环规划、执行并观察结果，直到任务完成。
+
+**工具系统如何工作？**
+工具通过 derive 宏（`#[derive(Tool)]`）定义，实现类型安全的输入/输出。AutoAgents 还提供沙箱化的 WASM 运行时，用于安全执行不可信工具。
+
+**有哪些内存后端？**
+AutoAgents 默认使用滑动窗口内存模型，并提供可扩展后端以支持自定义内存策略——实现对上下文管理的精细控制。
+
+### 多智能体编排
+
+**智能体如何通信？**
+AutoAgents 提供类型化的 pub/sub 通信，支持结构化消息传递和编译期类型安全。智能体可以在解耦架构中发布事件并订阅主题。
+
+**什么是环境（environment）系统？**
+环境系统管理多个智能体之间的共享状态和资源，提供受控空间供智能体交互、共享观察结果并协调行动。使用 `register_runtime` 注册运行时，用 `run()` 启动，用 `wait().await` 等待完成，或用 `shutdown().await?` 停止。生命周期模式请参阅 [Actor Agents 文档](https://liquidos-ai.github.io/AutoAgents/core-concepts/actor_agents#environment-lifecycle)。
+
+### 故障排除
+
+**构建因 Rust 版本错误失败，该怎么办？**
+AutoAgents 需要 Rust 1.75+。运行 `rustup update` 获取最新稳定版。最低版本要求请参阅[文档](https://liquidos-ai.github.io/AutoAgents/)。
+
+**在哪里获取帮助？**
+- 文档：https://liquidos-ai.github.io/AutoAgents/
+- 示例：仓库中的 `examples/` 目录
+- DeepWiki：https://deepwiki.com/liquidos-ai/AutoAgents
+- GitHub Issues：https://github.com/liquidos-ai/AutoAgents/issues
+
 ## 许可证
 
 AutoAgents 采用双许可证：

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -402,6 +402,7 @@ cargo bench -p autoagents-core --bench agent_runtime
 ## 文档
 
 - **[API 文档](https://liquidos-ai.github.io/AutoAgents)**：完整框架文档
+- **[FAQ](https://liquidos-ai.github.io/AutoAgents/faq)**：常见问题与故障排除
 - **[示例](examples/)**：实用实现示例
 
 ---
@@ -427,57 +428,7 @@ AutoAgents 面向高性能设计：
 
 ## 常见问题
 
-### 概述
-
-**什么是 AutoAgents？**
-AutoAgents 是一个用 Rust 编写的生产级多智能体框架。它提供模块化架构，支持类型安全的智能体模型、结构化工具调用、可配置内存和可插拔 LLM 后端——专为服务器和边缘环境的性能、安全性和可组合性而设计。
-
-**AutoAgents 与其他智能体框架有何不同？**
-AutoAgents 以 Rust 为先，提供内存安全、零成本抽象和高性能。它在单一框架中提供云和本地 LLM 提供商的统一接口、内置护栏、优化通道（缓存/重试）以及用于工具执行的 WASM 沙箱。
-
-**有 Python 版本吗？**
-有。AutoAgents 通过 PyPI 上的 `autoagents-py` 提供 Python 绑定，让 Python 开发者可以使用熟悉的 API 调用 Rust 核心。
-
-### 安装与配置
-
-**如何安装 AutoAgents？**
-通过 Cargo 安装：`cargo add autoagents`；Python 用户：`pip install autoagents-py`。详细指南请参阅[文档](https://liquidos-ai.github.io/AutoAgents/)。
-
-**支持哪些 LLM 提供商？**
-AutoAgents 通过统一接口支持 OpenAI、OpenRouter、Anthropic、DeepSeek、xAI 及本地模型。请在环境变量或配置文件中设置 API 密钥。
-
-**可以使用本地模型吗？**
-可以。AutoAgents 通过统一的提供商接口支持本地 LLM 后端，实现完全离线的智能体运行。
-
-### 智能体开发
-
-**什么是 ReAct 执行器？**
-ReAct（推理 + 行动）执行器是 AutoAgents 的主要智能体执行模型。它在推理步骤和工具调用之间交替，使智能体能够循环规划、执行并观察结果，直到任务完成。
-
-**工具系统如何工作？**
-工具通过 derive 宏（`#[derive(Tool)]`）定义，实现类型安全的输入/输出。AutoAgents 还提供沙箱化的 WASM 运行时，用于安全执行不可信工具。
-
-**有哪些内存后端？**
-AutoAgents 默认使用滑动窗口内存模型，并提供可扩展后端以支持自定义内存策略——实现对上下文管理的精细控制。
-
-### 多智能体编排
-
-**智能体如何通信？**
-AutoAgents 提供类型化的 pub/sub 通信，支持结构化消息传递和编译期类型安全。智能体可以在解耦架构中发布事件并订阅主题。
-
-**什么是环境（environment）系统？**
-环境系统管理多个智能体之间的共享状态和资源，提供受控空间供智能体交互、共享观察结果并协调行动。使用 `register_runtime` 注册运行时，用 `run()` 启动，用 `wait().await` 等待完成，或用 `shutdown().await?` 停止。生命周期模式请参阅 [Actor Agents 文档](https://liquidos-ai.github.io/AutoAgents/core-concepts/actor_agents#environment-lifecycle)。
-
-### 故障排除
-
-**构建因 Rust 版本错误失败，该怎么办？**
-AutoAgents 需要 Rust 1.75+。运行 `rustup update` 获取最新稳定版。最低版本要求请参阅[文档](https://liquidos-ai.github.io/AutoAgents/)。
-
-**在哪里获取帮助？**
-- 文档：https://liquidos-ai.github.io/AutoAgents/
-- 示例：仓库中的 `examples/` 目录
-- DeepWiki：https://deepwiki.com/liquidos-ai/AutoAgents
-- GitHub Issues：https://github.com/liquidos-ai/AutoAgents/issues
+安装、提供商、执行器、环境生命周期和故障排除请参阅文档中的 [FAQ](https://liquidos-ai.github.io/AutoAgents/faq)。
 
 ## 许可证
 

--- a/bindings/python/autoagents/examples/README.md
+++ b/bindings/python/autoagents/examples/README.md
@@ -68,7 +68,9 @@ Use `autoagents.experimental` to opt into Python-backed memory explicitly.
 ## Actor Runtime
 
 `actor_agent.py` shows `build_actor(...)`, `Runtime`, `Environment`, `Topic`,
-and environment event consumption.
+and environment event consumption. In Rust, pair `environment.run()` with
+`environment.wait().await` to join the runtime task; Python's `Environment.run()`
+starts runtimes in the background and the example stops on `TaskComplete`.
 
 ## Protocol Event Stream
 

--- a/bindings/python/autoagents/src/agent/executor.rs
+++ b/bindings/python/autoagents/src/agent/executor.rs
@@ -1600,6 +1600,8 @@ where
     PyAgentOutput: From<<T as AgentExecutor>::Output>,
     <T as AgentExecutor>::Error: Into<RunnableAgentError>,
     <T as AgentDeriveT>::Output: From<<T as AgentExecutor>::Output>,
+    Value: From<<T as AgentExecutor>::Output>,
+    <T as AgentExecutor>::Output: Clone,
 {
     Box::pin(async move {
         let mut handle = AgentBuilder::<_, DirectAgent>::new(executor)

--- a/bindings/python/autoagents/src/agent/py_agent.rs
+++ b/bindings/python/autoagents/src/agent/py_agent.rs
@@ -1173,6 +1173,9 @@ impl<T> PyRunnable for BaseAgent<T, DirectAgent>
 where
     T: AgentDeriveT<Output = PyAgentOutput> + AgentExecutor + AgentHooks + Send + Sync + 'static,
     PyAgentOutput: From<<T as AgentExecutor>::Output>,
+    <T as AgentDeriveT>::Output: From<<T as AgentExecutor>::Output>,
+    Value: From<<T as AgentExecutor>::Output>,
+    <T as AgentExecutor>::Output: Clone,
     <T as AgentExecutor>::Error: Into<RunnableAgentError>,
 {
     async fn run(&self, task: Task) -> Result<PyAgentOutput, String> {

--- a/crates/autoagents-core/src/agent/actor.rs
+++ b/crates/autoagents-core/src/agent/actor.rs
@@ -281,14 +281,31 @@ impl<T: AgentDeriveT + AgentExecutor + AgentHooks> BaseAgent<T, ActorAgent> {
             }
         }
 
-        let agent_out = last_output.ok_or_else(|| {
-            RunnableAgentError::ExecutorError("Stream completed without output".to_string())
-        })?;
+        let agent_out = match last_output {
+            Some(output) => output,
+            None => {
+                let err = RunnableAgentError::ExecutorError(
+                    "Stream completed without output".to_string(),
+                );
+                #[cfg(not(target_arch = "wasm32"))]
+                EventHelper::send_task_error(&tx_event, submission_id, self.id, err.to_string())
+                    .await;
+                return Err(err);
+            }
+        };
 
-        let value = serde_json::to_value(&agent_out)
-            .map_err(|e| RunnableAgentError::ExecutorError(e.to_string()))?;
+        let value = match serde_json::to_value(&agent_out) {
+            Ok(value) => value,
+            Err(e) => {
+                let err = RunnableAgentError::ExecutorError(e.to_string());
+                #[cfg(not(target_arch = "wasm32"))]
+                EventHelper::send_task_error(&tx_event, submission_id, self.id, err.to_string())
+                    .await;
+                return Err(err);
+            }
+        };
         #[cfg(not(target_arch = "wasm32"))]
-        EventHelper::send_task_completed_value(
+        if let Err(e) = EventHelper::send_task_completed_value(
             &tx_event,
             submission_id,
             self.id,
@@ -296,7 +313,11 @@ impl<T: AgentDeriveT + AgentExecutor + AgentHooks> BaseAgent<T, ActorAgent> {
             &value,
         )
         .await
-        .map_err(|e| RunnableAgentError::ExecutorError(e.to_string()))?;
+        {
+            let err = RunnableAgentError::ExecutorError(e.to_string());
+            EventHelper::send_task_error(&tx_event, submission_id, self.id, err.to_string()).await;
+            return Err(err);
+        }
 
         self.inner
             .on_run_complete(&task, &agent_out, &context)
@@ -742,7 +763,7 @@ mod tests {
     #[tokio::test]
     async fn test_actor_run_stream_to_completion_empty_stream_error() {
         let llm = Arc::new(MockLLMProvider);
-        let (tx, _rx) = mpsc::channel(2);
+        let (tx, mut rx) = mpsc::channel(2);
         let agent = Arc::new(
             BaseAgent::<_, ActorAgent>::new(EmptyStreamAgent, llm, None, tx, true)
                 .await
@@ -755,6 +776,17 @@ mod tests {
             .expect_err("expected empty stream failure");
         assert!(matches!(err, RunnableAgentError::ExecutorError(_)));
         assert!(err.to_string().contains("without output"));
+
+        let event = tokio::time::timeout(std::time::Duration::from_secs(1), rx.recv())
+            .await
+            .expect("timed out waiting for TaskError event")
+            .expect("channel closed without event");
+        match event {
+            Event::TaskError { error, .. } => {
+                assert!(error.contains("without output"));
+            }
+            other => panic!("expected TaskError, got {other:?}"),
+        }
     }
 
     #[derive(Debug, Clone)]

--- a/crates/autoagents-core/src/agent/actor.rs
+++ b/crates/autoagents-core/src/agent/actor.rs
@@ -13,7 +13,7 @@ use crate::error::Error;
 #[cfg(not(target_arch = "wasm32"))]
 use crate::runtime::TypedRuntime;
 use async_trait::async_trait;
-use autoagents_protocol::Event;
+use autoagents_protocol::{Event, SubmissionId};
 #[cfg(target_arch = "wasm32")]
 use futures::SinkExt;
 #[cfg(not(target_arch = "wasm32"))]
@@ -127,6 +127,42 @@ impl<T: AgentDeriveT + AgentExecutor + AgentHooks> BaseAgent<T, ActorAgent> {
         self.tx.clone().ok_or(RunnableAgentError::EmptyTx)
     }
 
+    /// Convert executor output to a protocol event payload and finish the run
+    /// lifecycle. Uses `Value: From<AgentExecutor::Output>` so `TaskComplete`
+    /// matches the non-streaming path regardless of `AgentDeriveT::Output`.
+    async fn finish_executor_run(
+        &self,
+        task: &Task,
+        context: &Context,
+        tx_event: &Option<Sender<Event>>,
+        submission_id: SubmissionId,
+        executor_out: <T as AgentExecutor>::Output,
+    ) -> Result<<T as AgentDeriveT>::Output, RunnableAgentError>
+    where
+        Value: From<<T as AgentExecutor>::Output>,
+        <T as AgentDeriveT>::Output: From<<T as AgentExecutor>::Output>,
+    {
+        let value: Value = executor_out.clone().into();
+        #[cfg(not(target_arch = "wasm32"))]
+        if let Err(e) = EventHelper::send_task_completed_value(
+            tx_event,
+            submission_id,
+            self.id,
+            self.name().to_string(),
+            &value,
+        )
+        .await
+        {
+            let err = RunnableAgentError::ExecutorError(e.to_string());
+            EventHelper::send_task_error(tx_event, submission_id, self.id, err.to_string()).await;
+            return Err(err);
+        }
+
+        let agent_out: <T as AgentDeriveT>::Output = executor_out.into();
+        self.inner.on_run_complete(task, &agent_out, context).await;
+        Ok(agent_out)
+    }
+
     pub async fn run(
         self: Arc<Self>,
         task: Task,
@@ -152,27 +188,8 @@ impl<T: AgentDeriveT + AgentExecutor + AgentHooks> BaseAgent<T, ActorAgent> {
         // Execute the agent's logic using the executor
         match self.inner().execute(&task, context.clone()).await {
             Ok(output) => {
-                let value: Value = output.clone().into();
-                #[cfg(not(target_arch = "wasm32"))]
-                EventHelper::send_task_completed_value(
-                    &tx_event,
-                    submission_id,
-                    self.id,
-                    self.name().to_string(),
-                    &value,
-                )
-                .await
-                .map_err(|e| RunnableAgentError::ExecutorError(e.to_string()))?;
-
-                //Extract Agent output into the desired type
-                let agent_out: <T as AgentDeriveT>::Output = output.into();
-
-                //Run On complete Hook
-                self.inner
-                    .on_run_complete(&task, &agent_out, &context)
-                    .await;
-
-                Ok(agent_out)
+                self.finish_executor_run(&task, &context, &tx_event, submission_id, output)
+                    .await
             }
             Err(e) => {
                 #[cfg(not(target_arch = "wasm32"))]
@@ -198,6 +215,28 @@ impl<T: AgentDeriveT + AgentExecutor + AgentHooks> BaseAgent<T, ActorAgent> {
         self.run_stream_with_context(task, context).await
     }
 
+    async fn run_executor_stream_with_context(
+        self: Arc<Self>,
+        task: Task,
+        context: Arc<Context>,
+    ) -> Result<
+        crate::utils::BoxRuntimeStream<Result<<T as AgentExecutor>::Output, RunnableAgentError>>,
+        RunnableAgentError,
+    >
+    where
+        <T as AgentExecutor>::Error: Into<RunnableAgentError>,
+    {
+        match self.inner().execute_stream(&task, context).await {
+            Ok(stream) => {
+                use futures::StreamExt;
+                let transformed_stream =
+                    stream.map(move |result| result.map_err(|error| error.into()));
+                Ok(Box::pin(transformed_stream))
+            }
+            Err(error) => Err(error.into()),
+        }
+    }
+
     async fn run_stream_with_context(
         self: Arc<Self>,
         task: Task,
@@ -210,25 +249,10 @@ impl<T: AgentDeriveT + AgentExecutor + AgentHooks> BaseAgent<T, ActorAgent> {
         <T as AgentDeriveT>::Output: From<<T as AgentExecutor>::Output>,
         <T as AgentExecutor>::Error: Into<RunnableAgentError>,
     {
-        // Execute the agent's streaming logic using the executor
-        match self.inner().execute_stream(&task, context).await {
-            Ok(stream) => {
-                use futures::StreamExt;
-                // Transform the stream to convert agent output to TaskResult
-                let transformed_stream = stream.map(move |result| {
-                    match result {
-                        Ok(output) => Ok(output.into()),
-                        Err(e) => {
-                            // Handle error
-                            Err(e.into())
-                        }
-                    }
-                });
-
-                Ok(Box::pin(transformed_stream))
-            }
-            Err(e) => Err(e.into()),
-        }
+        let stream = self.run_executor_stream_with_context(task, context).await?;
+        use futures::StreamExt;
+        let transformed_stream = stream.map(|result| result.map(|output| output.into()));
+        Ok(Box::pin(transformed_stream))
     }
 
     /// Execute a streaming task to completion inside the actor, draining the
@@ -255,7 +279,7 @@ impl<T: AgentDeriveT + AgentExecutor + AgentHooks> BaseAgent<T, ActorAgent> {
 
         let mut stream = match self
             .clone()
-            .run_stream_with_context(task.clone(), context.clone())
+            .run_executor_stream_with_context(task.clone(), context.clone())
             .await
         {
             Ok(stream) => stream,
@@ -268,10 +292,10 @@ impl<T: AgentDeriveT + AgentExecutor + AgentHooks> BaseAgent<T, ActorAgent> {
         };
         use futures::StreamExt;
 
-        let mut last_output = None;
+        let mut last_executor_output = None;
         while let Some(result) = stream.next().await {
             match result {
-                Ok(output) => last_output = Some(output),
+                Ok(output) => last_executor_output = Some(output),
                 Err(e) => {
                     #[cfg(not(target_arch = "wasm32"))]
                     EventHelper::send_task_error(&tx_event, submission_id, self.id, e.to_string())
@@ -281,7 +305,7 @@ impl<T: AgentDeriveT + AgentExecutor + AgentHooks> BaseAgent<T, ActorAgent> {
             }
         }
 
-        let agent_out = match last_output {
+        let executor_out = match last_executor_output {
             Some(output) => output,
             None => {
                 let err = RunnableAgentError::ExecutorError(
@@ -294,36 +318,8 @@ impl<T: AgentDeriveT + AgentExecutor + AgentHooks> BaseAgent<T, ActorAgent> {
             }
         };
 
-        let value = match serde_json::to_value(&agent_out) {
-            Ok(value) => value,
-            Err(e) => {
-                let err = RunnableAgentError::ExecutorError(e.to_string());
-                #[cfg(not(target_arch = "wasm32"))]
-                EventHelper::send_task_error(&tx_event, submission_id, self.id, err.to_string())
-                    .await;
-                return Err(err);
-            }
-        };
-        #[cfg(not(target_arch = "wasm32"))]
-        if let Err(e) = EventHelper::send_task_completed_value(
-            &tx_event,
-            submission_id,
-            self.id,
-            self.name().to_string(),
-            &value,
-        )
-        .await
-        {
-            let err = RunnableAgentError::ExecutorError(e.to_string());
-            EventHelper::send_task_error(&tx_event, submission_id, self.id, err.to_string()).await;
-            return Err(err);
-        }
-
-        self.inner
-            .on_run_complete(&task, &agent_out, &context)
-            .await;
-
-        Ok(agent_out)
+        self.finish_executor_run(&task, &context, &tx_event, submission_id, executor_out)
+            .await
     }
 }
 
@@ -391,6 +387,7 @@ mod tests {
     use crate::utils::BoxEventStream;
     use async_trait::async_trait;
     use futures::{StreamExt, stream};
+    use serde::{Deserialize, Serialize};
     use std::any::{Any, TypeId};
     use std::sync::Arc;
     use tokio::sync::{Mutex, mpsc};
@@ -896,5 +893,209 @@ mod tests {
             .await
             .expect_err("expected missing tx failure");
         assert!(matches!(err, RunnableAgentError::EmptyTx));
+    }
+
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    struct DivergentExecutorOutput {
+        response: String,
+        executor_only: u32,
+    }
+
+    impl From<DivergentExecutorOutput> for Value {
+        fn from(output: DivergentExecutorOutput) -> Self {
+            serde_json::json!({
+                "response": output.response,
+                "executor_only": output.executor_only,
+            })
+        }
+    }
+
+    #[derive(Debug, Clone, Serialize, Deserialize)]
+    struct DivergentAgentOutput {
+        result: String,
+    }
+
+    impl AgentOutputT for DivergentAgentOutput {
+        fn output_schema() -> &'static str {
+            r#"{"type":"object","properties":{"result":{"type":"string"}},"required":["result"]}"#
+        }
+
+        fn structured_output_format() -> Value {
+            serde_json::json!({
+                "name": "DivergentAgentOutput",
+                "description": "Derived agent output",
+                "schema": {
+                    "type": "object",
+                    "properties": {
+                        "result": {"type": "string"}
+                    },
+                    "required": ["result"]
+                },
+                "strict": true
+            })
+        }
+    }
+
+    impl From<DivergentExecutorOutput> for DivergentAgentOutput {
+        fn from(output: DivergentExecutorOutput) -> Self {
+            Self {
+                result: output.response,
+            }
+        }
+    }
+
+    #[derive(Debug, Clone)]
+    struct DivergentStreamingAgent;
+
+    #[async_trait]
+    impl AgentDeriveT for DivergentStreamingAgent {
+        type Output = DivergentAgentOutput;
+
+        fn description(&self) -> &'static str {
+            "divergent streaming agent"
+        }
+
+        fn output_schema(&self) -> Option<Value> {
+            Some(DivergentAgentOutput::structured_output_format())
+        }
+
+        fn name(&self) -> &'static str {
+            "divergent_streaming_agent"
+        }
+
+        fn tools(&self) -> Vec<Box<dyn crate::tool::ToolT>> {
+            vec![]
+        }
+    }
+
+    #[async_trait]
+    impl AgentExecutor for DivergentStreamingAgent {
+        type Output = DivergentExecutorOutput;
+        type Error = TestError;
+
+        fn config(&self) -> ExecutorConfig {
+            ExecutorConfig::default()
+        }
+
+        async fn execute(
+            &self,
+            task: &Task,
+            _context: Arc<Context>,
+        ) -> Result<Self::Output, Self::Error> {
+            Ok(DivergentExecutorOutput {
+                response: task.prompt.clone(),
+                executor_only: 42,
+            })
+        }
+
+        async fn execute_stream(
+            &self,
+            task: &Task,
+            _context: Arc<Context>,
+        ) -> Result<crate::utils::BoxRuntimeStream<Result<Self::Output, Self::Error>>, Self::Error>
+        {
+            let output = DivergentExecutorOutput {
+                response: task.prompt.clone(),
+                executor_only: 42,
+            };
+            Ok(Box::pin(stream::iter([Ok(output)])))
+        }
+    }
+
+    impl AgentHooks for DivergentStreamingAgent {}
+
+    #[tokio::test]
+    async fn test_actor_run_stream_to_completion_task_complete_uses_executor_value_from() {
+        let llm = Arc::new(MockLLMProvider);
+        let (tx, mut rx) = mpsc::channel(2);
+        let agent = Arc::new(
+            BaseAgent::<_, ActorAgent>::new(DivergentStreamingAgent, llm, None, tx, true)
+                .await
+                .expect("agent should build"),
+        );
+
+        let output = agent
+            .run_stream_to_completion(Task::new("stream payload"))
+            .await
+            .expect("stream should complete");
+        assert_eq!(output.result, "stream payload");
+
+        let event = tokio::time::timeout(std::time::Duration::from_secs(1), rx.recv())
+            .await
+            .expect("timed out waiting for TaskComplete event")
+            .expect("channel closed without event");
+        match event {
+            Event::TaskComplete { result, .. } => {
+                let parsed: Value =
+                    serde_json::from_str(&result).expect("TaskComplete result should be JSON");
+                assert_eq!(parsed["executor_only"], 42);
+                assert_eq!(parsed["response"], "stream payload");
+            }
+            other => panic!("expected TaskComplete, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_actor_run_and_stream_to_completion_emit_matching_task_complete() {
+        let llm = Arc::new(MockLLMProvider);
+        let (tx_run, mut rx_run) = mpsc::channel(2);
+        let run_agent = Arc::new(
+            BaseAgent::<_, ActorAgent>::new(
+                DivergentStreamingAgent,
+                llm.clone(),
+                None,
+                tx_run,
+                false,
+            )
+            .await
+            .expect("run agent should build"),
+        );
+        let (tx_stream, mut rx_stream) = mpsc::channel(2);
+        let stream_agent = Arc::new(
+            BaseAgent::<_, ActorAgent>::new(DivergentStreamingAgent, llm, None, tx_stream, true)
+                .await
+                .expect("stream agent should build"),
+        );
+
+        let task = Task::new("parity payload");
+        run_agent
+            .clone()
+            .run(task.clone())
+            .await
+            .expect("run should succeed");
+        stream_agent
+            .run_stream_to_completion(task)
+            .await
+            .expect("stream should complete");
+
+        let run_event = tokio::time::timeout(std::time::Duration::from_secs(1), rx_run.recv())
+            .await
+            .expect("timed out waiting for run TaskComplete")
+            .expect("run channel closed without event");
+        let stream_event =
+            tokio::time::timeout(std::time::Duration::from_secs(1), rx_stream.recv())
+                .await
+                .expect("timed out waiting for stream TaskComplete")
+                .expect("stream channel closed without event");
+
+        match (run_event, stream_event) {
+            (
+                Event::TaskComplete {
+                    result: run_result, ..
+                },
+                Event::TaskComplete {
+                    result: stream_result,
+                    ..
+                },
+            ) => {
+                assert_eq!(
+                    run_result, stream_result,
+                    "run() and run_stream_to_completion() must serialize TaskComplete identically"
+                );
+            }
+            (run_event, stream_event) => {
+                panic!("expected TaskComplete events, got {run_event:?} and {stream_event:?}")
+            }
+        }
     }
 }

--- a/crates/autoagents-core/src/agent/actor.rs
+++ b/crates/autoagents-core/src/agent/actor.rs
@@ -1,6 +1,7 @@
 #[cfg(not(target_arch = "wasm32"))]
 use crate::actor::Topic;
 use crate::agent::base::AgentType;
+use crate::agent::context::Context;
 use crate::agent::error::{AgentBuildError, RunnableAgentError};
 use crate::agent::executor::event_helper::EventHelper;
 use crate::agent::hooks::AgentHooks;
@@ -194,7 +195,21 @@ impl<T: AgentDeriveT + AgentExecutor + AgentHooks> BaseAgent<T, ActorAgent> {
         <T as AgentExecutor>::Error: Into<RunnableAgentError>,
     {
         let context = self.create_context();
+        self.run_stream_with_context(task, context).await
+    }
 
+    async fn run_stream_with_context(
+        self: Arc<Self>,
+        task: Task,
+        context: Arc<Context>,
+    ) -> Result<
+        crate::utils::BoxRuntimeStream<Result<<T as AgentDeriveT>::Output, RunnableAgentError>>,
+        RunnableAgentError,
+    >
+    where
+        <T as AgentDeriveT>::Output: From<<T as AgentExecutor>::Output>,
+        <T as AgentExecutor>::Error: Into<RunnableAgentError>,
+    {
         // Execute the agent's streaming logic using the executor
         match self.inner().execute_stream(&task, context).await {
             Ok(stream) => {
@@ -241,7 +256,10 @@ impl<T: AgentDeriveT + AgentExecutor + AgentHooks> BaseAgent<T, ActorAgent> {
             HookOutcome::Continue => {}
         }
 
-        let mut stream = self.clone().run_stream(task.clone()).await?;
+        let mut stream = self
+            .clone()
+            .run_stream_with_context(task.clone(), context.clone())
+            .await?;
         use futures::StreamExt;
 
         let mut last_output = None;

--- a/crates/autoagents-core/src/agent/actor.rs
+++ b/crates/autoagents-core/src/agent/actor.rs
@@ -390,16 +390,20 @@ where
         _state: &mut Self::State,
     ) -> Result<(), ActorProcessingErr> {
         let agent = self.0.clone();
-        let task = message;
 
-        //Run agent
-        if agent.stream() {
-            let _ = agent.run_stream_to_completion(task).await?;
-            Ok(())
+        // Run agent
+        let result = if agent.stream() {
+            agent.run_stream_to_completion(message).await
         } else {
-            let _ = agent.run(task).await?;
-            Ok(())
-        }
+            agent.run(message).await
+        };
+
+        // Task-level failures are surfaced on the event channel as `TaskError` (or
+        // `TaskComplete` on success) by the run helpers above. Do not propagate them
+        // to ractor — returning `Err` here terminates the actor and breaks long-running
+        // pub/sub agents after a single bad task.
+        let _ = result;
+        Ok(())
     }
 }
 

--- a/crates/autoagents-core/src/agent/actor.rs
+++ b/crates/autoagents-core/src/agent/actor.rs
@@ -227,10 +227,7 @@ impl<T: AgentDeriveT + AgentExecutor + AgentHooks> BaseAgent<T, ActorAgent> {
 
                 Ok(Box::pin(transformed_stream))
             }
-            Err(e) => {
-                // Send error event for stream creation failure
-                Err(e.into())
-            }
+            Err(e) => Err(e.into()),
         }
     }
 
@@ -256,10 +253,19 @@ impl<T: AgentDeriveT + AgentExecutor + AgentHooks> BaseAgent<T, ActorAgent> {
             HookOutcome::Continue => {}
         }
 
-        let mut stream = self
+        let mut stream = match self
             .clone()
             .run_stream_with_context(task.clone(), context.clone())
-            .await?;
+            .await
+        {
+            Ok(stream) => stream,
+            Err(e) => {
+                #[cfg(not(target_arch = "wasm32"))]
+                EventHelper::send_task_error(&tx_event, submission_id, self.id, e.to_string())
+                    .await;
+                return Err(e);
+            }
+        };
         use futures::StreamExt;
 
         let mut last_output = None;
@@ -356,11 +362,14 @@ where
 mod tests {
     use super::*;
     use crate::actor::{LocalTransport, Topic, Transport};
+    use crate::agent::hooks::HookOutcome;
+    use crate::agent::output::AgentOutputT;
+    use crate::agent::{Context, ExecutorConfig};
     use crate::runtime::{Runtime, RuntimeError};
-    use crate::tests::{MockAgentImpl, MockLLMProvider};
+    use crate::tests::{MockAgentImpl, MockLLMProvider, TestAgentOutput, TestError};
     use crate::utils::BoxEventStream;
     use async_trait::async_trait;
-    use futures::stream;
+    use futures::{StreamExt, stream};
     use std::any::{Any, TypeId};
     use std::sync::Arc;
     use tokio::sync::{Mutex, mpsc};
@@ -486,6 +495,374 @@ mod tests {
             .unwrap();
         agent.tx = None;
         let err = agent.tx().unwrap_err();
+        assert!(matches!(err, RunnableAgentError::EmptyTx));
+    }
+
+    async fn streaming_actor_agent(stream: bool) -> Arc<BaseAgent<MockAgentImpl, ActorAgent>> {
+        let mock = MockAgentImpl::new("stream_agent", "streaming test agent");
+        let llm = Arc::new(MockLLMProvider);
+        let (tx, _rx) = mpsc::channel(8);
+        Arc::new(
+            BaseAgent::<_, ActorAgent>::new(mock, llm, None, tx, stream)
+                .await
+                .expect("agent should build"),
+        )
+    }
+
+    #[tokio::test]
+    async fn test_actor_run_stream_returns_executor_output() {
+        let agent = streaming_actor_agent(true).await;
+        let task = Task::new("stream me");
+        let stream = agent.run_stream(task).await.expect("stream should start");
+        let outputs: Vec<_> = stream.collect().await;
+        assert_eq!(outputs.len(), 1);
+        let output = outputs[0].as_ref().expect("expected stream output");
+        assert!(output.result.contains("stream me"));
+    }
+
+    #[tokio::test]
+    async fn test_actor_run_stream_to_completion_returns_output() {
+        let agent = streaming_actor_agent(true).await;
+        let task = Task::new("complete me");
+        let output = agent
+            .run_stream_to_completion(task)
+            .await
+            .expect("stream should complete");
+        assert!(output.result.contains("complete me"));
+    }
+
+    #[derive(Debug, Clone)]
+    struct AbortStreamingAgent;
+
+    #[async_trait]
+    impl AgentDeriveT for AbortStreamingAgent {
+        type Output = TestAgentOutput;
+
+        fn description(&self) -> &'static str {
+            "abort streaming agent"
+        }
+
+        fn output_schema(&self) -> Option<serde_json::Value> {
+            Some(TestAgentOutput::structured_output_format())
+        }
+
+        fn name(&self) -> &'static str {
+            "abort_streaming_agent"
+        }
+
+        fn tools(&self) -> Vec<Box<dyn crate::tool::ToolT>> {
+            vec![]
+        }
+    }
+
+    #[async_trait]
+    impl AgentExecutor for AbortStreamingAgent {
+        type Output = TestAgentOutput;
+        type Error = TestError;
+
+        fn config(&self) -> ExecutorConfig {
+            ExecutorConfig::default()
+        }
+
+        async fn execute(
+            &self,
+            _task: &Task,
+            _context: Arc<Context>,
+        ) -> Result<Self::Output, Self::Error> {
+            Ok(TestAgentOutput {
+                result: "unused".to_string(),
+            })
+        }
+    }
+
+    #[async_trait]
+    impl AgentHooks for AbortStreamingAgent {
+        async fn on_run_start(&self, _task: &Task, _ctx: &Context) -> HookOutcome {
+            HookOutcome::Abort
+        }
+    }
+
+    #[tokio::test]
+    async fn test_actor_run_stream_to_completion_aborts_on_hook() {
+        let llm = Arc::new(MockLLMProvider);
+        let (tx, _rx) = mpsc::channel(2);
+        let agent = Arc::new(
+            BaseAgent::<_, ActorAgent>::new(AbortStreamingAgent, llm, None, tx, true)
+                .await
+                .expect("agent should build"),
+        );
+
+        let err = agent
+            .run_stream_to_completion(Task::new("abort"))
+            .await
+            .expect_err("expected hook abort");
+        assert!(matches!(err, RunnableAgentError::Abort));
+    }
+
+    #[derive(Debug, Clone)]
+    struct FailingStreamSetupAgent;
+
+    #[async_trait]
+    impl AgentDeriveT for FailingStreamSetupAgent {
+        type Output = TestAgentOutput;
+
+        fn description(&self) -> &'static str {
+            "failing stream setup"
+        }
+
+        fn output_schema(&self) -> Option<serde_json::Value> {
+            Some(TestAgentOutput::structured_output_format())
+        }
+
+        fn name(&self) -> &'static str {
+            "failing_stream_setup"
+        }
+
+        fn tools(&self) -> Vec<Box<dyn crate::tool::ToolT>> {
+            vec![]
+        }
+    }
+
+    #[async_trait]
+    impl AgentExecutor for FailingStreamSetupAgent {
+        type Output = TestAgentOutput;
+        type Error = TestError;
+
+        fn config(&self) -> ExecutorConfig {
+            ExecutorConfig::default()
+        }
+
+        async fn execute(
+            &self,
+            _task: &Task,
+            _context: Arc<Context>,
+        ) -> Result<Self::Output, Self::Error> {
+            Ok(TestAgentOutput {
+                result: "unused".to_string(),
+            })
+        }
+
+        async fn execute_stream(
+            &self,
+            _task: &Task,
+            _context: Arc<Context>,
+        ) -> Result<crate::utils::BoxRuntimeStream<Result<Self::Output, Self::Error>>, Self::Error>
+        {
+            Err(TestError::ExecutionFailed(
+                "stream setup failed".to_string(),
+            ))
+        }
+    }
+
+    impl AgentHooks for FailingStreamSetupAgent {}
+
+    #[tokio::test]
+    async fn test_actor_run_stream_to_completion_execute_stream_setup_error() {
+        let llm = Arc::new(MockLLMProvider);
+        let (tx, mut rx) = mpsc::channel(2);
+        let agent = Arc::new(
+            BaseAgent::<_, ActorAgent>::new(FailingStreamSetupAgent, llm, None, tx, true)
+                .await
+                .expect("agent should build"),
+        );
+
+        let err = agent
+            .run_stream_to_completion(Task::new("fail setup"))
+            .await
+            .expect_err("expected stream setup failure");
+        assert!(matches!(err, RunnableAgentError::ExecutorError(_)));
+
+        let event = tokio::time::timeout(std::time::Duration::from_secs(1), rx.recv())
+            .await
+            .expect("timed out waiting for TaskError event")
+            .expect("channel closed without event");
+        match event {
+            Event::TaskError { error, .. } => {
+                assert!(error.contains("stream setup failed"));
+            }
+            other => panic!("expected TaskError, got {other:?}"),
+        }
+    }
+
+    #[derive(Debug, Clone)]
+    struct EmptyStreamAgent;
+
+    #[async_trait]
+    impl AgentDeriveT for EmptyStreamAgent {
+        type Output = TestAgentOutput;
+
+        fn description(&self) -> &'static str {
+            "empty stream agent"
+        }
+
+        fn output_schema(&self) -> Option<serde_json::Value> {
+            Some(TestAgentOutput::structured_output_format())
+        }
+
+        fn name(&self) -> &'static str {
+            "empty_stream_agent"
+        }
+
+        fn tools(&self) -> Vec<Box<dyn crate::tool::ToolT>> {
+            vec![]
+        }
+    }
+
+    #[async_trait]
+    impl AgentExecutor for EmptyStreamAgent {
+        type Output = TestAgentOutput;
+        type Error = TestError;
+
+        fn config(&self) -> ExecutorConfig {
+            ExecutorConfig::default()
+        }
+
+        async fn execute(
+            &self,
+            _task: &Task,
+            _context: Arc<Context>,
+        ) -> Result<Self::Output, Self::Error> {
+            Ok(TestAgentOutput {
+                result: "unused".to_string(),
+            })
+        }
+
+        async fn execute_stream(
+            &self,
+            _task: &Task,
+            _context: Arc<Context>,
+        ) -> Result<crate::utils::BoxRuntimeStream<Result<Self::Output, Self::Error>>, Self::Error>
+        {
+            Ok(Box::pin(stream::empty()))
+        }
+    }
+
+    impl AgentHooks for EmptyStreamAgent {}
+
+    #[tokio::test]
+    async fn test_actor_run_stream_to_completion_empty_stream_error() {
+        let llm = Arc::new(MockLLMProvider);
+        let (tx, _rx) = mpsc::channel(2);
+        let agent = Arc::new(
+            BaseAgent::<_, ActorAgent>::new(EmptyStreamAgent, llm, None, tx, true)
+                .await
+                .expect("agent should build"),
+        );
+
+        let err = agent
+            .run_stream_to_completion(Task::new("empty"))
+            .await
+            .expect_err("expected empty stream failure");
+        assert!(matches!(err, RunnableAgentError::ExecutorError(_)));
+        assert!(err.to_string().contains("without output"));
+    }
+
+    #[derive(Debug, Clone)]
+    struct StreamItemErrorAgent;
+
+    #[async_trait]
+    impl AgentDeriveT for StreamItemErrorAgent {
+        type Output = TestAgentOutput;
+
+        fn description(&self) -> &'static str {
+            "stream item error agent"
+        }
+
+        fn output_schema(&self) -> Option<serde_json::Value> {
+            Some(TestAgentOutput::structured_output_format())
+        }
+
+        fn name(&self) -> &'static str {
+            "stream_item_error_agent"
+        }
+
+        fn tools(&self) -> Vec<Box<dyn crate::tool::ToolT>> {
+            vec![]
+        }
+    }
+
+    #[async_trait]
+    impl AgentExecutor for StreamItemErrorAgent {
+        type Output = TestAgentOutput;
+        type Error = TestError;
+
+        fn config(&self) -> ExecutorConfig {
+            ExecutorConfig::default()
+        }
+
+        async fn execute(
+            &self,
+            _task: &Task,
+            _context: Arc<Context>,
+        ) -> Result<Self::Output, Self::Error> {
+            Ok(TestAgentOutput {
+                result: "unused".to_string(),
+            })
+        }
+
+        async fn execute_stream(
+            &self,
+            _task: &Task,
+            _context: Arc<Context>,
+        ) -> Result<crate::utils::BoxRuntimeStream<Result<Self::Output, Self::Error>>, Self::Error>
+        {
+            Ok(Box::pin(stream::iter([Err(TestError::ExecutionFailed(
+                "stream item failed".to_string(),
+            ))])))
+        }
+    }
+
+    impl AgentHooks for StreamItemErrorAgent {}
+
+    #[tokio::test]
+    async fn test_actor_run_stream_to_completion_stream_item_error() {
+        let llm = Arc::new(MockLLMProvider);
+        let (tx, mut rx) = mpsc::channel(2);
+        let agent = Arc::new(
+            BaseAgent::<_, ActorAgent>::new(StreamItemErrorAgent, llm, None, tx, true)
+                .await
+                .expect("agent should build"),
+        );
+
+        let err = agent
+            .run_stream_to_completion(Task::new("stream error"))
+            .await
+            .expect_err("expected stream item failure");
+        assert!(matches!(err, RunnableAgentError::ExecutorError(_)));
+        assert!(err.to_string().contains("stream item failed"));
+
+        let event = tokio::time::timeout(std::time::Duration::from_secs(1), rx.recv())
+            .await
+            .expect("timed out waiting for TaskError event")
+            .expect("channel closed without event");
+        match event {
+            Event::TaskError { error, .. } => {
+                assert!(error.contains("stream item failed"));
+            }
+            other => panic!("expected TaskError, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_actor_run_stream_to_completion_missing_tx_error() {
+        let llm = Arc::new(MockLLMProvider);
+        let (tx, _rx) = mpsc::channel(2);
+        let mut agent = BaseAgent::<_, ActorAgent>::new(
+            MockAgentImpl::new("agent", "desc"),
+            llm,
+            None,
+            tx,
+            true,
+        )
+        .await
+        .expect("agent should build");
+        agent.tx = None;
+        let agent = Arc::new(agent);
+
+        let err = agent
+            .run_stream_to_completion(Task::new("missing tx"))
+            .await
+            .expect_err("expected missing tx failure");
         assert!(matches!(err, RunnableAgentError::EmptyTx));
     }
 }

--- a/crates/autoagents-core/src/agent/actor.rs
+++ b/crates/autoagents-core/src/agent/actor.rs
@@ -13,7 +13,7 @@ use crate::error::Error;
 #[cfg(not(target_arch = "wasm32"))]
 use crate::runtime::TypedRuntime;
 use async_trait::async_trait;
-use autoagents_protocol::{Event, SubmissionId};
+use autoagents_protocol::Event;
 #[cfg(target_arch = "wasm32")]
 use futures::SinkExt;
 #[cfg(not(target_arch = "wasm32"))]
@@ -28,6 +28,7 @@ use std::sync::Arc;
 ///
 /// Actor agents run inside a runtime, can subscribe to topics, receive
 /// messages, and emit protocol `Event`s for streaming updates.
+#[derive(Clone, Copy)]
 pub struct ActorAgent {}
 
 impl AgentType for ActorAgent {
@@ -127,42 +128,6 @@ impl<T: AgentDeriveT + AgentExecutor + AgentHooks> BaseAgent<T, ActorAgent> {
         self.tx.clone().ok_or(RunnableAgentError::EmptyTx)
     }
 
-    /// Convert executor output to a protocol event payload and finish the run
-    /// lifecycle. Uses `Value: From<AgentExecutor::Output>` so `TaskComplete`
-    /// matches the non-streaming path regardless of `AgentDeriveT::Output`.
-    async fn finish_executor_run(
-        &self,
-        task: &Task,
-        context: &Context,
-        tx_event: &Option<Sender<Event>>,
-        submission_id: SubmissionId,
-        executor_out: <T as AgentExecutor>::Output,
-    ) -> Result<<T as AgentDeriveT>::Output, RunnableAgentError>
-    where
-        Value: From<<T as AgentExecutor>::Output>,
-        <T as AgentDeriveT>::Output: From<<T as AgentExecutor>::Output>,
-    {
-        let value: Value = executor_out.clone().into();
-        #[cfg(not(target_arch = "wasm32"))]
-        if let Err(e) = EventHelper::send_task_completed_value(
-            tx_event,
-            submission_id,
-            self.id,
-            self.name().to_string(),
-            &value,
-        )
-        .await
-        {
-            let err = RunnableAgentError::ExecutorError(e.to_string());
-            EventHelper::send_task_error(tx_event, submission_id, self.id, err.to_string()).await;
-            return Err(err);
-        }
-
-        let agent_out: <T as AgentDeriveT>::Output = executor_out.into();
-        self.inner.on_run_complete(task, &agent_out, context).await;
-        Ok(agent_out)
-    }
-
     pub async fn run(
         self: Arc<Self>,
         task: Task,
@@ -192,7 +157,7 @@ impl<T: AgentDeriveT + AgentExecutor + AgentHooks> BaseAgent<T, ActorAgent> {
         // Execute the agent's logic using the executor
         match self.inner().execute(&task, context.clone()).await {
             Ok(output) => {
-                self.finish_executor_run(&task, &context, &tx_event, submission_id, output)
+                self.finish_executor_run(&task, &context, submission_id, output)
                     .await
             }
             Err(e) => {
@@ -347,7 +312,7 @@ impl<T: AgentDeriveT + AgentExecutor + AgentHooks> BaseAgent<T, ActorAgent> {
             }
         };
 
-        self.finish_executor_run(&task, &context, &tx_event, submission_id, executor_out)
+        self.finish_executor_run(&task, &context, submission_id, executor_out)
             .await
     }
 }

--- a/crates/autoagents-core/src/agent/actor.rs
+++ b/crates/autoagents-core/src/agent/actor.rs
@@ -193,7 +193,6 @@ impl<T: AgentDeriveT + AgentExecutor + AgentHooks> BaseAgent<T, ActorAgent> {
         <T as AgentDeriveT>::Output: From<<T as AgentExecutor>::Output>,
         <T as AgentExecutor>::Error: Into<RunnableAgentError>,
     {
-        // let submission_id = task.submission_id;
         let context = self.create_context();
 
         // Execute the agent's streaming logic using the executor
@@ -218,6 +217,68 @@ impl<T: AgentDeriveT + AgentExecutor + AgentHooks> BaseAgent<T, ActorAgent> {
                 Err(e.into())
             }
         }
+    }
+
+    /// Execute a streaming task to completion inside the actor, draining the
+    /// stream and running lifecycle hooks before returning.
+    pub async fn run_stream_to_completion(
+        self: Arc<Self>,
+        task: Task,
+    ) -> Result<<T as AgentDeriveT>::Output, RunnableAgentError>
+    where
+        Value: From<<T as AgentExecutor>::Output>,
+        <T as AgentDeriveT>::Output: From<<T as AgentExecutor>::Output>,
+        <T as AgentExecutor>::Error: Into<RunnableAgentError>,
+    {
+        let submission_id = task.submission_id;
+        let tx = self.tx().map_err(|_| RunnableAgentError::EmptyTx)?;
+        let tx_event = Some(tx.clone());
+        let context = self.create_context();
+
+        let hook_outcome = self.inner.on_run_start(&task, &context).await;
+        match hook_outcome {
+            HookOutcome::Abort => return Err(RunnableAgentError::Abort),
+            HookOutcome::Continue => {}
+        }
+
+        let mut stream = self.clone().run_stream(task.clone()).await?;
+        use futures::StreamExt;
+
+        let mut last_output = None;
+        while let Some(result) = stream.next().await {
+            match result {
+                Ok(output) => last_output = Some(output),
+                Err(e) => {
+                    #[cfg(not(target_arch = "wasm32"))]
+                    EventHelper::send_task_error(&tx_event, submission_id, self.id, e.to_string())
+                        .await;
+                    return Err(e);
+                }
+            }
+        }
+
+        let agent_out = last_output.ok_or_else(|| {
+            RunnableAgentError::ExecutorError("Stream completed without output".to_string())
+        })?;
+
+        let value = serde_json::to_value(&agent_out)
+            .map_err(|e| RunnableAgentError::ExecutorError(e.to_string()))?;
+        #[cfg(not(target_arch = "wasm32"))]
+        EventHelper::send_task_completed_value(
+            &tx_event,
+            submission_id,
+            self.id,
+            self.name().to_string(),
+            &value,
+        )
+        .await
+        .map_err(|e| RunnableAgentError::ExecutorError(e.to_string()))?;
+
+        self.inner
+            .on_run_complete(&task, &agent_out, &context)
+            .await;
+
+        Ok(agent_out)
     }
 }
 
@@ -263,7 +324,7 @@ where
 
         //Run agent
         if agent.stream() {
-            let _ = agent.run_stream(task).await?;
+            let _ = agent.run_stream_to_completion(task).await?;
             Ok(())
         } else {
             let _ = agent.run(task).await?;

--- a/crates/autoagents-core/src/agent/actor.rs
+++ b/crates/autoagents-core/src/agent/actor.rs
@@ -182,15 +182,9 @@ impl<T: AgentDeriveT + AgentExecutor + AgentHooks> BaseAgent<T, ActorAgent> {
         let hook_outcome = self.inner.on_run_start(&task, &context).await;
         match hook_outcome {
             HookOutcome::Abort => {
-                #[cfg(not(target_arch = "wasm32"))]
-                EventHelper::send_task_error(
-                    &tx_event,
-                    submission_id,
-                    self.id,
-                    RunnableAgentError::Abort.to_string(),
-                )
-                .await;
-                return Err(RunnableAgentError::Abort);
+                return Err(
+                    EventHelper::abort_run_from_hook(&tx_event, submission_id, self.id).await,
+                );
             }
             HookOutcome::Continue => {}
         }
@@ -288,15 +282,9 @@ impl<T: AgentDeriveT + AgentExecutor + AgentHooks> BaseAgent<T, ActorAgent> {
         let hook_outcome = self.inner.on_run_start(&task, &context).await;
         match hook_outcome {
             HookOutcome::Abort => {
-                #[cfg(not(target_arch = "wasm32"))]
-                EventHelper::send_task_error(
-                    &tx_event,
-                    submission_id,
-                    self.id,
-                    RunnableAgentError::Abort.to_string(),
-                )
-                .await;
-                return Err(RunnableAgentError::Abort);
+                return Err(
+                    EventHelper::abort_run_from_hook(&tx_event, submission_id, self.id).await,
+                );
             }
             HookOutcome::Continue => {}
         }
@@ -318,14 +306,11 @@ impl<T: AgentDeriveT + AgentExecutor + AgentHooks> BaseAgent<T, ActorAgent> {
 
         let mut last_executor_output = None;
         while let Some(result) = stream.next().await {
-            match result {
+            match EventHelper::map_executor_stream_item(&tx_event, submission_id, self.id, result)
+                .await
+            {
                 Ok(output) => last_executor_output = Some(output),
-                Err(e) => {
-                    #[cfg(not(target_arch = "wasm32"))]
-                    EventHelper::send_task_error(&tx_event, submission_id, self.id, e.to_string())
-                        .await;
-                    return Err(e);
-                }
+                Err(e) => return Err(e),
             }
         }
 

--- a/crates/autoagents-core/src/agent/actor.rs
+++ b/crates/autoagents-core/src/agent/actor.rs
@@ -181,7 +181,17 @@ impl<T: AgentDeriveT + AgentExecutor + AgentHooks> BaseAgent<T, ActorAgent> {
         //Run Hook
         let hook_outcome = self.inner.on_run_start(&task, &context).await;
         match hook_outcome {
-            HookOutcome::Abort => return Err(RunnableAgentError::Abort),
+            HookOutcome::Abort => {
+                #[cfg(not(target_arch = "wasm32"))]
+                EventHelper::send_task_error(
+                    &tx_event,
+                    submission_id,
+                    self.id,
+                    RunnableAgentError::Abort.to_string(),
+                )
+                .await;
+                return Err(RunnableAgentError::Abort);
+            }
             HookOutcome::Continue => {}
         }
 
@@ -257,6 +267,10 @@ impl<T: AgentDeriveT + AgentExecutor + AgentHooks> BaseAgent<T, ActorAgent> {
 
     /// Execute a streaming task to completion inside the actor, draining the
     /// stream and running lifecycle hooks before returning.
+    ///
+    /// When the executor stream yields multiple successful outputs, only the
+    /// **last** item is used for `TaskComplete` and the returned agent output.
+    /// Intermediate items are not emitted as terminal events.
     pub async fn run_stream_to_completion(
         self: Arc<Self>,
         task: Task,
@@ -273,7 +287,17 @@ impl<T: AgentDeriveT + AgentExecutor + AgentHooks> BaseAgent<T, ActorAgent> {
 
         let hook_outcome = self.inner.on_run_start(&task, &context).await;
         match hook_outcome {
-            HookOutcome::Abort => return Err(RunnableAgentError::Abort),
+            HookOutcome::Abort => {
+                #[cfg(not(target_arch = "wasm32"))]
+                EventHelper::send_task_error(
+                    &tx_event,
+                    submission_id,
+                    self.id,
+                    RunnableAgentError::Abort.to_string(),
+                )
+                .await;
+                return Err(RunnableAgentError::Abort);
+            }
             HookOutcome::Continue => {}
         }
 
@@ -383,11 +407,13 @@ mod tests {
     use crate::agent::output::AgentOutputT;
     use crate::agent::{Context, ExecutorConfig};
     use crate::runtime::{Runtime, RuntimeError};
-    use crate::tests::{MockAgentImpl, MockLLMProvider, TestAgentOutput, TestError};
+    use crate::tests::{
+        DivergentStreamingAgent, MockAgentImpl, MockLLMProvider, MultiItemStreamAgent,
+        TestAgentOutput, TestError,
+    };
     use crate::utils::BoxEventStream;
     use async_trait::async_trait;
     use futures::{StreamExt, stream};
-    use serde::{Deserialize, Serialize};
     use std::any::{Any, TypeId};
     use std::sync::Arc;
     use tokio::sync::{Mutex, mpsc};
@@ -601,9 +627,37 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_actor_run_aborts_on_hook_emits_task_error() {
+        let llm = Arc::new(MockLLMProvider);
+        let (tx, mut rx) = mpsc::channel(2);
+        let agent = Arc::new(
+            BaseAgent::<_, ActorAgent>::new(AbortStreamingAgent, llm, None, tx, false)
+                .await
+                .expect("agent should build"),
+        );
+
+        let err = agent
+            .run(Task::new("abort"))
+            .await
+            .expect_err("expected hook abort");
+        assert!(matches!(err, RunnableAgentError::Abort));
+
+        let event = tokio::time::timeout(std::time::Duration::from_secs(1), rx.recv())
+            .await
+            .expect("timed out waiting for TaskError event")
+            .expect("channel closed without event");
+        match event {
+            Event::TaskError { error, .. } => {
+                assert!(error.contains("Abort"));
+            }
+            other => panic!("expected TaskError, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
     async fn test_actor_run_stream_to_completion_aborts_on_hook() {
         let llm = Arc::new(MockLLMProvider);
-        let (tx, _rx) = mpsc::channel(2);
+        let (tx, mut rx) = mpsc::channel(2);
         let agent = Arc::new(
             BaseAgent::<_, ActorAgent>::new(AbortStreamingAgent, llm, None, tx, true)
                 .await
@@ -615,6 +669,17 @@ mod tests {
             .await
             .expect_err("expected hook abort");
         assert!(matches!(err, RunnableAgentError::Abort));
+
+        let event = tokio::time::timeout(std::time::Duration::from_secs(1), rx.recv())
+            .await
+            .expect("timed out waiting for TaskError event")
+            .expect("channel closed without event");
+        match event {
+            Event::TaskError { error, .. } => {
+                assert!(error.contains("Abort"));
+            }
+            other => panic!("expected TaskError, got {other:?}"),
+        }
     }
 
     #[derive(Debug, Clone)]
@@ -895,114 +960,36 @@ mod tests {
         assert!(matches!(err, RunnableAgentError::EmptyTx));
     }
 
-    #[derive(Debug, Clone, Serialize, Deserialize)]
-    struct DivergentExecutorOutput {
-        response: String,
-        executor_only: u32,
-    }
+    #[tokio::test]
+    async fn test_actor_run_stream_to_completion_uses_last_stream_item() {
+        let llm = Arc::new(MockLLMProvider);
+        let (tx, mut rx) = mpsc::channel(2);
+        let agent = Arc::new(
+            BaseAgent::<_, ActorAgent>::new(MultiItemStreamAgent, llm, None, tx, true)
+                .await
+                .expect("agent should build"),
+        );
 
-    impl From<DivergentExecutorOutput> for Value {
-        fn from(output: DivergentExecutorOutput) -> Self {
-            serde_json::json!({
-                "response": output.response,
-                "executor_only": output.executor_only,
-            })
-        }
-    }
+        let output = agent
+            .run_stream_to_completion(Task::new("chunked"))
+            .await
+            .expect("stream should complete");
+        assert_eq!(output.result, "chunked-3");
 
-    #[derive(Debug, Clone, Serialize, Deserialize)]
-    struct DivergentAgentOutput {
-        result: String,
-    }
-
-    impl AgentOutputT for DivergentAgentOutput {
-        fn output_schema() -> &'static str {
-            r#"{"type":"object","properties":{"result":{"type":"string"}},"required":["result"]}"#
-        }
-
-        fn structured_output_format() -> Value {
-            serde_json::json!({
-                "name": "DivergentAgentOutput",
-                "description": "Derived agent output",
-                "schema": {
-                    "type": "object",
-                    "properties": {
-                        "result": {"type": "string"}
-                    },
-                    "required": ["result"]
-                },
-                "strict": true
-            })
-        }
-    }
-
-    impl From<DivergentExecutorOutput> for DivergentAgentOutput {
-        fn from(output: DivergentExecutorOutput) -> Self {
-            Self {
-                result: output.response,
+        let event = tokio::time::timeout(std::time::Duration::from_secs(1), rx.recv())
+            .await
+            .expect("timed out waiting for TaskComplete event")
+            .expect("channel closed without event");
+        match event {
+            Event::TaskComplete { result, .. } => {
+                let parsed: Value =
+                    serde_json::from_str(&result).expect("TaskComplete result should be JSON");
+                assert_eq!(parsed["sequence"], 3);
+                assert_eq!(parsed["response"], "chunked-3");
             }
+            other => panic!("expected TaskComplete, got {other:?}"),
         }
     }
-
-    #[derive(Debug, Clone)]
-    struct DivergentStreamingAgent;
-
-    #[async_trait]
-    impl AgentDeriveT for DivergentStreamingAgent {
-        type Output = DivergentAgentOutput;
-
-        fn description(&self) -> &'static str {
-            "divergent streaming agent"
-        }
-
-        fn output_schema(&self) -> Option<Value> {
-            Some(DivergentAgentOutput::structured_output_format())
-        }
-
-        fn name(&self) -> &'static str {
-            "divergent_streaming_agent"
-        }
-
-        fn tools(&self) -> Vec<Box<dyn crate::tool::ToolT>> {
-            vec![]
-        }
-    }
-
-    #[async_trait]
-    impl AgentExecutor for DivergentStreamingAgent {
-        type Output = DivergentExecutorOutput;
-        type Error = TestError;
-
-        fn config(&self) -> ExecutorConfig {
-            ExecutorConfig::default()
-        }
-
-        async fn execute(
-            &self,
-            task: &Task,
-            _context: Arc<Context>,
-        ) -> Result<Self::Output, Self::Error> {
-            Ok(DivergentExecutorOutput {
-                response: task.prompt.clone(),
-                executor_only: 42,
-            })
-        }
-
-        async fn execute_stream(
-            &self,
-            task: &Task,
-            _context: Arc<Context>,
-        ) -> Result<crate::utils::BoxRuntimeStream<Result<Self::Output, Self::Error>>, Self::Error>
-        {
-            let output = DivergentExecutorOutput {
-                response: task.prompt.clone(),
-                executor_only: 42,
-            };
-            Ok(Box::pin(stream::iter([Ok(output)])))
-        }
-    }
-
-    impl AgentHooks for DivergentStreamingAgent {}
 
     #[tokio::test]
     async fn test_actor_run_stream_to_completion_task_complete_uses_executor_value_from() {

--- a/crates/autoagents-core/src/agent/actor.rs
+++ b/crates/autoagents-core/src/agent/actor.rs
@@ -204,6 +204,19 @@ impl<T: AgentDeriveT + AgentExecutor + AgentHooks> BaseAgent<T, ActorAgent> {
         }
     }
 
+    /// Return a live executor output stream without the full task lifecycle.
+    ///
+    /// **Event channel:** Does **not** emit terminal protocol events (`TaskComplete`,
+    /// `TaskError`) on the agent event channel. In-stream failures appear only as `Err`
+    /// items on the returned stream. Lifecycle hooks (`on_run_start`, `on_run_complete`) are
+    /// also skipped.
+    ///
+    /// Use [`Self::run_stream_to_completion`] when dispatching through a runtime, waiting on
+    /// `TaskComplete` / `TaskError`, or matching the pub/sub actor path (which calls
+    /// `run_stream_to_completion` internally).
+    ///
+    /// Mid-run events (`StreamChunk`, tool-call events, etc.) may still be emitted by the
+    /// executor while the returned stream is polled.
     pub async fn run_stream(
         self: Arc<Self>,
         task: Task,
@@ -262,9 +275,16 @@ impl<T: AgentDeriveT + AgentExecutor + AgentHooks> BaseAgent<T, ActorAgent> {
     /// Execute a streaming task to completion inside the actor, draining the
     /// stream and running lifecycle hooks before returning.
     ///
+    /// This is the **event-aware** streaming entry point: emits `TaskError` on hook abort,
+    /// stream setup failure, in-stream item errors, and empty streams; emits `TaskComplete`
+    /// on success. Pub/sub [`AgentActor`](AgentActor) dispatch uses this method when
+    /// `stream()` is enabled.
+    ///
     /// When the executor stream yields multiple successful outputs, only the
     /// **last** item is used for `TaskComplete` and the returned agent output.
     /// Intermediate items are not emitted as terminal events.
+    ///
+    /// For incremental output without terminal events, see [`Self::run_stream`].
     pub async fn run_stream_to_completion(
         self: Arc<Self>,
         task: Task,
@@ -892,6 +912,37 @@ mod tests {
     }
 
     impl AgentHooks for StreamItemErrorAgent {}
+
+    #[tokio::test]
+    async fn test_actor_run_stream_does_not_emit_task_error_on_item_failure() {
+        let llm = Arc::new(MockLLMProvider);
+        let (tx, mut rx) = mpsc::channel(2);
+        let agent = Arc::new(
+            BaseAgent::<_, ActorAgent>::new(StreamItemErrorAgent, llm, None, tx, true)
+                .await
+                .expect("agent should build"),
+        );
+
+        let mut stream = agent
+            .run_stream(Task::new("stream error"))
+            .await
+            .expect("stream should start");
+        let err = stream
+            .next()
+            .await
+            .expect("stream should yield one item")
+            .expect_err("expected stream item failure");
+        assert!(err.to_string().contains("stream item failed"));
+
+        let event = tokio::time::timeout(std::time::Duration::from_millis(100), rx.recv()).await;
+        match event {
+            Ok(Some(Event::TaskError { .. })) => {
+                panic!("run_stream must not emit TaskError; use run_stream_to_completion")
+            }
+            Ok(Some(_)) | Ok(None) => {}
+            Err(_) => {}
+        }
+    }
 
     #[tokio::test]
     async fn test_actor_run_stream_to_completion_stream_item_error() {

--- a/crates/autoagents-core/src/agent/base.rs
+++ b/crates/autoagents-core/src/agent/base.rs
@@ -1,11 +1,13 @@
 use crate::agent::config::AgentConfig;
+use crate::agent::executor::event_helper::EventHelper;
 use crate::agent::memory::MemoryProvider;
+use crate::agent::task::Task;
 use crate::agent::{AgentExecutor, Context, output::AgentOutputT};
 use crate::tool::{ToolT, to_llm_tool};
 use async_trait::async_trait;
 use autoagents_llm::LLMProvider;
 use autoagents_llm::chat::Tool;
-use autoagents_protocol::{ActorID, Event};
+use autoagents_protocol::{ActorID, Event, SubmissionId};
 
 use serde_json::Value;
 use std::marker::PhantomData;
@@ -172,6 +174,58 @@ impl<T: AgentDeriveT + AgentExecutor + AgentHooks, A: AgentType> BaseAgent<T, A>
     /// Get the memory provider if available
     pub fn memory(&self) -> Option<Arc<Mutex<Box<dyn MemoryProvider>>>> {
         self.memory.clone()
+    }
+
+    /// Clone handle-style fields without requiring `T: Clone`.
+    pub(crate) fn clone_shallow(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            llm: self.llm.clone(),
+            id: self.id,
+            memory: self.memory.clone(),
+            serialized_tools: self.serialized_tools.clone(),
+            tx: self.tx.clone(),
+            stream: self.stream,
+            marker: PhantomData,
+        }
+    }
+
+    /// Emit `TaskComplete`, run `on_run_complete`, and return the agent output.
+    ///
+    /// Uses `Value: From<AgentExecutor::Output>` so `TaskComplete` serialization matches
+    /// the executor payload regardless of `AgentDeriveT::Output`.
+    pub(crate) async fn finish_executor_run(
+        &self,
+        task: &Task,
+        context: &Context,
+        submission_id: SubmissionId,
+        executor_out: <T as AgentExecutor>::Output,
+    ) -> Result<<T as AgentDeriveT>::Output, RunnableAgentError>
+    where
+        Value: From<<T as AgentExecutor>::Output>,
+        <T as AgentDeriveT>::Output: From<<T as AgentExecutor>::Output>,
+        <T as AgentExecutor>::Output: Clone,
+    {
+        let tx_event = self.tx.clone();
+        let value: Value = executor_out.clone().into();
+        #[cfg(not(target_arch = "wasm32"))]
+        if let Err(e) = EventHelper::send_task_completed_value(
+            &tx_event,
+            submission_id,
+            self.id,
+            self.name().to_string(),
+            &value,
+        )
+        .await
+        {
+            let err = RunnableAgentError::ExecutorError(e.to_string());
+            EventHelper::send_task_error(&tx_event, submission_id, self.id, err.to_string()).await;
+            return Err(err);
+        }
+
+        let agent_out: <T as AgentDeriveT>::Output = executor_out.into();
+        self.inner.on_run_complete(task, &agent_out, context).await;
+        Ok(agent_out)
     }
 }
 

--- a/crates/autoagents-core/src/agent/direct.rs
+++ b/crates/autoagents-core/src/agent/direct.rs
@@ -32,6 +32,9 @@ impl AgentType for DirectAgent {
 /// Handle for a direct agent containing the agent instance and an event stream
 /// receiver. Use `agent.run(...)` for one-shot calls or `agent.run_stream(...)`
 /// to receive streaming outputs.
+///
+/// Terminal failures (hook abort, executor error, stream setup error, and in-stream
+/// item errors) emit [`Event::TaskError`] on [`Self::rx`].
 pub struct DirectAgentHandle<T: AgentDeriveT + AgentExecutor + AgentHooks + Send + Sync> {
     pub agent: BaseAgent<T, DirectAgent>,
     pub rx: BoxEventStream<Event>,
@@ -94,15 +97,9 @@ impl<T: AgentDeriveT + AgentExecutor + AgentHooks> BaseAgent<T, DirectAgent> {
         let hook_outcome = self.inner.on_run_start(&task, &context).await;
         match hook_outcome {
             HookOutcome::Abort => {
-                #[cfg(not(target_arch = "wasm32"))]
-                EventHelper::send_task_error(
-                    &tx_event,
-                    submission_id,
-                    self.id,
-                    RunnableAgentError::Abort.to_string(),
-                )
-                .await;
-                return Err(RunnableAgentError::Abort);
+                return Err(
+                    EventHelper::abort_run_from_hook(&tx_event, submission_id, self.id).await,
+                );
             }
             HookOutcome::Continue => {}
         }
@@ -122,8 +119,11 @@ impl<T: AgentDeriveT + AgentExecutor + AgentHooks> BaseAgent<T, DirectAgent> {
                 Ok(agent_out)
             }
             Err(e) => {
-                // Send error event
-                Err(e.into())
+                let err: RunnableAgentError = e.into();
+                #[cfg(not(target_arch = "wasm32"))]
+                EventHelper::send_task_error(&tx_event, submission_id, self.id, err.to_string())
+                    .await;
+                Err(err)
             }
         }
     }
@@ -149,15 +149,9 @@ impl<T: AgentDeriveT + AgentExecutor + AgentHooks> BaseAgent<T, DirectAgent> {
         let hook_outcome = self.inner.on_run_start(&task, &context).await;
         match hook_outcome {
             HookOutcome::Abort => {
-                #[cfg(not(target_arch = "wasm32"))]
-                EventHelper::send_task_error(
-                    &tx_event,
-                    submission_id,
-                    self.id,
-                    RunnableAgentError::Abort.to_string(),
-                )
-                .await;
-                return Err(RunnableAgentError::Abort);
+                return Err(
+                    EventHelper::abort_run_from_hook(&tx_event, submission_id, self.id).await,
+                );
             }
             HookOutcome::Continue => {}
         }
@@ -165,18 +159,33 @@ impl<T: AgentDeriveT + AgentExecutor + AgentHooks> BaseAgent<T, DirectAgent> {
         // Execute the agent's streaming logic using the executor
         match self.inner().execute_stream(&task, context.clone()).await {
             Ok(stream) => {
-                use futures::TryStreamExt;
-                // Convert stream output/error without returning large Result err types from closures.
+                use futures::{StreamExt, TryStreamExt};
+                let tx_event = tx_event.clone();
+                let actor_id = self.id;
                 let transformed_stream = stream
+                    .then(move |result| {
+                        let tx = tx_event.clone();
+                        async move {
+                            EventHelper::map_executor_stream_item(
+                                &tx,
+                                submission_id,
+                                actor_id,
+                                result,
+                            )
+                            .await
+                        }
+                    })
                     .map_ok(Into::into)
-                    .map_err(Into::<RunnableAgentError>::into)
                     .map_err(Error::from);
 
                 Ok(Box::pin(transformed_stream))
             }
             Err(e) => {
-                // Send error event for stream creation failure
-                Err(e.into())
+                let err: RunnableAgentError = e.into();
+                #[cfg(not(target_arch = "wasm32"))]
+                EventHelper::send_task_error(&tx_event, submission_id, self.id, err.to_string())
+                    .await;
+                Err(err)
             }
         }
     }
@@ -237,7 +246,7 @@ mod tests {
     async fn test_direct_agent_run_executor_error() {
         let mock_agent = MockAgentImpl::new("direct", "direct agent").with_failure(true);
         let llm = Arc::new(ConfigurableLLMProvider::default());
-        let handle = AgentBuilder::<_, DirectAgent>::new(mock_agent)
+        let mut handle = AgentBuilder::<_, DirectAgent>::new(mock_agent)
             .llm(llm)
             .build()
             .await
@@ -246,6 +255,17 @@ mod tests {
         let task = Task::new("fail");
         let err = handle.agent.run(task).await.expect_err("expected error");
         assert!(matches!(err, RunnableAgentError::ExecutorError(_)));
+
+        let event = tokio::time::timeout(std::time::Duration::from_secs(1), handle.rx.next())
+            .await
+            .expect("timed out waiting for TaskError event")
+            .expect("stream ended without event");
+        match event {
+            Event::TaskError { error, .. } => {
+                assert!(error.contains("Mock execution failed"));
+            }
+            other => panic!("expected TaskError, got {other:?}"),
+        }
     }
 
     #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -514,6 +534,253 @@ mod tests {
         match event {
             Event::TaskError { error, .. } => {
                 assert!(error.contains("Abort"));
+            }
+            other => panic!("expected TaskError, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_direct_agent_run_stream_aborts_before_execute_stream() {
+        let executed = Arc::new(AtomicBool::new(false));
+        let agent = AbortAgent {
+            executed: Arc::clone(&executed),
+        };
+        let llm = Arc::new(ConfigurableLLMProvider::default());
+        let mut handle = AgentBuilder::<_, DirectAgent>::new(agent)
+            .llm(llm)
+            .stream(true)
+            .build()
+            .await
+            .expect("build should succeed");
+
+        let task = Task::new("abort");
+        let err = match handle.agent.run_stream(task).await {
+            Err(err) => err,
+            Ok(_) => panic!("expected abort"),
+        };
+        assert!(matches!(err, RunnableAgentError::Abort));
+        assert!(!executed.load(Ordering::SeqCst));
+
+        let event = tokio::time::timeout(std::time::Duration::from_secs(1), handle.rx.next())
+            .await
+            .expect("timed out waiting for TaskError event")
+            .expect("stream ended without event");
+        match event {
+            Event::TaskError { error, .. } => {
+                assert!(error.contains("Abort"));
+            }
+            other => panic!("expected TaskError, got {other:?}"),
+        }
+    }
+
+    #[derive(Debug, Clone)]
+    struct FailingStreamSetupAgent;
+
+    #[async_trait]
+    impl AgentDeriveT for FailingStreamSetupAgent {
+        type Output = TestAgentOutput;
+
+        fn description(&self) -> &'static str {
+            "failing stream setup"
+        }
+
+        fn output_schema(&self) -> Option<Value> {
+            Some(TestAgentOutput::structured_output_format())
+        }
+
+        fn name(&self) -> &'static str {
+            "failing_stream_setup"
+        }
+
+        fn tools(&self) -> Vec<Box<dyn ToolT>> {
+            vec![]
+        }
+    }
+
+    #[async_trait]
+    impl AgentExecutor for FailingStreamSetupAgent {
+        type Output = TestAgentOutput;
+        type Error = TestError;
+
+        fn config(&self) -> ExecutorConfig {
+            ExecutorConfig::default()
+        }
+
+        async fn execute(
+            &self,
+            _task: &Task,
+            _context: Arc<Context>,
+        ) -> Result<Self::Output, Self::Error> {
+            Ok(TestAgentOutput {
+                result: "unused".to_string(),
+            })
+        }
+
+        async fn execute_stream(
+            &self,
+            _task: &Task,
+            _context: Arc<Context>,
+        ) -> Result<crate::utils::BoxRuntimeStream<Result<Self::Output, Self::Error>>, Self::Error>
+        {
+            Err(TestError::ExecutionFailed(
+                "stream setup failed".to_string(),
+            ))
+        }
+    }
+
+    impl AgentHooks for FailingStreamSetupAgent {}
+
+    #[tokio::test]
+    async fn test_direct_agent_run_stream_setup_error_emits_task_error() {
+        let llm = Arc::new(ConfigurableLLMProvider::default());
+        let mut handle = AgentBuilder::<_, DirectAgent>::new(FailingStreamSetupAgent)
+            .llm(llm)
+            .stream(true)
+            .build()
+            .await
+            .expect("build should succeed");
+
+        let err = match handle.agent.run_stream(Task::new("fail setup")).await {
+            Err(err) => err,
+            Ok(_) => panic!("expected stream setup failure"),
+        };
+        assert!(matches!(err, RunnableAgentError::ExecutorError(_)));
+
+        let event = tokio::time::timeout(std::time::Duration::from_secs(1), handle.rx.next())
+            .await
+            .expect("timed out waiting for TaskError event")
+            .expect("stream ended without event");
+        match event {
+            Event::TaskError { error, .. } => {
+                assert!(error.contains("stream setup failed"));
+            }
+            other => panic!("expected TaskError, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_direct_agent_run_stream_item_error_emits_task_error() {
+        let mock_agent = MockAgentImpl::new("direct", "direct agent").with_failure(true);
+        let llm = Arc::new(ConfigurableLLMProvider::default());
+        let mut handle = AgentBuilder::<_, DirectAgent>::new(mock_agent)
+            .llm(llm)
+            .stream(true)
+            .build()
+            .await
+            .expect("build should succeed");
+
+        let mut stream = handle
+            .agent
+            .run_stream(Task::new("fail"))
+            .await
+            .expect("default execute_stream should return Ok stream");
+
+        let err = stream
+            .next()
+            .await
+            .expect("stream should yield one item")
+            .expect_err("expected stream item error");
+        assert!(matches!(err, Error::RunnableAgentError(_)));
+
+        let event = tokio::time::timeout(std::time::Duration::from_secs(1), handle.rx.next())
+            .await
+            .expect("timed out waiting for TaskError event")
+            .expect("stream ended without event");
+        match event {
+            Event::TaskError { error, .. } => {
+                assert!(error.contains("Mock execution failed"));
+            }
+            other => panic!("expected TaskError, got {other:?}"),
+        }
+    }
+
+    #[derive(Debug, Clone)]
+    struct StreamItemErrorAgent;
+
+    #[async_trait]
+    impl AgentDeriveT for StreamItemErrorAgent {
+        type Output = TestAgentOutput;
+
+        fn description(&self) -> &'static str {
+            "stream item error agent"
+        }
+
+        fn output_schema(&self) -> Option<Value> {
+            Some(TestAgentOutput::structured_output_format())
+        }
+
+        fn name(&self) -> &'static str {
+            "stream_item_error"
+        }
+
+        fn tools(&self) -> Vec<Box<dyn ToolT>> {
+            vec![]
+        }
+    }
+
+    #[async_trait]
+    impl AgentExecutor for StreamItemErrorAgent {
+        type Output = TestAgentOutput;
+        type Error = TestError;
+
+        fn config(&self) -> ExecutorConfig {
+            ExecutorConfig::default()
+        }
+
+        async fn execute(
+            &self,
+            _task: &Task,
+            _context: Arc<Context>,
+        ) -> Result<Self::Output, Self::Error> {
+            Ok(TestAgentOutput {
+                result: "unused".to_string(),
+            })
+        }
+
+        async fn execute_stream(
+            &self,
+            _task: &Task,
+            _context: Arc<Context>,
+        ) -> Result<crate::utils::BoxRuntimeStream<Result<Self::Output, Self::Error>>, Self::Error>
+        {
+            Ok(Box::pin(futures::stream::iter([Err(
+                TestError::ExecutionFailed("stream item failed".to_string()),
+            )])))
+        }
+    }
+
+    impl AgentHooks for StreamItemErrorAgent {}
+
+    #[tokio::test]
+    async fn test_direct_agent_run_stream_custom_item_error_emits_task_error() {
+        let llm = Arc::new(ConfigurableLLMProvider::default());
+        let mut handle = AgentBuilder::<_, DirectAgent>::new(StreamItemErrorAgent)
+            .llm(llm)
+            .stream(true)
+            .build()
+            .await
+            .expect("build should succeed");
+
+        let mut stream = handle
+            .agent
+            .run_stream(Task::new("stream error"))
+            .await
+            .expect("stream should start");
+
+        let err = stream
+            .next()
+            .await
+            .expect("stream should yield one item")
+            .expect_err("expected stream item failure");
+        assert!(matches!(err, Error::RunnableAgentError(_)));
+
+        let event = tokio::time::timeout(std::time::Duration::from_secs(1), handle.rx.next())
+            .await
+            .expect("timed out waiting for TaskError event")
+            .expect("stream ended without event");
+        match event {
+            Event::TaskError { error, .. } => {
+                assert!(error.contains("stream item failed"));
             }
             other => panic!("expected TaskError, got {other:?}"),
         }

--- a/crates/autoagents-core/src/agent/direct.rs
+++ b/crates/autoagents-core/src/agent/direct.rs
@@ -1,10 +1,13 @@
 use crate::agent::base::AgentType;
+use crate::agent::context::Context;
 use crate::agent::error::{AgentBuildError, RunnableAgentError};
 use crate::agent::executor::event_helper::EventHelper;
 use crate::agent::task::Task;
 use crate::agent::{AgentBuilder, AgentDeriveT, AgentExecutor, AgentHooks, BaseAgent, HookOutcome};
 use crate::error::Error;
 use autoagents_protocol::Event;
+use serde_json::Value;
+use std::sync::Arc;
 
 use crate::agent::constants::DEFAULT_CHANNEL_BUFFER;
 
@@ -21,6 +24,7 @@ use futures_util::stream;
 /// Direct agents execute immediately within the caller's task without
 /// requiring a runtime or event wiring. Use this for simple one-shot
 /// invocations and unit tests.
+#[derive(Clone, Copy)]
 pub struct DirectAgent {}
 
 impl AgentType for DirectAgent {
@@ -33,8 +37,11 @@ impl AgentType for DirectAgent {
 /// receiver. Use `agent.run(...)` for one-shot calls or `agent.run_stream(...)`
 /// to receive streaming outputs.
 ///
-/// Terminal failures (hook abort, executor error, stream setup error, and in-stream
-/// item errors) emit [`Event::TaskError`] on [`Self::rx`].
+/// Terminal outcomes emit protocol events on [`Self::rx`]: `TaskComplete` on success
+/// and `TaskError` on failure (hook abort, executor error, stream setup error,
+/// in-stream item errors, and empty streams). For `run_stream()`, `TaskComplete`
+/// is emitted when the returned output stream is fully drained; the last successful
+/// item is used for the event payload.
 pub struct DirectAgentHandle<T: AgentDeriveT + AgentExecutor + AgentHooks + Send + Sync> {
     pub agent: BaseAgent<T, DirectAgent>,
     pub rx: BoxEventStream<Event>,
@@ -82,11 +89,104 @@ impl<T: AgentDeriveT + AgentExecutor + AgentHooks> AgentBuilder<T, DirectAgent> 
     }
 }
 
+fn wrap_direct_stream_with_terminal_events<T>(
+    agent: BaseAgent<T, DirectAgent>,
+    stream: crate::utils::BoxRuntimeStream<
+        Result<<T as AgentExecutor>::Output, <T as AgentExecutor>::Error>,
+    >,
+    task: Task,
+    context: Arc<Context>,
+    tx_event: Option<crate::channel::Sender<Event>>,
+    submission_id: autoagents_protocol::SubmissionId,
+    actor_id: autoagents_protocol::ActorID,
+) -> crate::utils::BoxRuntimeStream<Result<<T as AgentDeriveT>::Output, Error>>
+where
+    T: AgentDeriveT + AgentExecutor + AgentHooks + Send + Sync,
+    Value: From<<T as AgentExecutor>::Output>,
+    <T as AgentDeriveT>::Output: From<<T as AgentExecutor>::Output>,
+    <T as AgentExecutor>::Output: Clone,
+    <T as AgentExecutor>::Error: Into<RunnableAgentError>,
+{
+    use futures::StreamExt;
+
+    Box::pin(futures::stream::unfold(
+        (
+            stream,
+            false,
+            None::<<T as AgentExecutor>::Output>,
+            task,
+            context,
+        ),
+        move |(mut stream, mut saw_error, last, task, context)| {
+            let agent = agent.clone_shallow();
+            let tx_event = tx_event.clone();
+            async move {
+                match stream.next().await {
+                    Some(result) => {
+                        match EventHelper::map_executor_stream_item(
+                            &tx_event,
+                            submission_id,
+                            actor_id,
+                            result,
+                        )
+                        .await
+                        {
+                            Ok(output) => {
+                                let agent_out: <T as AgentDeriveT>::Output = output.clone().into();
+                                Some((
+                                    Ok(agent_out),
+                                    (stream, saw_error, Some(output), task, context),
+                                ))
+                            }
+                            Err(err) => {
+                                saw_error = true;
+                                Some((
+                                    Err(Error::from(err)),
+                                    (stream, saw_error, last, task, context),
+                                ))
+                            }
+                        }
+                    }
+                    None => {
+                        if !saw_error {
+                            if let Some(executor_out) = last {
+                                let _ = agent
+                                    .finish_executor_run(
+                                        &task,
+                                        context.as_ref(),
+                                        submission_id,
+                                        executor_out,
+                                    )
+                                    .await;
+                            } else {
+                                let err = RunnableAgentError::ExecutorError(
+                                    "Stream completed without output".to_string(),
+                                );
+                                #[cfg(not(target_arch = "wasm32"))]
+                                EventHelper::send_task_error(
+                                    &tx_event,
+                                    submission_id,
+                                    actor_id,
+                                    err.to_string(),
+                                )
+                                .await;
+                            }
+                        }
+                        None
+                    }
+                }
+            }
+        },
+    ))
+}
+
 impl<T: AgentDeriveT + AgentExecutor + AgentHooks> BaseAgent<T, DirectAgent> {
     /// Execute the agent for a single task and return the final agent output.
     pub async fn run(&self, task: Task) -> Result<<T as AgentDeriveT>::Output, RunnableAgentError>
     where
+        Value: From<<T as AgentExecutor>::Output>,
         <T as AgentDeriveT>::Output: From<<T as AgentExecutor>::Output>,
+        <T as AgentExecutor>::Output: Clone,
         <T as AgentExecutor>::Error: Into<RunnableAgentError>,
     {
         let submission_id = task.submission_id;
@@ -107,16 +207,8 @@ impl<T: AgentDeriveT + AgentExecutor + AgentHooks> BaseAgent<T, DirectAgent> {
         // Execute the agent's logic using the executor
         match self.inner().execute(&task, context.clone()).await {
             Ok(output) => {
-                let output: <T as AgentExecutor>::Output = output;
-
-                //Extract Agent output into the desired type
-                let agent_out: <T as AgentDeriveT>::Output = output.into();
-
-                //Run On complete Hook
-                self.inner
-                    .on_run_complete(&task, &agent_out, &context)
-                    .await;
-                Ok(agent_out)
+                self.finish_executor_run(&task, &context, submission_id, output)
+                    .await
             }
             Err(e) => {
                 let err: RunnableAgentError = e.into();
@@ -138,7 +230,9 @@ impl<T: AgentDeriveT + AgentExecutor + AgentHooks> BaseAgent<T, DirectAgent> {
         RunnableAgentError,
     >
     where
+        Value: From<<T as AgentExecutor>::Output>,
         <T as AgentDeriveT>::Output: From<<T as AgentExecutor>::Output>,
+        <T as AgentExecutor>::Output: Clone,
         <T as AgentExecutor>::Error: Into<RunnableAgentError>,
     {
         let submission_id = task.submission_id;
@@ -158,28 +252,15 @@ impl<T: AgentDeriveT + AgentExecutor + AgentHooks> BaseAgent<T, DirectAgent> {
 
         // Execute the agent's streaming logic using the executor
         match self.inner().execute_stream(&task, context.clone()).await {
-            Ok(stream) => {
-                use futures::{StreamExt, TryStreamExt};
-                let tx_event = tx_event.clone();
-                let actor_id = self.id;
-                let transformed_stream = stream
-                    .then(move |result| {
-                        let tx = tx_event.clone();
-                        async move {
-                            EventHelper::map_executor_stream_item(
-                                &tx,
-                                submission_id,
-                                actor_id,
-                                result,
-                            )
-                            .await
-                        }
-                    })
-                    .map_ok(Into::into)
-                    .map_err(Error::from);
-
-                Ok(Box::pin(transformed_stream))
-            }
+            Ok(stream) => Ok(wrap_direct_stream_with_terminal_events(
+                self.clone_shallow(),
+                stream,
+                task,
+                context,
+                tx_event,
+                submission_id,
+                self.id,
+            )),
             Err(e) => {
                 let err: RunnableAgentError = e.into();
                 #[cfg(not(target_arch = "wasm32"))]
@@ -202,7 +283,9 @@ mod tests {
     };
     use crate::agent::task::Task;
     use crate::agent::{Context, ExecutorConfig};
-    use crate::tests::{ConfigurableLLMProvider, MockAgentImpl, TestAgentOutput, TestError};
+    use crate::tests::{
+        ConfigurableLLMProvider, MockAgentImpl, MultiItemStreamAgent, TestAgentOutput, TestError,
+    };
     use crate::tool::ToolT;
     use async_trait::async_trait;
     use futures::StreamExt;
@@ -231,7 +314,7 @@ mod tests {
     async fn test_direct_agent_run_success() {
         let mock_agent = MockAgentImpl::new("direct", "direct agent");
         let llm = Arc::new(ConfigurableLLMProvider::default());
-        let handle = AgentBuilder::<_, DirectAgent>::new(mock_agent)
+        let mut handle = AgentBuilder::<_, DirectAgent>::new(mock_agent)
             .llm(llm)
             .build()
             .await
@@ -240,6 +323,19 @@ mod tests {
         let task = Task::new("hello");
         let result = handle.agent.run(task).await.expect("run should succeed");
         assert_eq!(result.result, "Processed: hello");
+
+        let event = tokio::time::timeout(std::time::Duration::from_secs(1), handle.rx.next())
+            .await
+            .expect("timed out waiting for TaskComplete event")
+            .expect("stream ended without event");
+        match event {
+            Event::TaskComplete { result, .. } => {
+                let parsed: Value =
+                    serde_json::from_str(&result).expect("TaskComplete result should be JSON");
+                assert_eq!(parsed["result"], "Processed: hello");
+            }
+            other => panic!("expected TaskComplete, got {other:?}"),
+        }
     }
 
     #[tokio::test]
@@ -437,7 +533,7 @@ mod tests {
     #[tokio::test]
     async fn test_direct_agent_run_stream_default_executes_once() {
         let llm = Arc::new(ConfigurableLLMProvider::default());
-        let handle = AgentBuilder::<_, DirectAgent>::new(StreamAgent)
+        let mut handle = AgentBuilder::<_, DirectAgent>::new(StreamAgent)
             .llm(llm)
             .build()
             .await
@@ -453,6 +549,19 @@ mod tests {
         assert_eq!(outputs.len(), 1);
         let output = outputs[0].as_ref().expect("expected Ok output");
         assert_eq!(output.result, "Streamed: stream");
+
+        let event = tokio::time::timeout(std::time::Duration::from_secs(1), handle.rx.next())
+            .await
+            .expect("timed out waiting for TaskComplete event")
+            .expect("stream ended without event");
+        match event {
+            Event::TaskComplete { result, .. } => {
+                let parsed: Value =
+                    serde_json::from_str(&result).expect("TaskComplete result should be JSON");
+                assert_eq!(parsed["result"], "Streamed: stream");
+            }
+            other => panic!("expected TaskComplete, got {other:?}"),
+        }
     }
 
     #[derive(Debug)]
@@ -784,5 +893,238 @@ mod tests {
             }
             other => panic!("expected TaskError, got {other:?}"),
         }
+    }
+
+    #[derive(Debug, Clone)]
+    struct EmptyStreamAgent;
+
+    #[async_trait]
+    impl AgentDeriveT for EmptyStreamAgent {
+        type Output = TestAgentOutput;
+
+        fn description(&self) -> &'static str {
+            "empty stream agent"
+        }
+
+        fn output_schema(&self) -> Option<Value> {
+            Some(TestAgentOutput::structured_output_format())
+        }
+
+        fn name(&self) -> &'static str {
+            "empty_stream_agent"
+        }
+
+        fn tools(&self) -> Vec<Box<dyn ToolT>> {
+            vec![]
+        }
+    }
+
+    #[async_trait]
+    impl AgentExecutor for EmptyStreamAgent {
+        type Output = TestAgentOutput;
+        type Error = TestError;
+
+        fn config(&self) -> ExecutorConfig {
+            ExecutorConfig::default()
+        }
+
+        async fn execute(
+            &self,
+            _task: &Task,
+            _context: Arc<Context>,
+        ) -> Result<Self::Output, Self::Error> {
+            Ok(TestAgentOutput {
+                result: "unused".to_string(),
+            })
+        }
+
+        async fn execute_stream(
+            &self,
+            _task: &Task,
+            _context: Arc<Context>,
+        ) -> Result<crate::utils::BoxRuntimeStream<Result<Self::Output, Self::Error>>, Self::Error>
+        {
+            Ok(Box::pin(futures::stream::empty()))
+        }
+    }
+
+    impl AgentHooks for EmptyStreamAgent {}
+
+    #[tokio::test]
+    async fn test_direct_agent_run_stream_empty_stream_emits_task_error() {
+        let llm = Arc::new(ConfigurableLLMProvider::default());
+        let mut handle = AgentBuilder::<_, DirectAgent>::new(EmptyStreamAgent)
+            .llm(llm)
+            .stream(true)
+            .build()
+            .await
+            .expect("build should succeed");
+
+        let stream = handle
+            .agent
+            .run_stream(Task::new("empty"))
+            .await
+            .expect("stream should start");
+        let outputs: Vec<_> = stream.collect().await;
+        assert!(outputs.is_empty());
+
+        let event = tokio::time::timeout(std::time::Duration::from_secs(1), handle.rx.next())
+            .await
+            .expect("timed out waiting for TaskError event")
+            .expect("stream ended without event");
+        match event {
+            Event::TaskError { error, .. } => {
+                assert!(error.contains("without output"));
+            }
+            other => panic!("expected TaskError, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_direct_agent_run_stream_uses_last_item_for_task_complete() {
+        let llm = Arc::new(ConfigurableLLMProvider::default());
+        let mut handle = AgentBuilder::<_, DirectAgent>::new(MultiItemStreamAgent)
+            .llm(llm)
+            .stream(true)
+            .build()
+            .await
+            .expect("build should succeed");
+
+        let stream = handle
+            .agent
+            .run_stream(Task::new("chunked"))
+            .await
+            .expect("stream should start");
+        let outputs: Vec<_> = stream.collect().await;
+        assert_eq!(outputs.len(), 3);
+        assert_eq!(outputs[2].as_ref().expect("third item").result, "chunked-3");
+
+        let event = tokio::time::timeout(std::time::Duration::from_secs(1), handle.rx.next())
+            .await
+            .expect("timed out waiting for TaskComplete event")
+            .expect("stream ended without event");
+        match event {
+            Event::TaskComplete { result, .. } => {
+                let parsed: Value =
+                    serde_json::from_str(&result).expect("TaskComplete result should be JSON");
+                assert_eq!(parsed["sequence"], 3);
+                assert_eq!(parsed["response"], "chunked-3");
+            }
+            other => panic!("expected TaskComplete, got {other:?}"),
+        }
+    }
+
+    #[derive(Debug, Clone)]
+    struct OkThenErrStreamAgent;
+
+    #[async_trait]
+    impl AgentDeriveT for OkThenErrStreamAgent {
+        type Output = TestAgentOutput;
+
+        fn description(&self) -> &'static str {
+            "ok then err stream agent"
+        }
+
+        fn output_schema(&self) -> Option<Value> {
+            Some(TestAgentOutput::structured_output_format())
+        }
+
+        fn name(&self) -> &'static str {
+            "ok_then_err_stream_agent"
+        }
+
+        fn tools(&self) -> Vec<Box<dyn ToolT>> {
+            vec![]
+        }
+    }
+
+    #[async_trait]
+    impl AgentExecutor for OkThenErrStreamAgent {
+        type Output = TestAgentOutput;
+        type Error = TestError;
+
+        fn config(&self) -> ExecutorConfig {
+            ExecutorConfig::default()
+        }
+
+        async fn execute(
+            &self,
+            _task: &Task,
+            _context: Arc<Context>,
+        ) -> Result<Self::Output, Self::Error> {
+            Ok(TestAgentOutput {
+                result: "unused".to_string(),
+            })
+        }
+
+        async fn execute_stream(
+            &self,
+            _task: &Task,
+            _context: Arc<Context>,
+        ) -> Result<crate::utils::BoxRuntimeStream<Result<Self::Output, Self::Error>>, Self::Error>
+        {
+            Ok(Box::pin(futures::stream::iter([
+                Ok(TestAgentOutput {
+                    result: "partial".to_string(),
+                }),
+                Err(TestError::ExecutionFailed("stream item failed".to_string())),
+            ])))
+        }
+    }
+
+    impl AgentHooks for OkThenErrStreamAgent {}
+
+    #[tokio::test]
+    async fn test_direct_agent_run_stream_ok_then_err_emits_task_error_not_task_complete() {
+        let llm = Arc::new(ConfigurableLLMProvider::default());
+        let mut handle = AgentBuilder::<_, DirectAgent>::new(OkThenErrStreamAgent)
+            .llm(llm)
+            .stream(true)
+            .build()
+            .await
+            .expect("build should succeed");
+
+        let mut stream = handle
+            .agent
+            .run_stream(Task::new("partial failure"))
+            .await
+            .expect("stream should start");
+
+        let first = stream
+            .next()
+            .await
+            .expect("stream should yield ok item")
+            .expect("expected ok item");
+        assert_eq!(first.result, "partial");
+
+        let second = stream
+            .next()
+            .await
+            .expect("stream should yield err item")
+            .expect_err("expected err item");
+        assert!(matches!(second, Error::RunnableAgentError(_)));
+
+        assert!(
+            stream.next().await.is_none(),
+            "stream should end after error item"
+        );
+
+        let event = tokio::time::timeout(std::time::Duration::from_secs(1), handle.rx.next())
+            .await
+            .expect("timed out waiting for TaskError event")
+            .expect("stream ended without event");
+        match event {
+            Event::TaskError { error, .. } => {
+                assert!(error.contains("stream item failed"));
+            }
+            other => panic!("expected TaskError, got {other:?}"),
+        }
+
+        let no_terminal_success =
+            tokio::time::timeout(std::time::Duration::from_millis(100), handle.rx.next()).await;
+        assert!(
+            no_terminal_success.is_err(),
+            "Ok-then-Err stream should not emit TaskComplete after TaskError"
+        );
     }
 }

--- a/crates/autoagents-core/src/agent/direct.rs
+++ b/crates/autoagents-core/src/agent/direct.rs
@@ -1,5 +1,6 @@
 use crate::agent::base::AgentType;
 use crate::agent::error::{AgentBuildError, RunnableAgentError};
+use crate::agent::executor::event_helper::EventHelper;
 use crate::agent::task::Task;
 use crate::agent::{AgentBuilder, AgentDeriveT, AgentExecutor, AgentHooks, BaseAgent, HookOutcome};
 use crate::error::Error;
@@ -85,12 +86,24 @@ impl<T: AgentDeriveT + AgentExecutor + AgentHooks> BaseAgent<T, DirectAgent> {
         <T as AgentDeriveT>::Output: From<<T as AgentExecutor>::Output>,
         <T as AgentExecutor>::Error: Into<RunnableAgentError>,
     {
+        let submission_id = task.submission_id;
+        let tx_event = self.tx.clone();
         let context = self.create_context();
 
         //Run Hook
         let hook_outcome = self.inner.on_run_start(&task, &context).await;
         match hook_outcome {
-            HookOutcome::Abort => return Err(RunnableAgentError::Abort),
+            HookOutcome::Abort => {
+                #[cfg(not(target_arch = "wasm32"))]
+                EventHelper::send_task_error(
+                    &tx_event,
+                    submission_id,
+                    self.id,
+                    RunnableAgentError::Abort.to_string(),
+                )
+                .await;
+                return Err(RunnableAgentError::Abort);
+            }
             HookOutcome::Continue => {}
         }
 
@@ -128,12 +141,24 @@ impl<T: AgentDeriveT + AgentExecutor + AgentHooks> BaseAgent<T, DirectAgent> {
         <T as AgentDeriveT>::Output: From<<T as AgentExecutor>::Output>,
         <T as AgentExecutor>::Error: Into<RunnableAgentError>,
     {
+        let submission_id = task.submission_id;
+        let tx_event = self.tx.clone();
         let context = self.create_context();
 
         //Run Hook
         let hook_outcome = self.inner.on_run_start(&task, &context).await;
         match hook_outcome {
-            HookOutcome::Abort => return Err(RunnableAgentError::Abort),
+            HookOutcome::Abort => {
+                #[cfg(not(target_arch = "wasm32"))]
+                EventHelper::send_task_error(
+                    &tx_event,
+                    submission_id,
+                    self.id,
+                    RunnableAgentError::Abort.to_string(),
+                )
+                .await;
+                return Err(RunnableAgentError::Abort);
+            }
             HookOutcome::Continue => {}
         }
 
@@ -471,7 +496,7 @@ mod tests {
             executed: Arc::clone(&executed),
         };
         let llm = Arc::new(ConfigurableLLMProvider::default());
-        let handle = AgentBuilder::<_, DirectAgent>::new(agent)
+        let mut handle = AgentBuilder::<_, DirectAgent>::new(agent)
             .llm(llm)
             .build()
             .await
@@ -481,5 +506,16 @@ mod tests {
         let err = handle.agent.run(task).await.expect_err("expected abort");
         assert!(matches!(err, RunnableAgentError::Abort));
         assert!(!executed.load(Ordering::SeqCst));
+
+        let event = tokio::time::timeout(std::time::Duration::from_secs(1), handle.rx.next())
+            .await
+            .expect("timed out waiting for TaskError event")
+            .expect("stream ended without event");
+        match event {
+            Event::TaskError { error, .. } => {
+                assert!(error.contains("Abort"));
+            }
+            other => panic!("expected TaskError, got {other:?}"),
+        }
     }
 }

--- a/crates/autoagents-core/src/agent/executor/event_helper.rs
+++ b/crates/autoagents-core/src/agent/executor/event_helper.rs
@@ -3,6 +3,8 @@ use autoagents_protocol::StreamChunk;
 use autoagents_protocol::{ActorID, Event, SubmissionId};
 use serde_json::Value;
 
+use crate::agent::error::RunnableAgentError;
+
 #[cfg(not(target_arch = "wasm32"))]
 use tokio::sync::mpsc;
 
@@ -99,6 +101,38 @@ impl EventHelper {
             },
         )
         .await;
+    }
+
+    /// Emit `TaskError` for a hook abort and return `RunnableAgentError::Abort`.
+    pub async fn abort_run_from_hook(
+        tx: &Option<mpsc::Sender<Event>>,
+        sub_id: SubmissionId,
+        actor_id: ActorID,
+    ) -> RunnableAgentError {
+        #[cfg(not(target_arch = "wasm32"))]
+        Self::send_task_error(tx, sub_id, actor_id, RunnableAgentError::Abort.to_string()).await;
+        RunnableAgentError::Abort
+    }
+
+    /// Map an executor stream item to `RunnableAgentError`, emitting `TaskError` on failure.
+    pub async fn map_executor_stream_item<T, E>(
+        tx: &Option<mpsc::Sender<Event>>,
+        sub_id: SubmissionId,
+        actor_id: ActorID,
+        result: Result<T, E>,
+    ) -> Result<T, RunnableAgentError>
+    where
+        E: Into<RunnableAgentError>,
+    {
+        match result {
+            Ok(value) => Ok(value),
+            Err(error) => {
+                let err = error.into();
+                #[cfg(not(target_arch = "wasm32"))]
+                Self::send_task_error(tx, sub_id, actor_id, err.to_string()).await;
+                Err(err)
+            }
+        }
     }
 
     /// Send turn started event

--- a/crates/autoagents-core/src/environment.rs
+++ b/crates/autoagents-core/src/environment.rs
@@ -28,6 +28,9 @@ pub enum EnvironmentError {
 
     #[error("Run task join error: {0}")]
     JoinError(#[from] tokio::task::JoinError),
+
+    #[error("Finished run task result was not yet available")]
+    RunResultNotReady,
 }
 
 /// Configuration for the process environment that owns one or more runtimes.
@@ -152,15 +155,28 @@ impl Environment {
     /// Returns `Ok(Ok(()))` when no run task has been started. After the task
     /// completes, the stored handle is cleared so subsequent calls return
     /// immediately.
+    ///
+    /// If this future is dropped before completion (for example when a
+    /// `tokio::select!` branch wins elsewhere), the join handle is restored on
+    /// the environment so a later [`shutdown`](Self::shutdown) can still stop
+    /// runtimes and join the run task.
     pub async fn wait(&mut self) -> Result<Result<(), RuntimeError>, tokio::task::JoinError> {
-        match self.handle.take() {
-            Some(handle) => {
-                let result = handle.await;
-                self.launch_state = RuntimeLaunchState::Idle;
-                result
-            }
-            None => Ok(Ok(())),
-        }
+        let handle = match self.handle.take() {
+            Some(handle) => handle,
+            None => return Ok(Ok(())),
+        };
+
+        let mut guard = RestoreRunHandleOnDrop {
+            environment: self,
+            handle: Some(handle),
+        };
+
+        let join_result = guard.handle.as_mut().expect("handle was just set").await;
+
+        guard.handle = None;
+        guard.environment.launch_state = RuntimeLaunchState::Idle;
+
+        join_result
     }
 
     /// Start all registered runtimes and return immediately without waiting
@@ -273,11 +289,31 @@ impl Environment {
     fn join_finished_handle(
         handle: JoinHandle<Result<(), RuntimeError>>,
     ) -> Result<(), EnvironmentError> {
+        debug_assert!(
+            handle.is_finished(),
+            "join_finished_handle requires a finished run task"
+        );
+
         match handle.now_or_never() {
             Some(Ok(Ok(()))) => Ok(()),
             Some(Ok(Err(e))) => Err(EnvironmentError::RuntimeError(e)),
             Some(Err(e)) => Err(EnvironmentError::JoinError(e)),
-            None => Err(EnvironmentError::AlreadyRunning),
+            None => Err(EnvironmentError::RunResultNotReady),
+        }
+    }
+}
+
+/// Restores a managed run [`JoinHandle`] when a [`Environment::wait`] future is
+/// cancelled before the join completes.
+struct RestoreRunHandleOnDrop<'a> {
+    environment: &'a mut Environment,
+    handle: Option<JoinHandle<Result<(), RuntimeError>>>,
+}
+
+impl Drop for RestoreRunHandleOnDrop<'_> {
+    fn drop(&mut self) {
+        if let Some(handle) = self.handle.take() {
+            self.environment.handle = Some(handle);
         }
     }
 }
@@ -368,6 +404,12 @@ mod tests {
     fn test_environment_error_already_running_display() {
         let error = EnvironmentError::AlreadyRunning;
         assert!(error.to_string().contains("already running"));
+    }
+
+    #[test]
+    fn test_environment_error_run_result_not_ready_display() {
+        let error = EnvironmentError::RunResultNotReady;
+        assert!(error.to_string().contains("not yet available"));
     }
 
     #[test]
@@ -474,6 +516,38 @@ mod tests {
             result,
             Err(EnvironmentError::RuntimeNotFound(id)) if id == non_existent_id
         ));
+    }
+
+    #[tokio::test]
+    async fn test_environment_wait_restores_handle_when_cancelled() {
+        use tokio::time::{Duration, sleep};
+
+        let mut env = Environment::new(None);
+        let runtime = SingleThreadedRuntime::new(None);
+        env.register_runtime(runtime).await.unwrap();
+
+        env.run().expect("run should succeed");
+        assert!(env.is_running());
+
+        {
+            let wait_fut = env.wait();
+            tokio::pin!(wait_fut);
+
+            tokio::select! {
+                _ = &mut wait_fut => panic!("run task should not finish immediately"),
+                _ = sleep(Duration::from_millis(10)) => {}
+            }
+        }
+
+        assert!(
+            env.is_running(),
+            "cancelled wait should restore the join handle"
+        );
+
+        env.shutdown()
+            .await
+            .expect("shutdown should join the restored handle");
+        assert!(!env.is_running());
     }
 
     #[tokio::test]

--- a/crates/autoagents-core/src/environment.rs
+++ b/crates/autoagents-core/src/environment.rs
@@ -280,11 +280,20 @@ impl Environment {
         }
     }
 
-    /// Returns whether a background run task is currently in progress.
+    /// Returns whether the environment has an active runtime launch.
+    ///
+    /// For [`run`](Self::run) this checks the managed join handle. For
+    /// [`run_background`](Self::run_background) this returns `true` until
+    /// [`shutdown`](Self::shutdown) clears the launch state.
     pub fn is_running(&self) -> bool {
-        self.handle
-            .as_ref()
-            .is_some_and(|handle| !handle.is_finished())
+        match self.launch_state {
+            RuntimeLaunchState::Background => true,
+            RuntimeLaunchState::Managed => self
+                .handle
+                .as_ref()
+                .is_some_and(|handle| !handle.is_finished()),
+            RuntimeLaunchState::Idle => false,
+        }
     }
 
     #[allow(clippy::result_large_err)]
@@ -714,6 +723,10 @@ mod tests {
         env.run_background()
             .await
             .expect("run_background should succeed");
+        assert!(
+            env.is_running(),
+            "run_background should mark the environment as running until shutdown"
+        );
 
         env.shutdown().await.expect("shutdown should succeed");
     }

--- a/crates/autoagents-core/src/environment.rs
+++ b/crates/autoagents-core/src/environment.rs
@@ -26,23 +26,6 @@ pub enum EnvironmentError {
     EventError,
 }
 
-/// Returned when [`Environment::run`] is called while a run task is already active.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
-#[error("Environment is already running")]
-pub struct EnvironmentAlreadyRunning;
-
-impl From<EnvironmentAlreadyRunning> for EnvironmentError {
-    fn from(_: EnvironmentAlreadyRunning) -> Self {
-        Self::AlreadyRunning
-    }
-}
-
-impl From<EnvironmentAlreadyRunning> for Error {
-    fn from(err: EnvironmentAlreadyRunning) -> Self {
-        EnvironmentError::from(err).into()
-    }
-}
-
 /// Configuration for the process environment that owns one or more runtimes.
 #[derive(Clone)]
 pub struct EnvironmentConfig {
@@ -127,10 +110,11 @@ impl Environment {
     ///
     /// Use [`wait`](Self::wait) to await the background run task, or
     /// [`shutdown`](Self::shutdown) to stop runtimes and join the task.
-    pub fn run(&mut self) -> Result<(), EnvironmentAlreadyRunning> {
+    #[allow(clippy::result_large_err)] // Only `AlreadyRunning` is returned from this method.
+    pub fn run(&mut self) -> Result<(), EnvironmentError> {
         if let Some(handle) = &self.handle {
             if !handle.is_finished() {
-                return Err(EnvironmentAlreadyRunning);
+                return Err(EnvironmentError::AlreadyRunning);
             }
             self.handle = None;
         }
@@ -143,9 +127,11 @@ impl Environment {
 
     /// Await the background task started by [`run`](Self::run).
     ///
-    /// Returns `Ok(Ok(()))` when no run task has been started.
+    /// Returns `Ok(Ok(()))` when no run task has been started. After the task
+    /// completes, the stored handle is cleared so subsequent calls return
+    /// immediately.
     pub async fn wait(&mut self) -> Result<Result<(), RuntimeError>, tokio::task::JoinError> {
-        match self.handle.as_mut() {
+        match self.handle.take() {
             Some(handle) => handle.await,
             None => Ok(Ok(())),
         }
@@ -293,7 +279,7 @@ mod tests {
 
     #[test]
     fn test_environment_error_already_running_display() {
-        let error = EnvironmentAlreadyRunning;
+        let error = EnvironmentError::AlreadyRunning;
         assert!(error.to_string().contains("already running"));
     }
 
@@ -347,10 +333,7 @@ mod tests {
         assert!(!env.is_running());
         env.run().expect("run should succeed");
         assert!(env.is_running());
-        assert_eq!(
-            env.run().expect_err("second run should fail while active"),
-            EnvironmentAlreadyRunning
-        );
+        assert!(matches!(env.run(), Err(EnvironmentError::AlreadyRunning)));
 
         env.shutdown().await;
         assert!(!env.is_running());
@@ -395,5 +378,24 @@ mod tests {
             result,
             Err(EnvironmentError::RuntimeNotFound(id)) if id == non_existent_id
         ));
+    }
+
+    #[tokio::test]
+    async fn test_environment_wait_is_idempotent() {
+        use tokio::time::{Duration, timeout};
+
+        let mut env = Environment::new(None);
+        let runtime = SingleThreadedRuntime::new(None);
+        env.register_runtime(runtime).await.unwrap();
+
+        env.run().expect("run should succeed");
+        env.shutdown().await;
+
+        for _ in 0..2 {
+            let result = timeout(Duration::from_secs(1), env.wait())
+                .await
+                .expect("wait should not hang");
+            assert!(result.is_ok());
+        }
     }
 }

--- a/crates/autoagents-core/src/environment.rs
+++ b/crates/autoagents-core/src/environment.rs
@@ -3,6 +3,7 @@ use crate::runtime::manager::RuntimeManager;
 use crate::runtime::{Runtime, RuntimeError};
 use crate::utils::BoxEventStream;
 use autoagents_protocol::{Event, RuntimeID};
+use futures_util::FutureExt;
 use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::task::JoinHandle;
@@ -24,6 +25,9 @@ pub enum EnvironmentError {
 
     #[error("Error when consuming receiver")]
     EventError,
+
+    #[error("Run task join error: {0}")]
+    JoinError(#[from] tokio::task::JoinError),
 }
 
 /// Configuration for the process environment that owns one or more runtimes.
@@ -48,6 +52,15 @@ pub struct Environment {
     runtime_manager: Arc<RuntimeManager>,
     default_runtime: Option<RuntimeID>,
     handle: Option<JoinHandle<Result<(), RuntimeError>>>,
+    launch_state: RuntimeLaunchState,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+enum RuntimeLaunchState {
+    #[default]
+    Idle,
+    Managed,
+    Background,
 }
 
 impl Environment {
@@ -61,6 +74,7 @@ impl Environment {
             runtime_manager,
             default_runtime: None,
             handle: None,
+            launch_state: RuntimeLaunchState::Idle,
         }
     }
 
@@ -108,20 +122,28 @@ impl Environment {
     /// runtimes and await completion. Returns [`EnvironmentError::AlreadyRunning`]
     /// if a run task is already in progress.
     ///
+    /// If a previous managed run task finished without [`wait`](Self::wait) or
+    /// [`shutdown`](Self::shutdown), its result is joined and returned before
+    /// spawning a new run task.
+    ///
     /// Use [`wait`](Self::wait) to await the background run task, or
     /// [`shutdown`](Self::shutdown) to stop runtimes and join the task.
     #[allow(clippy::result_large_err)] // Only `AlreadyRunning` is returned from this method.
     pub fn run(&mut self) -> Result<(), EnvironmentError> {
-        if let Some(handle) = &self.handle {
-            if !handle.is_finished() {
-                return Err(EnvironmentError::AlreadyRunning);
-            }
-            self.handle = None;
+        self.reconcile_finished_managed_launch()?;
+
+        if self.launch_state == RuntimeLaunchState::Background {
+            return Err(EnvironmentError::AlreadyRunning);
+        }
+
+        if self.is_running() {
+            return Err(EnvironmentError::AlreadyRunning);
         }
 
         let manager = self.runtime_manager.clone();
         let handle = tokio::spawn(async move { manager.run().await });
         self.handle = Some(handle);
+        self.launch_state = RuntimeLaunchState::Managed;
         Ok(())
     }
 
@@ -132,17 +154,34 @@ impl Environment {
     /// immediately.
     pub async fn wait(&mut self) -> Result<Result<(), RuntimeError>, tokio::task::JoinError> {
         match self.handle.take() {
-            Some(handle) => handle.await,
+            Some(handle) => {
+                let result = handle.await;
+                self.launch_state = RuntimeLaunchState::Idle;
+                result
+            }
             None => Ok(Ok(())),
         }
     }
 
     /// Start all registered runtimes and return immediately without waiting
     /// for completion.
-    pub async fn run_background(&mut self) -> Result<(), RuntimeError> {
+    ///
+    /// Cannot be combined with [`run`](Self::run) on the same environment
+    /// instance without calling [`shutdown`](Self::shutdown) first.
+    pub async fn run_background(&mut self) -> Result<(), EnvironmentError> {
+        self.reconcile_finished_managed_launch()?;
+
+        if self.launch_state != RuntimeLaunchState::Idle || self.is_running() {
+            return Err(EnvironmentError::AlreadyRunning);
+        }
+
         let manager = self.runtime_manager.clone();
-        // Spawn background task to run the runtimes.
-        manager.run_background().await
+        manager
+            .run_background()
+            .await
+            .map_err(EnvironmentError::RuntimeError)?;
+        self.launch_state = RuntimeLaunchState::Background;
+        Ok(())
     }
 
     /// Take the event receiver for a specific runtime (or the default one) so
@@ -181,11 +220,25 @@ impl Environment {
     }
 
     /// Request shutdown on all runtimes and await the run handle if present.
-    pub async fn shutdown(&mut self) {
-        let _ = self.runtime_manager.stop().await;
+    pub async fn shutdown(&mut self) -> Result<(), EnvironmentError> {
+        let stop_result = self.runtime_manager.stop().await;
 
-        if let Some(handle) = self.handle.take() {
-            let _ = handle.await;
+        let join_result = if let Some(handle) = self.handle.take() {
+            Some(handle.await)
+        } else {
+            None
+        };
+
+        self.launch_state = RuntimeLaunchState::Idle;
+
+        if let Err(e) = stop_result {
+            return Err(EnvironmentError::RuntimeError(e));
+        }
+
+        match join_result {
+            None | Some(Ok(Ok(()))) => Ok(()),
+            Some(Ok(Err(e))) => Err(EnvironmentError::RuntimeError(e)),
+            Some(Err(e)) => Err(EnvironmentError::JoinError(e)),
         }
     }
 
@@ -194,6 +247,38 @@ impl Environment {
         self.handle
             .as_ref()
             .is_some_and(|handle| !handle.is_finished())
+    }
+
+    #[allow(clippy::result_large_err)]
+    fn reconcile_finished_managed_launch(&mut self) -> Result<(), EnvironmentError> {
+        if self.launch_state != RuntimeLaunchState::Managed {
+            return Ok(());
+        }
+
+        let Some(handle) = self.handle.take() else {
+            self.launch_state = RuntimeLaunchState::Idle;
+            return Ok(());
+        };
+
+        if !handle.is_finished() {
+            self.handle = Some(handle);
+            return Ok(());
+        }
+
+        self.launch_state = RuntimeLaunchState::Idle;
+        Self::join_finished_handle(handle)
+    }
+
+    #[allow(clippy::result_large_err)]
+    fn join_finished_handle(
+        handle: JoinHandle<Result<(), RuntimeError>>,
+    ) -> Result<(), EnvironmentError> {
+        match handle.now_or_never() {
+            Some(Ok(Ok(()))) => Ok(()),
+            Some(Ok(Err(e))) => Err(EnvironmentError::RuntimeError(e)),
+            Some(Err(e)) => Err(EnvironmentError::JoinError(e)),
+            None => Err(EnvironmentError::AlreadyRunning),
+        }
     }
 }
 
@@ -258,8 +343,9 @@ mod tests {
     #[tokio::test]
     async fn test_environment_shutdown() {
         let mut env = Environment::new(None);
-        env.shutdown().await;
-        // Should not panic
+        env.shutdown()
+            .await
+            .expect("shutdown should succeed when idle");
     }
 
     #[tokio::test]
@@ -271,11 +357,11 @@ mod tests {
         let non_existent_id = Uuid::new_v4();
 
         let result = env.get_runtime_or_default(Some(non_existent_id)).await;
-        assert!(result.is_err());
-
-        assert!(result.is_err());
-        // Just test that it's an error, not the specific variant
-        assert!(result.is_err());
+        assert!(matches!(
+            result,
+            Err(Error::EnvironmentError(EnvironmentError::RuntimeNotFound(id)))
+            if id == non_existent_id
+        ));
     }
 
     #[test]
@@ -336,7 +422,7 @@ mod tests {
         assert!(env.is_running());
         assert!(matches!(env.run(), Err(EnvironmentError::AlreadyRunning)));
 
-        env.shutdown().await;
+        env.shutdown().await.expect("shutdown should succeed");
         assert!(!env.is_running());
     }
 
@@ -347,9 +433,18 @@ mod tests {
         env.register_runtime(runtime).await.unwrap();
 
         env.run().expect("initial run should succeed");
-        env.shutdown().await;
+        env.shutdown().await.expect("shutdown should succeed");
+
+        // Environment allows spawning a new run task after shutdown. The same
+        // SingleThreadedRuntime instance cannot re-enter its event loop, so the
+        // second run task fails when joined.
         env.run().expect("run after shutdown should succeed");
-        env.shutdown().await;
+        let run_result = env.wait().await.expect("wait should join run task");
+        assert!(run_result.is_err());
+
+        env.shutdown()
+            .await
+            .expect("shutdown should succeed when idle after failed run");
     }
 
     #[tokio::test]
@@ -390,7 +485,7 @@ mod tests {
         env.register_runtime(runtime).await.unwrap();
 
         env.run().expect("run should succeed");
-        env.shutdown().await;
+        env.shutdown().await.expect("shutdown should succeed");
 
         for _ in 0..2 {
             let result = timeout(Duration::from_secs(1), env.wait())
@@ -500,7 +595,7 @@ mod tests {
         assert!(!env.is_running());
 
         env.run().expect("run after finished handle should succeed");
-        env.shutdown().await;
+        env.shutdown().await.expect("shutdown should succeed");
     }
 
     #[tokio::test]
@@ -517,6 +612,42 @@ mod tests {
         env.run_background()
             .await
             .expect("run_background should succeed");
+
+        env.shutdown().await.expect("shutdown should succeed");
+    }
+
+    #[tokio::test]
+    async fn test_environment_run_background_rejects_after_run() {
+        let mut env = Environment::new(None);
+        let runtime = SingleThreadedRuntime::new(None);
+        env.register_runtime(runtime).await.unwrap();
+
+        env.run().expect("run should succeed");
+        assert!(matches!(
+            env.run_background().await,
+            Err(EnvironmentError::AlreadyRunning)
+        ));
+
+        env.shutdown().await.expect("shutdown should succeed");
+    }
+
+    #[tokio::test]
+    async fn test_environment_run_rejects_after_run_background() {
+        let mut env = Environment::new(None);
+        let (tx, _rx) = mpsc::channel(1);
+        let runtime = Arc::new(ImmediateRuntime {
+            id: RuntimeID::new_v4(),
+            behavior: ImmediateRuntimeBehavior::Success,
+            tx,
+        }) as Arc<dyn Runtime>;
+        env.register_runtime(runtime).await.unwrap();
+
+        env.run_background()
+            .await
+            .expect("run_background should succeed");
+        assert!(matches!(env.run(), Err(EnvironmentError::AlreadyRunning)));
+
+        env.shutdown().await.expect("shutdown should succeed");
     }
 
     #[tokio::test]
@@ -533,6 +664,53 @@ mod tests {
         env.run().expect("run should succeed");
         let wait_result = env.wait().await.expect("wait join should succeed");
         assert!(wait_result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_environment_run_surfaces_prior_failure_without_wait() {
+        use tokio::time::{Duration, sleep};
+
+        let mut env = Environment::new(None);
+        let (tx, _rx) = mpsc::channel(1);
+        let runtime = Arc::new(ImmediateRuntime {
+            id: RuntimeID::new_v4(),
+            behavior: ImmediateRuntimeBehavior::Error,
+            tx,
+        }) as Arc<dyn Runtime>;
+        env.register_runtime(runtime).await.unwrap();
+
+        env.run().expect("initial run should succeed");
+        sleep(Duration::from_millis(20)).await;
+        assert!(!env.is_running());
+
+        let err = env
+            .run()
+            .expect_err("restart should surface prior run failure");
+        assert!(matches!(err, EnvironmentError::RuntimeError(_)));
+    }
+
+    #[tokio::test]
+    async fn test_environment_run_background_surfaces_prior_failure_without_wait() {
+        use tokio::time::{Duration, sleep};
+
+        let mut env = Environment::new(None);
+        let (tx, _rx) = mpsc::channel(1);
+        let runtime = Arc::new(ImmediateRuntime {
+            id: RuntimeID::new_v4(),
+            behavior: ImmediateRuntimeBehavior::Error,
+            tx,
+        }) as Arc<dyn Runtime>;
+        env.register_runtime(runtime).await.unwrap();
+
+        env.run().expect("initial run should succeed");
+        sleep(Duration::from_millis(20)).await;
+        assert!(!env.is_running());
+
+        let err = env
+            .run_background()
+            .await
+            .expect_err("run_background should surface prior run failure");
+        assert!(matches!(err, EnvironmentError::RuntimeError(_)));
     }
 
     #[test]

--- a/crates/autoagents-core/src/environment.rs
+++ b/crates/autoagents-core/src/environment.rs
@@ -13,11 +13,34 @@ pub enum EnvironmentError {
     #[error("Runtime not found: {0}")]
     RuntimeNotFound(RuntimeID),
 
+    #[error("No default runtime registered")]
+    NoDefaultRuntime,
+
+    #[error("Environment is already running")]
+    AlreadyRunning,
+
     #[error("Runtime error: {0}")]
     RuntimeError(#[from] RuntimeError),
 
     #[error("Error when consuming receiver")]
     EventError,
+}
+
+/// Returned when [`Environment::run`] is called while a run task is already active.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+#[error("Environment is already running")]
+pub struct EnvironmentAlreadyRunning;
+
+impl From<EnvironmentAlreadyRunning> for EnvironmentError {
+    fn from(_: EnvironmentAlreadyRunning) -> Self {
+        Self::AlreadyRunning
+    }
+}
+
+impl From<EnvironmentAlreadyRunning> for Error {
+    fn from(err: EnvironmentAlreadyRunning) -> Self {
+        EnvironmentError::from(err).into()
+    }
 }
 
 /// Configuration for the process environment that owns one or more runtimes.
@@ -85,18 +108,47 @@ impl Environment {
         &self,
         runtime_id: Option<RuntimeID>,
     ) -> Result<Arc<dyn Runtime>, Error> {
-        let rid = runtime_id.unwrap_or_else(|| self.default_runtime.unwrap());
+        let rid = match runtime_id {
+            Some(id) => id,
+            None => self
+                .default_runtime
+                .ok_or(EnvironmentError::NoDefaultRuntime)?,
+        };
         self.get_runtime(&rid)
             .await
             .ok_or_else(|| EnvironmentError::RuntimeNotFound(rid).into())
     }
 
-    /// Start all registered runtimes and return a handle that resolves when
-    /// they finish. This will typically run until shutdown is requested.
-    pub fn run(&mut self) -> JoinHandle<Result<(), RuntimeError>> {
+    /// Start all registered runtimes in the background.
+    ///
+    /// Stores the spawned task handle so [`shutdown`](Self::shutdown) can stop
+    /// runtimes and await completion. Returns [`EnvironmentError::AlreadyRunning`]
+    /// if a run task is already in progress.
+    ///
+    /// Use [`wait`](Self::wait) to await the background run task, or
+    /// [`shutdown`](Self::shutdown) to stop runtimes and join the task.
+    pub fn run(&mut self) -> Result<(), EnvironmentAlreadyRunning> {
+        if let Some(handle) = &self.handle {
+            if !handle.is_finished() {
+                return Err(EnvironmentAlreadyRunning);
+            }
+            self.handle = None;
+        }
+
         let manager = self.runtime_manager.clone();
-        // Spawn background task to run the runtimes. This will wait indefinitely
-        tokio::spawn(async move { manager.run().await })
+        let handle = tokio::spawn(async move { manager.run().await });
+        self.handle = Some(handle);
+        Ok(())
+    }
+
+    /// Await the background task started by [`run`](Self::run).
+    ///
+    /// Returns `Ok(Ok(()))` when no run task has been started.
+    pub async fn wait(&mut self) -> Result<Result<(), RuntimeError>, tokio::task::JoinError> {
+        match self.handle.as_mut() {
+            Some(handle) => handle.await,
+            None => Ok(Ok(())),
+        }
     }
 
     /// Start all registered runtimes and return immediately without waiting
@@ -113,14 +165,18 @@ impl Environment {
         &mut self,
         runtime_id: Option<RuntimeID>,
     ) -> Result<BoxEventStream<Event>, EnvironmentError> {
-        if let Ok(runtime) = self.get_runtime_or_default(runtime_id).await {
-            runtime
-                .take_event_receiver()
-                .await
-                .ok_or_else(|| EnvironmentError::EventError)
-        } else {
-            Err(EnvironmentError::RuntimeNotFound(runtime_id.unwrap()))
-        }
+        let runtime = self
+            .get_runtime_or_default(runtime_id)
+            .await
+            .map_err(|err| match err {
+                Error::EnvironmentError(env_err) => env_err,
+                _ => EnvironmentError::EventError,
+            })?;
+
+        runtime
+            .take_event_receiver()
+            .await
+            .ok_or(EnvironmentError::EventError)
     }
 
     /// Subscribe to runtime events without consuming the receiver.
@@ -145,6 +201,13 @@ impl Environment {
         if let Some(handle) = self.handle.take() {
             let _ = handle.await;
         }
+    }
+
+    /// Returns whether a background run task is currently in progress.
+    pub fn is_running(&self) -> bool {
+        self.handle
+            .as_ref()
+            .is_some_and(|handle| !handle.is_finished())
     }
 }
 
@@ -229,10 +292,108 @@ mod tests {
     }
 
     #[test]
+    fn test_environment_error_already_running_display() {
+        let error = EnvironmentAlreadyRunning;
+        assert!(error.to_string().contains("already running"));
+    }
+
+    #[test]
     fn test_environment_error_display() {
         let runtime_id = Uuid::new_v4();
         let error = EnvironmentError::RuntimeNotFound(runtime_id);
         assert!(error.to_string().contains("Runtime not found"));
         assert!(error.to_string().contains(&runtime_id.to_string()));
+    }
+
+    #[test]
+    fn test_environment_error_no_default_display() {
+        let error = EnvironmentError::NoDefaultRuntime;
+        assert!(error.to_string().contains("No default runtime registered"));
+    }
+
+    #[tokio::test]
+    async fn test_get_runtime_or_default_no_default_runtime() {
+        let env = Environment::new(None);
+
+        let result = env.get_runtime_or_default(None).await;
+        assert!(matches!(
+            result,
+            Err(Error::EnvironmentError(EnvironmentError::NoDefaultRuntime))
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_take_event_receiver_no_default_runtime() {
+        let mut env = Environment::new(None);
+
+        let result = env.take_event_receiver(None).await;
+        assert!(matches!(result, Err(EnvironmentError::NoDefaultRuntime)));
+    }
+
+    #[tokio::test]
+    async fn test_subscribe_events_no_default_runtime() {
+        let env = Environment::new(None);
+
+        let result = env.subscribe_events(None).await;
+        assert!(matches!(result, Err(EnvironmentError::NoDefaultRuntime)));
+    }
+
+    #[tokio::test]
+    async fn test_environment_run_stores_handle() {
+        let mut env = Environment::new(None);
+        let runtime = SingleThreadedRuntime::new(None);
+        env.register_runtime(runtime).await.unwrap();
+
+        assert!(!env.is_running());
+        env.run().expect("run should succeed");
+        assert!(env.is_running());
+        assert_eq!(
+            env.run().expect_err("second run should fail while active"),
+            EnvironmentAlreadyRunning
+        );
+
+        env.shutdown().await;
+        assert!(!env.is_running());
+    }
+
+    #[tokio::test]
+    async fn test_environment_run_can_restart_after_shutdown() {
+        let mut env = Environment::new(None);
+        let runtime = SingleThreadedRuntime::new(None);
+        env.register_runtime(runtime).await.unwrap();
+
+        env.run().expect("initial run should succeed");
+        env.shutdown().await;
+        env.run().expect("run after shutdown should succeed");
+        env.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn test_get_runtime_or_default_runtime_not_found_variant() {
+        let mut env = Environment::new(None);
+        let runtime = SingleThreadedRuntime::new(None);
+        env.register_runtime(runtime).await.unwrap();
+        let non_existent_id = Uuid::new_v4();
+
+        let result = env.get_runtime_or_default(Some(non_existent_id)).await;
+        assert!(matches!(
+            result,
+            Err(Error::EnvironmentError(EnvironmentError::RuntimeNotFound(id)))
+            if id == non_existent_id
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_take_event_receiver_runtime_not_found() {
+        let mut env = Environment::new(None);
+        let runtime = SingleThreadedRuntime::new(None);
+        env.register_runtime(runtime).await.unwrap();
+        let non_existent_id = Uuid::new_v4();
+
+        let result = env.take_event_receiver(Some(non_existent_id)).await;
+        assert!(matches!(
+            result,
+            Err(EnvironmentError::RuntimeNotFound(id)) if id == non_existent_id
+        ));
     }
 }

--- a/crates/autoagents-core/src/environment.rs
+++ b/crates/autoagents-core/src/environment.rs
@@ -202,6 +202,7 @@ mod tests {
     use super::*;
     use crate::runtime::SingleThreadedRuntime;
     use tempfile::tempdir;
+    use tokio::sync::mpsc;
     use uuid::Uuid;
 
     #[test]
@@ -397,5 +398,174 @@ mod tests {
                 .expect("wait should not hang");
             assert!(result.is_ok());
         }
+    }
+
+    #[derive(Clone, Copy)]
+    enum ImmediateRuntimeBehavior {
+        Success,
+        Error,
+    }
+
+    struct ImmediateRuntime {
+        id: RuntimeID,
+        behavior: ImmediateRuntimeBehavior,
+        tx: mpsc::Sender<Event>,
+    }
+
+    #[async_trait::async_trait]
+    impl Runtime for ImmediateRuntime {
+        fn id(&self) -> RuntimeID {
+            self.id
+        }
+
+        async fn subscribe_any(
+            &self,
+            _topic_name: &str,
+            _topic_type: std::any::TypeId,
+            _actor: Arc<dyn crate::actor::AnyActor>,
+        ) -> Result<(), RuntimeError> {
+            Ok(())
+        }
+
+        async fn publish_any(
+            &self,
+            _topic_name: &str,
+            _topic_type: std::any::TypeId,
+            _message: Arc<dyn std::any::Any + Send + Sync>,
+        ) -> Result<(), RuntimeError> {
+            Ok(())
+        }
+
+        fn tx(&self) -> mpsc::Sender<Event> {
+            self.tx.clone()
+        }
+
+        async fn transport(&self) -> Arc<dyn crate::actor::Transport> {
+            Arc::new(crate::actor::LocalTransport)
+        }
+
+        async fn take_event_receiver(&self) -> Option<BoxEventStream<Event>> {
+            None
+        }
+
+        async fn subscribe_events(&self) -> BoxEventStream<Event> {
+            Box::pin(futures::stream::empty())
+        }
+
+        async fn run(&self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+            match self.behavior {
+                ImmediateRuntimeBehavior::Success => Ok(()),
+                ImmediateRuntimeBehavior::Error => {
+                    Err(std::io::Error::other("immediate runtime run failed").into())
+                }
+            }
+        }
+
+        async fn stop(&self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn test_environment_wait_awaits_completed_run_task() {
+        let mut env = Environment::new(None);
+        let (tx, _rx) = mpsc::channel(1);
+        let runtime = Arc::new(ImmediateRuntime {
+            id: RuntimeID::new_v4(),
+            behavior: ImmediateRuntimeBehavior::Success,
+            tx,
+        }) as Arc<dyn Runtime>;
+        env.register_runtime(runtime).await.unwrap();
+
+        env.run().expect("run should succeed");
+        let wait_result = env.wait().await.expect("wait join should succeed");
+        assert!(wait_result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_environment_run_restarts_after_finished_handle() {
+        use tokio::time::{Duration, sleep};
+
+        let mut env = Environment::new(None);
+        let (tx, _rx) = mpsc::channel(1);
+        let runtime = Arc::new(ImmediateRuntime {
+            id: RuntimeID::new_v4(),
+            behavior: ImmediateRuntimeBehavior::Success,
+            tx,
+        }) as Arc<dyn Runtime>;
+        env.register_runtime(runtime).await.unwrap();
+
+        env.run().expect("initial run should succeed");
+        sleep(Duration::from_millis(20)).await;
+        assert!(!env.is_running());
+
+        env.run().expect("run after finished handle should succeed");
+        env.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn test_environment_run_background_starts_runtimes() {
+        let mut env = Environment::new(None);
+        let (tx, _rx) = mpsc::channel(1);
+        let runtime = Arc::new(ImmediateRuntime {
+            id: RuntimeID::new_v4(),
+            behavior: ImmediateRuntimeBehavior::Success,
+            tx,
+        }) as Arc<dyn Runtime>;
+        env.register_runtime(runtime).await.unwrap();
+
+        env.run_background()
+            .await
+            .expect("run_background should succeed");
+    }
+
+    #[tokio::test]
+    async fn test_environment_wait_propagates_run_failure() {
+        let mut env = Environment::new(None);
+        let (tx, _rx) = mpsc::channel(1);
+        let runtime = Arc::new(ImmediateRuntime {
+            id: RuntimeID::new_v4(),
+            behavior: ImmediateRuntimeBehavior::Error,
+            tx,
+        }) as Arc<dyn Runtime>;
+        env.register_runtime(runtime).await.unwrap();
+
+        env.run().expect("run should succeed");
+        let wait_result = env.wait().await.expect("wait join should succeed");
+        assert!(wait_result.is_err());
+    }
+
+    #[test]
+    fn test_environment_config_accessor() {
+        let dir = tempdir().expect("Unable to create temp dir");
+        let config = EnvironmentConfig {
+            working_dir: dir.path().to_path_buf(),
+        };
+        let env = Environment::new(Some(config.clone()));
+        assert_eq!(env.config().working_dir, config.working_dir);
+    }
+
+    #[tokio::test]
+    async fn test_subscribe_events_with_default_runtime() {
+        let mut env = Environment::new(None);
+        let runtime = SingleThreadedRuntime::new(None);
+        env.register_runtime(runtime).await.unwrap();
+
+        let stream = env.subscribe_events(None).await;
+        assert!(stream.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_get_runtime_or_default_uses_default_runtime() {
+        let mut env = Environment::new(None);
+        let runtime = SingleThreadedRuntime::new(None);
+        let runtime_id = runtime.id;
+        env.register_runtime(runtime).await.unwrap();
+
+        let resolved = env
+            .get_runtime_or_default(None)
+            .await
+            .expect("default runtime should resolve");
+        assert_eq!(resolved.id(), runtime_id);
     }
 }

--- a/crates/autoagents-core/src/environment.rs
+++ b/crates/autoagents-core/src/environment.rs
@@ -50,6 +50,25 @@ impl Default for EnvironmentConfig {
 /// High-level container that owns one or more runtimes, exposes a unified
 /// event receiver, and provides lifecycle helpers for running and shutting down
 /// the underlying actor system.
+///
+/// ## Run lifecycle state machine
+///
+/// An internal [`RuntimeLaunchState`] records how runtimes were last started:
+///
+/// - **`Idle`** — no active launch mode; safe to call `run()` or `run_background()`.
+/// - **`Managed`** — [`run`](Self::run) spawned a join handle tracked by this environment.
+///   Await it with [`wait`](Self::wait) or stop with [`shutdown`](Self::shutdown).
+/// - **`Background`** — [`run_background`](Self::run_background) started runtimes without storing
+///   a handle on the environment. Call [`shutdown`](Self::shutdown) before `run()`.
+///
+/// `run()` and `run_background()` both call [`reconcile_finished_managed_launch`](Self::reconcile_finished_managed_launch)
+/// first. When a managed run task finished without `wait()` or `shutdown()`, that helper joins the
+/// stale handle and surfaces any runtime or join error before a new launch proceeds.
+///
+/// [`wait`](Self::wait) temporarily takes the managed join handle. If the future is dropped early
+/// (for example when another branch wins in `tokio::select!`), [`RestoreRunHandleOnDrop`] puts the
+/// handle back so a later `shutdown()` can still stop runtimes and join the task. A successful
+/// `wait()` clears the handle and returns the launch state to `Idle`.
 pub struct Environment {
     config: EnvironmentConfig,
     runtime_manager: Arc<RuntimeManager>,
@@ -60,9 +79,12 @@ pub struct Environment {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 enum RuntimeLaunchState {
+    /// No launch in progress; `run()` and `run_background()` are allowed.
     #[default]
     Idle,
+    /// [`Environment::run`] spawned a managed join handle stored on the environment.
     Managed,
+    /// [`Environment::run_background`] started runtimes without a stored join handle.
     Background,
 }
 
@@ -266,6 +288,12 @@ impl Environment {
     }
 
     #[allow(clippy::result_large_err)]
+    /// Join a managed run task that finished without `wait()` or `shutdown()`.
+    ///
+    /// No-op unless `launch_state` is [`RuntimeLaunchState::Managed`]. When the stored handle is
+    /// still running, the handle is restored and this returns `Ok(())`. When the handle finished,
+    /// it is joined via [`join_finished_handle`](Self::join_finished_handle) and `launch_state`
+    /// becomes `Idle`.
     fn reconcile_finished_managed_launch(&mut self) -> Result<(), EnvironmentError> {
         if self.launch_state != RuntimeLaunchState::Managed {
             return Ok(());

--- a/crates/autoagents-core/src/runtime/single_threaded.rs
+++ b/crates/autoagents-core/src/runtime/single_threaded.rs
@@ -317,13 +317,19 @@ impl Runtime for SingleThreadedRuntime {
     }
 
     async fn stop(&self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        if self.shutdown_flag.load(Ordering::SeqCst) {
+            return Ok(());
+        }
+
         info!("Initiating runtime shutdown for {}", self.id);
 
         // Send shutdown signal
-        self.internal_tx
-            .send(InternalEvent::Shutdown)
-            .await
-            .map_err(|e| format!("Failed to send shutdown signal: {e}"))?;
+        if let Err(e) = self.internal_tx.send(InternalEvent::Shutdown).await {
+            if self.shutdown_flag.load(Ordering::SeqCst) {
+                return Ok(());
+            }
+            return Err(format!("Failed to send shutdown signal: {e}").into());
+        }
 
         // Wait a brief moment for shutdown to complete
         tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;

--- a/crates/autoagents-core/src/tests/agent_integration_tests.rs
+++ b/crates/autoagents-core/src/tests/agent_integration_tests.rs
@@ -64,7 +64,8 @@ mod tests {
 
         // Start environment in background
         let env_handle = tokio::spawn(async move {
-            let _ = environment.run().await;
+            environment.run().expect("Failed to start environment");
+            let _ = environment.wait().await;
         });
 
         // Publish task
@@ -108,18 +109,61 @@ mod tests {
         let memory = Box::new(SlidingWindowMemory::new(10));
 
         let agent = MockAgentImpl::new("streaming_agent", "A streaming agent");
-        let result = AgentBuilder::new(agent)
+        let _agent_handle = AgentBuilder::new(agent)
             .llm(llm)
             .runtime(runtime.clone())
             .subscribe(topic.clone())
             .memory(memory)
             .stream(true)
             .build()
-            .await;
+            .await
+            .expect("Failed to build streaming agent");
+
+        let mut environment = Environment::new(None);
+        environment
+            .register_runtime(runtime.clone())
+            .await
+            .expect("Failed to register runtime");
+
+        let receiver = environment
+            .take_event_receiver(None)
+            .await
+            .expect("Failed to get event receiver");
+        let mut event_stream = receiver;
+
+        let env_handle = tokio::spawn(async move {
+            environment.run().expect("Failed to start environment");
+            let _ = environment.wait().await;
+        });
+
+        let task = Task::new("Streaming task execution");
+        runtime
+            .publish(&topic, task)
+            .await
+            .expect("Failed to publish task");
+
+        let result = timeout(Duration::from_secs(3), async {
+            while let Some(event) = event_stream.next().await {
+                match event {
+                    Event::TaskComplete { result: value, .. } => {
+                        let output: Result<TestAgentOutput, _> = serde_json::from_str(&value);
+                        if let Ok(agent_output) = output {
+                            return Some(agent_output);
+                        }
+                    }
+                    _ => continue,
+                }
+            }
+            None
+        })
+        .await;
+
+        env_handle.abort();
 
         assert!(result.is_ok());
-        let agent_handle = result.unwrap();
-        assert!(agent_handle.agent.stream());
+        if let Ok(Some(agent_output)) = result {
+            assert!(agent_output.result.contains("Streaming task execution"));
+        }
     }
 
     #[tokio::test]
@@ -152,7 +196,8 @@ mod tests {
 
         // Start environment in background
         let env_handle = tokio::spawn(async move {
-            let _ = environment.run().await;
+            environment.run().expect("Failed to start environment");
+            let _ = environment.wait().await;
         });
 
         // Publish task

--- a/crates/autoagents-core/src/tests/agent_integration_tests.rs
+++ b/crates/autoagents-core/src/tests/agent_integration_tests.rs
@@ -241,6 +241,66 @@ mod tests {
         let error_message = wait_for_task_error(&mut event_stream).await;
         assert!(error_message.contains("Mock execution failed"));
 
+        runtime
+            .publish(&topic, Task::new("Second failing task"))
+            .await
+            .expect("Failed to publish second task");
+
+        let second_error = wait_for_task_error(&mut event_stream).await;
+        assert!(second_error.contains("Mock execution failed"));
+
+        environment
+            .shutdown()
+            .await
+            .expect("shutdown should succeed");
+    }
+
+    #[tokio::test]
+    async fn test_streaming_pub_sub_actor_survives_stream_task_failure() {
+        let llm = Arc::new(MockLLMProvider);
+        let runtime = SingleThreadedRuntime::new(None);
+        let topic = Topic::<Task>::new("streaming_failure_test");
+
+        let agent = MockAgentImpl::new("failing_stream_agent", "Streaming agent that fails")
+            .with_failure(true);
+        let _agent_handle = AgentBuilder::new(agent)
+            .llm(llm)
+            .runtime(runtime.clone())
+            .subscribe(topic.clone())
+            .stream(true)
+            .build()
+            .await
+            .expect("Failed to build streaming agent");
+
+        let mut environment = Environment::new(None);
+        environment
+            .register_runtime(runtime.clone())
+            .await
+            .expect("Failed to register runtime");
+
+        let mut event_stream = environment
+            .take_event_receiver(None)
+            .await
+            .expect("Failed to get event receiver");
+
+        environment.run().expect("Failed to start environment");
+
+        runtime
+            .publish(&topic, Task::new("First streaming failure"))
+            .await
+            .expect("Failed to publish first task");
+
+        let first_error = wait_for_task_error(&mut event_stream).await;
+        assert!(first_error.contains("Mock execution failed"));
+
+        runtime
+            .publish(&topic, Task::new("Second streaming failure"))
+            .await
+            .expect("Failed to publish second task");
+
+        let second_error = wait_for_task_error(&mut event_stream).await;
+        assert!(second_error.contains("Mock execution failed"));
+
         environment
             .shutdown()
             .await

--- a/crates/autoagents-core/src/tests/agent_integration_tests.rs
+++ b/crates/autoagents-core/src/tests/agent_integration_tests.rs
@@ -4,11 +4,40 @@ mod tests {
     use crate::agent::{AgentBuilder, memory::SlidingWindowMemory, task::Task};
     use crate::environment::Environment;
     use crate::runtime::{SingleThreadedRuntime, TypedRuntime};
-    use crate::tests::{MockAgentImpl, MockLLMProvider, TestAgentOutput};
+    use crate::tests::{DivergentStreamingAgent, MockAgentImpl, MockLLMProvider, TestAgentOutput};
     use autoagents_protocol::Event;
     use std::sync::Arc;
     use tokio::time::{Duration, timeout};
     use tokio_stream::StreamExt;
+
+    async fn wait_for_task_complete(
+        event_stream: &mut crate::utils::BoxEventStream<Event>,
+    ) -> TestAgentOutput {
+        timeout(Duration::from_secs(3), async {
+            while let Some(event) = event_stream.next().await {
+                if let Event::TaskComplete { result: value, .. } = event {
+                    return serde_json::from_str::<TestAgentOutput>(&value)
+                        .expect("TaskComplete result should deserialize");
+                }
+            }
+            panic!("event stream ended without TaskComplete");
+        })
+        .await
+        .expect("timed out waiting for TaskComplete")
+    }
+
+    async fn wait_for_task_error(event_stream: &mut crate::utils::BoxEventStream<Event>) -> String {
+        timeout(Duration::from_secs(3), async {
+            while let Some(event) = event_stream.next().await {
+                if let Event::TaskError { error, .. } = event {
+                    return error;
+                }
+            }
+            panic!("event stream ended without TaskError");
+        })
+        .await
+        .expect("timed out waiting for TaskError")
+    }
 
     #[tokio::test]
     async fn test_agent_creation_and_subscription() {
@@ -49,56 +78,31 @@ mod tests {
             .await
             .expect("Failed to build agent");
 
-        // Set up environment
         let mut environment = Environment::new(None);
         environment
             .register_runtime(runtime.clone())
             .await
             .expect("Failed to register runtime");
 
-        let receiver = environment
+        let mut event_stream = environment
             .take_event_receiver(None)
             .await
             .expect("Failed to get event receiver");
-        let mut event_stream = receiver;
 
-        // Start environment in background
-        let env_handle = tokio::spawn(async move {
-            environment.run().expect("Failed to start environment");
-            let _ = environment.wait().await;
-        });
+        environment.run().expect("Failed to start environment");
 
-        // Publish task
-        let task = Task::new("Test task execution");
         runtime
-            .publish(&topic, task)
+            .publish(&topic, Task::new("Test task execution"))
             .await
             .expect("Failed to publish task");
 
-        // Wait for task completion with timeout
-        let result = timeout(Duration::from_secs(3), async {
-            while let Some(event) = event_stream.next().await {
-                match event {
-                    Event::TaskComplete { result: value, .. } => {
-                        let output: Result<TestAgentOutput, _> = serde_json::from_str(&value);
-                        if let Ok(agent_output) = output {
-                            return Some(agent_output);
-                        }
-                    }
-                    _ => continue,
-                }
-            }
-            None
-        })
-        .await;
+        let agent_output = wait_for_task_complete(&mut event_stream).await;
+        assert!(agent_output.result.contains("Test task execution"));
 
-        // Clean up
-        env_handle.abort();
-
-        assert!(result.is_ok());
-        if let Ok(Some(agent_output)) = result {
-            assert!(agent_output.result.contains("Test task execution"));
-        }
+        environment
+            .shutdown()
+            .await
+            .expect("shutdown should succeed");
     }
 
     #[tokio::test]
@@ -125,45 +129,80 @@ mod tests {
             .await
             .expect("Failed to register runtime");
 
-        let receiver = environment
+        let mut event_stream = environment
             .take_event_receiver(None)
             .await
             .expect("Failed to get event receiver");
-        let mut event_stream = receiver;
 
-        let env_handle = tokio::spawn(async move {
-            environment.run().expect("Failed to start environment");
-            let _ = environment.wait().await;
-        });
+        environment.run().expect("Failed to start environment");
 
-        let task = Task::new("Streaming task execution");
         runtime
-            .publish(&topic, task)
+            .publish(&topic, Task::new("Streaming task execution"))
+            .await
+            .expect("Failed to publish task");
+
+        let agent_output = wait_for_task_complete(&mut event_stream).await;
+        assert!(agent_output.result.contains("Streaming task execution"));
+
+        environment
+            .shutdown()
+            .await
+            .expect("shutdown should succeed");
+    }
+
+    #[tokio::test]
+    async fn test_streaming_actor_emits_executor_task_complete_through_runtime() {
+        let llm = Arc::new(MockLLMProvider);
+        let runtime = SingleThreadedRuntime::new(None);
+        let topic = Topic::<Task>::new("streaming_executor_payload");
+
+        let _agent_handle = AgentBuilder::new(DivergentStreamingAgent)
+            .llm(llm)
+            .runtime(runtime.clone())
+            .subscribe(topic.clone())
+            .stream(true)
+            .build()
+            .await
+            .expect("Failed to build streaming agent");
+
+        let mut environment = Environment::new(None);
+        environment
+            .register_runtime(runtime.clone())
+            .await
+            .expect("Failed to register runtime");
+
+        let mut event_stream = environment
+            .take_event_receiver(None)
+            .await
+            .expect("Failed to get event receiver");
+
+        environment.run().expect("Failed to start environment");
+
+        runtime
+            .publish(&topic, Task::new("runtime payload"))
             .await
             .expect("Failed to publish task");
 
         let result = timeout(Duration::from_secs(3), async {
             while let Some(event) = event_stream.next().await {
-                match event {
-                    Event::TaskComplete { result: value, .. } => {
-                        let output: Result<TestAgentOutput, _> = serde_json::from_str(&value);
-                        if let Ok(agent_output) = output {
-                            return Some(agent_output);
-                        }
-                    }
-                    _ => continue,
+                if let Event::TaskComplete { result, .. } = event {
+                    let parsed: serde_json::Value =
+                        serde_json::from_str(&result).expect("TaskComplete should be JSON");
+                    return parsed;
                 }
             }
-            None
+            panic!("event stream ended without TaskComplete");
         })
-        .await;
+        .await
+        .expect("timed out waiting for TaskComplete");
 
-        env_handle.abort();
+        assert_eq!(result["executor_only"], 42);
+        assert_eq!(result["response"], "runtime payload");
 
-        assert!(result.is_ok());
-        if let Ok(Some(agent_output)) = result {
-            assert!(agent_output.result.contains("Streaming task execution"));
-        }
+        environment
+            .shutdown()
+            .await
+            .expect("shutdown should succeed");
     }
 
     #[tokio::test]
@@ -181,53 +220,31 @@ mod tests {
             .await
             .expect("Failed to build agent");
 
-        // Set up environment
         let mut environment = Environment::new(None);
         environment
             .register_runtime(runtime.clone())
             .await
             .expect("Failed to register runtime");
 
-        let receiver = environment
+        let mut event_stream = environment
             .take_event_receiver(None)
             .await
             .expect("Failed to get event receiver");
-        let mut event_stream = receiver;
 
-        // Start environment in background
-        let env_handle = tokio::spawn(async move {
-            environment.run().expect("Failed to start environment");
-            let _ = environment.wait().await;
-        });
+        environment.run().expect("Failed to start environment");
 
-        // Publish task
-        let task = Task::new("This should fail");
         runtime
-            .publish(&topic, task)
+            .publish(&topic, Task::new("This should fail"))
             .await
             .expect("Failed to publish task");
 
-        // Wait for task result (should be an error)
-        let result = timeout(Duration::from_secs(3), async {
-            while let Some(event) = event_stream.next().await {
-                match event {
-                    Event::TaskError { error, .. } => {
-                        return Some(error);
-                    }
-                    _ => continue,
-                }
-            }
-            None
-        })
-        .await;
+        let error_message = wait_for_task_error(&mut event_stream).await;
+        assert!(error_message.contains("Mock execution failed"));
 
-        // Clean up
-        env_handle.abort();
-
-        assert!(result.is_ok());
-        if let Ok(Some(error_message)) = result {
-            assert!(error_message.contains("Mock execution failed"));
-        }
+        environment
+            .shutdown()
+            .await
+            .expect("shutdown should succeed");
     }
 
     #[tokio::test]
@@ -251,14 +268,12 @@ mod tests {
         assert!(result.is_ok());
         let _agent_handle = result.unwrap();
 
-        // Set up environment
         let mut environment = Environment::new(None);
         environment
             .register_runtime(runtime.clone())
             .await
             .expect("Failed to register runtime");
 
-        // Publish tasks to both topics - should not panic
         let task1 = Task::new("Task for topic 1");
         let task2 = Task::new("Task for topic 2");
 
@@ -280,7 +295,6 @@ mod tests {
 
         assert!(result.is_err());
         let error_string = result.unwrap_err().to_string();
-        // The error should be a build failure
         assert!(error_string.contains("Build Failure"));
     }
 
@@ -298,7 +312,6 @@ mod tests {
 
         assert!(result.is_err());
         let error_string = result.unwrap_err().to_string();
-        // The error should be a build failure
         assert!(error_string.contains("Build Failure"));
     }
 
@@ -319,7 +332,6 @@ mod tests {
             .await
             .expect("Failed to build agent");
 
-        // Verify memory is configured
         assert!(agent_handle.agent.memory().is_some());
     }
 
@@ -339,7 +351,6 @@ mod tests {
             .expect("Failed to build agent");
 
         let tools = agent_handle.agent.tools();
-        // MockAgentImpl returns empty tools vector by default
         assert_eq!(tools.len(), 0);
     }
 }

--- a/crates/autoagents-core/src/tests/mod.rs
+++ b/crates/autoagents-core/src/tests/mod.rs
@@ -352,3 +352,205 @@ impl EmbeddingProvider for MockLLMProvider {
 impl ModelsProvider for MockLLMProvider {}
 
 impl LLMProvider for MockLLMProvider {}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct DivergentExecutorOutput {
+    pub(crate) response: String,
+    pub(crate) executor_only: u32,
+}
+
+impl From<DivergentExecutorOutput> for Value {
+    fn from(output: DivergentExecutorOutput) -> Self {
+        serde_json::json!({
+            "response": output.response,
+            "executor_only": output.executor_only,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct DivergentAgentOutput {
+    pub(crate) result: String,
+}
+
+impl AgentOutputT for DivergentAgentOutput {
+    fn output_schema() -> &'static str {
+        r#"{"type":"object","properties":{"result":{"type":"string"}},"required":["result"]}"#
+    }
+
+    fn structured_output_format() -> Value {
+        serde_json::json!({
+            "name": "DivergentAgentOutput",
+            "description": "Derived agent output",
+            "schema": {
+                "type": "object",
+                "properties": {
+                    "result": {"type": "string"}
+                },
+                "required": ["result"]
+            },
+            "strict": true
+        })
+    }
+}
+
+impl From<DivergentExecutorOutput> for DivergentAgentOutput {
+    fn from(output: DivergentExecutorOutput) -> Self {
+        Self {
+            result: output.response,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct DivergentStreamingAgent;
+
+#[async_trait]
+impl AgentDeriveT for DivergentStreamingAgent {
+    type Output = DivergentAgentOutput;
+
+    fn description(&self) -> &'static str {
+        "divergent streaming agent"
+    }
+
+    fn output_schema(&self) -> Option<Value> {
+        Some(DivergentAgentOutput::structured_output_format())
+    }
+
+    fn name(&self) -> &'static str {
+        "divergent_streaming_agent"
+    }
+
+    fn tools(&self) -> Vec<Box<dyn ToolT>> {
+        vec![]
+    }
+}
+
+#[async_trait]
+impl AgentExecutor for DivergentStreamingAgent {
+    type Output = DivergentExecutorOutput;
+    type Error = TestError;
+
+    fn config(&self) -> ExecutorConfig {
+        ExecutorConfig::default()
+    }
+
+    async fn execute(
+        &self,
+        task: &Task,
+        _context: Arc<Context>,
+    ) -> Result<Self::Output, Self::Error> {
+        Ok(DivergentExecutorOutput {
+            response: task.prompt.clone(),
+            executor_only: 42,
+        })
+    }
+
+    async fn execute_stream(
+        &self,
+        task: &Task,
+        _context: Arc<Context>,
+    ) -> Result<Pin<Box<dyn Stream<Item = Result<Self::Output, Self::Error>> + Send>>, Self::Error>
+    {
+        let output = DivergentExecutorOutput {
+            response: task.prompt.clone(),
+            executor_only: 42,
+        };
+        Ok(Box::pin(stream::iter([Ok(output)])))
+    }
+}
+
+impl AgentHooks for DivergentStreamingAgent {}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct SequencedExecutorOutput {
+    pub(crate) response: String,
+    pub(crate) sequence: u32,
+}
+
+impl From<SequencedExecutorOutput> for Value {
+    fn from(output: SequencedExecutorOutput) -> Self {
+        serde_json::json!({
+            "response": output.response,
+            "sequence": output.sequence,
+        })
+    }
+}
+
+impl From<SequencedExecutorOutput> for TestAgentOutput {
+    fn from(output: SequencedExecutorOutput) -> Self {
+        Self {
+            result: output.response,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct MultiItemStreamAgent;
+
+#[async_trait]
+impl AgentDeriveT for MultiItemStreamAgent {
+    type Output = TestAgentOutput;
+
+    fn description(&self) -> &'static str {
+        "multi item stream agent"
+    }
+
+    fn output_schema(&self) -> Option<Value> {
+        Some(TestAgentOutput::structured_output_format())
+    }
+
+    fn name(&self) -> &'static str {
+        "multi_item_stream_agent"
+    }
+
+    fn tools(&self) -> Vec<Box<dyn ToolT>> {
+        vec![]
+    }
+}
+
+#[async_trait]
+impl AgentExecutor for MultiItemStreamAgent {
+    type Output = SequencedExecutorOutput;
+    type Error = TestError;
+
+    fn config(&self) -> ExecutorConfig {
+        ExecutorConfig::default()
+    }
+
+    async fn execute(
+        &self,
+        task: &Task,
+        _context: Arc<Context>,
+    ) -> Result<Self::Output, Self::Error> {
+        Ok(SequencedExecutorOutput {
+            response: task.prompt.clone(),
+            sequence: 1,
+        })
+    }
+
+    async fn execute_stream(
+        &self,
+        task: &Task,
+        _context: Arc<Context>,
+    ) -> Result<Pin<Box<dyn Stream<Item = Result<Self::Output, Self::Error>> + Send>>, Self::Error>
+    {
+        let prompt = task.prompt.clone();
+        Ok(Box::pin(stream::iter([
+            Ok(SequencedExecutorOutput {
+                response: format!("{prompt}-1"),
+                sequence: 1,
+            }),
+            Ok(SequencedExecutorOutput {
+                response: format!("{prompt}-2"),
+                sequence: 2,
+            }),
+            Ok(SequencedExecutorOutput {
+                response: format!("{prompt}-3"),
+                sequence: 3,
+            }),
+        ])))
+    }
+}
+
+impl AgentHooks for MultiItemStreamAgent {}

--- a/crates/autoagents-core/src/tests/mod.rs
+++ b/crates/autoagents-core/src/tests/mod.rs
@@ -141,15 +141,6 @@ impl AgentExecutor for MockAgentImpl {
             result: format!("Processed: {}", task.prompt),
         })
     }
-
-    async fn execute_stream(
-        &self,
-        _task: &Task,
-        _context: Arc<Context>,
-    ) -> Result<Pin<Box<dyn Stream<Item = Result<Self::Output, Self::Error>> + Send>>, Self::Error>
-    {
-        unimplemented!()
-    }
 }
 
 impl AgentHooks for MockAgentImpl {}

--- a/docs/content/core-concepts/actor_agents.md
+++ b/docs/content/core-concepts/actor_agents.md
@@ -30,6 +30,12 @@ After wiring agents and publishing work, start the registered runtimes:
 - **`run_background().await`** — starts runtimes without storing a join handle on the environment. Useful when you manage lifecycle elsewhere. Cannot be combined with `run()` on the same `Environment` until `shutdown().await` is called.
 - **`is_running()`** — returns whether a background run task is currently active.
 
+If a managed run task finishes without calling `wait()` or `shutdown()`, a subsequent `run()` joins the finished task first and returns any runtime or join error before spawning a new run.
+
+Calling `wait()` inside `tokio::select!` is safe: if another branch wins, the join handle stays on the environment so `shutdown()` can still drain the run task.
+
+`SingleThreadedRuntime` is single-cycle: after its event loop exits, register a **new** runtime instance to run again on the same `Environment`.
+
 ### Migration from earlier releases
 
 `Environment::run()` no longer returns a `JoinHandle`. Use the stored lifecycle instead:
@@ -61,14 +67,20 @@ if let Err(runtime_err) = run_result {
 ```rust
 // Interactive or long-running: start runtimes, handle Ctrl+C gracefully
 environment.run()?;
+// `wait()` is select-safe — if Ctrl+C wins, the join handle is restored
+// so shutdown can still drain runtimes. See design_patterns::environment_lifecycle.
 tokio::select! {
     result = environment.wait() => {
         if let Ok(Err(e)) = result {
             eprintln!("runtime error: {e}");
+        } else if let Err(e) = result {
+            eprintln!("run task join error: {e}");
         }
     }
     _ = tokio::signal::ctrl_c() => {
-        environment.shutdown().await?;
+        if let Err(err) = environment.shutdown().await {
+            eprintln!("shutdown failed: {err}");
+        }
     }
 }
 ```

--- a/docs/content/core-concepts/actor_agents.md
+++ b/docs/content/core-concepts/actor_agents.md
@@ -162,6 +162,21 @@ These map to `autoagents::core::protocol::Event` variants emitted by actor agent
 
 Internally, the runtime also routes `PublishMessage` for typed pub/sub (`Topic<M>`), but that variant is skipped in serde and used only inside the runtime.
 
+## Actor streaming APIs
+
+Actor agents expose two streaming entry points with different event contracts:
+
+| API | Terminal events (`TaskComplete` / `TaskError`) | Hooks | Typical use |
+|-----|-----------------------------------------------|-------|-------------|
+| `run_stream()` | **No** — failures are `Err` items on the returned stream only | Skipped | Incremental output; poll the stream directly |
+| `run_stream_to_completion()` | **Yes** — full task lifecycle on the event channel | Run | Runtime pub/sub dispatch, event subscribers, `select!` on `TaskError` |
+
+**Footgun:** If you subscribe to runtime or agent events and call `run_stream()` directly, terminal failures will **not** emit `TaskError` on the event channel even though mid-run events (`StreamChunk`, tool calls) may still arrive. Listeners waiting only for `TaskComplete` / `TaskError` can hang. Use `run_stream_to_completion()` instead, or handle errors on the returned output stream.
+
+Non-streaming `run()` always emits `TaskComplete` or `TaskError`. This matches `run_stream_to_completion()`, not `run_stream()`.
+
+For the direct-agent variant of this contract, see [Agents — Direct agent event contract](./agents.md#direct-agent-event-contract).
+
 ## When To Use Actor Agents vs Direct Agents
 
 - Use Direct agents for one-shot calls (no runtime, minimal wiring).

--- a/docs/content/core-concepts/actor_agents.md
+++ b/docs/content/core-concepts/actor_agents.md
@@ -18,6 +18,45 @@ Actor-based agents run inside a runtime and communicate via typed messages and p
 2) Spawn your agent as `ActorAgent` and subscribe it to one or more `Topic<Task>`.
 3) Take the environment's event receiver and forward events to your UI/log sink.
 4) Publish `Task` messages to the relevant topic to trigger work.
+5) Call [`Environment::run`](https://docs.rs/autoagents-core/latest/autoagents_core/environment/struct.Environment.html#method.run), then [`wait`](https://docs.rs/autoagents-core/latest/autoagents_core/environment/struct.Environment.html#method.wait) or [`shutdown`](https://docs.rs/autoagents-core/latest/autoagents_core/environment/struct.Environment.html#method.shutdown) to manage runtime lifecycle.
+
+## Environment Lifecycle
+
+After wiring agents and publishing work, start the registered runtimes:
+
+- **`run()`** — spawns a background task that runs all registered runtimes. Returns `Err(EnvironmentError::AlreadyRunning)` if a run task is already in progress. Does **not** block until work completes.
+- **`wait().await`** — joins the background task started by `run()`. Clears the stored handle when the task finishes, so later calls return immediately with `Ok(Ok(()))`. Use this in short-lived programs once messages/tasks have been published.
+- **`shutdown().await`** — requests shutdown on all runtimes and joins the run handle. Use for graceful exit (for example on `Ctrl+C`).
+- **`run_background().await`** — starts runtimes without storing a join handle on the environment. Useful when you manage lifecycle elsewhere.
+- **`is_running()`** — returns whether a background run task is currently active.
+
+Common patterns:
+
+```rust
+// Fire-and-wait: publish work, start runtimes, block until they finish
+environment.run()?;
+let run_result = environment.wait().await?;
+if let Err(runtime_err) = run_result {
+    eprintln!("runtime error: {runtime_err}");
+}
+```
+
+```rust
+// Interactive or long-running: start runtimes, handle Ctrl+C gracefully
+environment.run()?;
+tokio::select! {
+    result = environment.wait() => {
+        if let Ok(Err(e)) = result {
+            eprintln!("runtime error: {e}");
+        }
+    }
+    _ = tokio::signal::ctrl_c() => {
+        environment.shutdown().await;
+    }
+}
+```
+
+Call `run()` **after** registering runtimes and **before** or **after** publishing tasks depending on your program. Actor agents process messages only while runtimes are running.
 
 ## Minimal Example
 
@@ -53,6 +92,10 @@ tokio::spawn(async move { /* forward events to UI */ });
 // 4) Publish tasks
 runtime.publish(&chat_topic, Task::new("Hello!"))
     .await?;
+
+// 5) Start runtimes and wait for the background run task to finish
+env.run()?;
+let _ = env.wait().await?;
 ```
 
 ## Event Handling Patterns

--- a/docs/content/core-concepts/actor_agents.md
+++ b/docs/content/core-concepts/actor_agents.md
@@ -26,9 +26,26 @@ After wiring agents and publishing work, start the registered runtimes:
 
 - **`run()`** — spawns a background task that runs all registered runtimes. Returns `Err(EnvironmentError::AlreadyRunning)` if a run task is already in progress. Does **not** block until work completes.
 - **`wait().await`** — joins the background task started by `run()`. Clears the stored handle when the task finishes, so later calls return immediately with `Ok(Ok(()))`. Use this in short-lived programs once messages/tasks have been published.
-- **`shutdown().await`** — requests shutdown on all runtimes and joins the run handle. Use for graceful exit (for example on `Ctrl+C`).
-- **`run_background().await`** — starts runtimes without storing a join handle on the environment. Useful when you manage lifecycle elsewhere.
+- **`shutdown().await`** — requests shutdown on all runtimes and joins the run handle. Returns `Result<(), EnvironmentError>` so runtime or join failures are visible. Use for graceful exit (for example on `Ctrl+C`).
+- **`run_background().await`** — starts runtimes without storing a join handle on the environment. Useful when you manage lifecycle elsewhere. Cannot be combined with `run()` on the same `Environment` until `shutdown().await` is called.
 - **`is_running()`** — returns whether a background run task is currently active.
+
+### Migration from earlier releases
+
+`Environment::run()` no longer returns a `JoinHandle`. Use the stored lifecycle instead:
+
+```rust
+// Before
+let handle = environment.run();
+handle.await??;
+
+// After
+environment.run()?;
+let run_result = environment.wait().await?;
+run_result?;
+```
+
+For long-running programs that previously dropped the join handle, call `environment.shutdown().await?` on exit.
 
 Common patterns:
 
@@ -51,7 +68,7 @@ tokio::select! {
         }
     }
     _ = tokio::signal::ctrl_c() => {
-        environment.shutdown().await;
+        environment.shutdown().await?;
     }
 }
 ```

--- a/docs/content/core-concepts/actor_agents.md
+++ b/docs/content/core-concepts/actor_agents.md
@@ -28,7 +28,7 @@ After wiring agents and publishing work, start the registered runtimes:
 - **`wait().await`** — joins the background task started by `run()`. Clears the stored handle when the task finishes, so later calls return immediately with `Ok(Ok(()))`. Use this in short-lived programs once messages/tasks have been published.
 - **`shutdown().await`** — requests shutdown on all runtimes and joins the run handle. Returns `Result<(), EnvironmentError>` so runtime or join failures are visible. Use for graceful exit (for example on `Ctrl+C`).
 - **`run_background().await`** — starts runtimes without storing a join handle on the environment. Useful when you manage lifecycle elsewhere. Cannot be combined with `run()` on the same `Environment` until `shutdown().await` is called.
-- **`is_running()`** — returns whether a background run task is currently active.
+- **`is_running()`** — returns whether a runtime launch is active (`run()` join handle not finished, or `run_background()` until `shutdown()`).
 
 If a managed run task finishes without calling `wait()` or `shutdown()`, a subsequent `run()` joins the finished task first and returns any runtime or join error before spawning a new run.
 

--- a/docs/content/core-concepts/actor_agents.md
+++ b/docs/content/core-concepts/actor_agents.md
@@ -175,6 +175,8 @@ Actor agents expose two streaming entry points with different event contracts:
 
 Non-streaming `run()` always emits `TaskComplete` or `TaskError`. This matches `run_stream_to_completion()`, not `run_stream()`.
 
+Pub/sub dispatch (`AgentActor::handle`) calls `run()` / `run_stream_to_completion()` and **does not** propagate task failures to ractor. A failed task emits `TaskError` on the event channel but the actor keeps running so it can process subsequent messages.
+
 For the direct-agent variant of this contract, see [Agents — Direct agent event contract](./agents.md#direct-agent-event-contract).
 
 ## When To Use Actor Agents vs Direct Agents

--- a/docs/content/core-concepts/advanced_patterns.md
+++ b/docs/content/core-concepts/advanced_patterns.md
@@ -21,3 +21,4 @@ Use `SharedTool` or `shared_tools_to_boxes` to reuse `Arc<dyn ToolT>` across man
 
 - Use `Topic<M>` to broadcast tasks to a group of actor agents.
 - Combine with `Environment` + `Runtime` to route events and messages.
+- Start the environment with `environment.run()?`, then `environment.wait().await?` for batch workflows or `environment.shutdown().await` for graceful exit.

--- a/docs/content/core-concepts/advanced_patterns.md
+++ b/docs/content/core-concepts/advanced_patterns.md
@@ -21,4 +21,4 @@ Use `SharedTool` or `shared_tools_to_boxes` to reuse `Arc<dyn ToolT>` across man
 
 - Use `Topic<M>` to broadcast tasks to a group of actor agents.
 - Combine with `Environment` + `Runtime` to route events and messages.
-- Start the environment with `environment.run()?`, then `environment.wait().await?` for batch workflows or `environment.shutdown().await` for graceful exit.
+- Start the environment with `environment.run()?`, then `environment.wait().await?` for batch workflows or `environment.shutdown().await?` for graceful exit.

--- a/docs/content/core-concepts/agents.md
+++ b/docs/content/core-concepts/agents.md
@@ -55,7 +55,7 @@ Direct agents use a **return-value-first** model. Unlike actor agents running in
 
 **Mid-run events:** Executors may still emit non-terminal events (for example `TurnStarted`, `ToolCallRequested`, `StreamChunk`) on `handle.rx` during execution. Use `handle.subscribe_events()` when multiple consumers need the same stream.
 
-For full protocol event shapes, see [Actor Agents — Protocol Events Reference](./actor_agents.md#protocol-events-reference). Actor agents emit `TaskComplete` and route events through the runtime; direct agents only guarantee `TaskError` on the failure paths above.
+For full protocol event shapes, see [Actor Agents — Protocol Events Reference](./actor_agents.md#protocol-events-reference). Actor agents emit `TaskComplete` via `run()` and `run_stream_to_completion()`; see [Actor streaming APIs](./actor_agents.md#actor-streaming-apis) for the `run_stream()` distinction.
 
 ## Actor Based Agents
 

--- a/docs/content/core-concepts/agents.md
+++ b/docs/content/core-concepts/agents.md
@@ -21,16 +21,41 @@ An agent in AutoAgents typically:
 
 ## Direct Agents
 
-Direct agents expose simple `run`/`run_stream` APIs and return results to the caller.
+Direct agents expose simple `run`/`run_stream` APIs and return results to the caller. `AgentBuilder::build()` returns a `DirectAgentHandle` with the runnable agent and an event receiver (`handle.rx`).
 
 ```rust
+use autoagents::core::agent::task::Task;
 use autoagents::core::agent::{AgentBuilder, DirectAgent};
-let handle = AgentBuilder::<_, DirectAgent>::new(my_executor)
+
+let mut handle = AgentBuilder::<_, DirectAgent>::new(my_executor)
     .llm(llm)
     .build()
     .await?;
-let result = handle.agent.run(Task::new("Prompt")) .await?;
+
+// One-shot: the final output comes from the return value, not from handle.rx
+let result = handle.agent.run(Task::new("Prompt")).await?;
 ```
+
+### Direct agent event contract
+
+Direct agents use a **return-value-first** model. Unlike actor agents running inside a runtime, they do **not** emit `TaskComplete` on success — use the `Result` from `run()` or items from `run_stream()` for output.
+
+| Outcome | Return value | `handle.rx` |
+|--------|--------------|-------------|
+| Success (`run`) | `Ok(output)` | No terminal event |
+| Success (`run_stream`) | `Ok(stream)` of output items | No terminal event |
+| Hook abort | `Err(Abort)` | `TaskError` |
+| Executor error (`run`) | `Err(...)` | `TaskError` |
+| Stream setup error (`run_stream`) | `Err(...)` | `TaskError` |
+| In-stream item error (`run_stream`) | `Err(...)` on the output stream | `TaskError` when the stream item is polled |
+
+**Listening for failures:** If your code waits on `handle.rx` (for example in a `select!`), subscribe before or concurrently with execution. Terminal failures emit `TaskError` so listeners do not hang indefinitely.
+
+**Streaming caveat:** For `run_stream()`, in-stream failures emit `TaskError` on `handle.rx` when the **returned output stream is polled**. If you only listen on `handle.rx` and never poll the output stream, item-level errors will not surface on the event channel.
+
+**Mid-run events:** Executors may still emit non-terminal events (for example `TurnStarted`, `ToolCallRequested`, `StreamChunk`) on `handle.rx` during execution. Use `handle.subscribe_events()` when multiple consumers need the same stream.
+
+For full protocol event shapes, see [Actor Agents — Protocol Events Reference](./actor_agents.md#protocol-events-reference). Actor agents emit `TaskComplete` and route events through the runtime; direct agents only guarantee `TaskError` on the failure paths above.
 
 ## Actor Based Agents
 

--- a/docs/content/core-concepts/agents.md
+++ b/docs/content/core-concepts/agents.md
@@ -32,30 +32,31 @@ let mut handle = AgentBuilder::<_, DirectAgent>::new(my_executor)
     .build()
     .await?;
 
-// One-shot: the final output comes from the return value, not from handle.rx
+// One-shot: the final output is available from the return value and as TaskComplete on handle.rx
 let result = handle.agent.run(Task::new("Prompt")).await?;
 ```
 
 ### Direct agent event contract
 
-Direct agents use a **return-value-first** model. Unlike actor agents running inside a runtime, they do **not** emit `TaskComplete` on success — use the `Result` from `run()` or items from `run_stream()` for output.
+Direct agents emit the same terminal protocol events as actor agents on success and failure. Use the `Result` from `run()` or items from `run_stream()` for output; subscribe to `handle.rx` when multiple consumers need lifecycle events.
 
 | Outcome | Return value | `handle.rx` |
 |--------|--------------|-------------|
-| Success (`run`) | `Ok(output)` | No terminal event |
-| Success (`run_stream`) | `Ok(stream)` of output items | No terminal event |
+| Success (`run`) | `Ok(output)` | `TaskComplete` |
+| Success (`run_stream`) | `Ok(stream)` of output items | `TaskComplete` when the output stream is fully drained (last successful item) |
 | Hook abort | `Err(Abort)` | `TaskError` |
 | Executor error (`run`) | `Err(...)` | `TaskError` |
 | Stream setup error (`run_stream`) | `Err(...)` | `TaskError` |
+| Empty stream (`run_stream`) | `Ok(empty stream)` | `TaskError` when the output stream is fully drained |
 | In-stream item error (`run_stream`) | `Err(...)` on the output stream | `TaskError` when the stream item is polled |
 
-**Listening for failures:** If your code waits on `handle.rx` (for example in a `select!`), subscribe before or concurrently with execution. Terminal failures emit `TaskError` so listeners do not hang indefinitely.
+**Listening for terminal events:** If your code waits on `handle.rx` (for example in a `select!`), subscribe before or concurrently with execution. Both success and failure emit a terminal event so listeners do not hang indefinitely.
 
-**Streaming caveat:** For `run_stream()`, in-stream failures emit `TaskError` on `handle.rx` when the **returned output stream is polled**. If you only listen on `handle.rx` and never poll the output stream, item-level errors will not surface on the event channel.
+**Streaming caveat:** For `run_stream()`, in-stream failures and `TaskComplete` are emitted when the **returned output stream is polled**. If you only listen on `handle.rx` and never poll the output stream, item-level errors and stream completion will not surface on the event channel.
 
 **Mid-run events:** Executors may still emit non-terminal events (for example `TurnStarted`, `ToolCallRequested`, `StreamChunk`) on `handle.rx` during execution. Use `handle.subscribe_events()` when multiple consumers need the same stream.
 
-For full protocol event shapes, see [Actor Agents — Protocol Events Reference](./actor_agents.md#protocol-events-reference). Actor agents emit `TaskComplete` via `run()` and `run_stream_to_completion()`; see [Actor streaming APIs](./actor_agents.md#actor-streaming-apis) for the `run_stream()` distinction.
+For full protocol event shapes, see [Actor Agents — Protocol Events Reference](./actor_agents.md#protocol-events-reference). Direct agents and actor agents both emit `TaskComplete` / `TaskError` on the terminal paths above; see [Actor streaming APIs](./actor_agents.md#actor-streaming-apis) for the actor-only `run_stream()` footgun (no terminal events on the public streaming API).
 
 ## Actor Based Agents
 

--- a/docs/content/core-concepts/agents.md
+++ b/docs/content/core-concepts/agents.md
@@ -40,8 +40,10 @@ High‑level flow:
 
 - Create a `SingleThreadedRuntime`
 - Build the agent with `.runtime(runtime.clone())`
-- Register runtime in an `Environment` and run it
+- Register runtime in an `Environment`, call `run()`, then `wait()` or `shutdown()`
 - Publish `Task`s to topics or send direct messages
+
+See [Actor Agents](./actor_agents.md#environment-lifecycle) for lifecycle details (`run`, `wait`, `shutdown`).
 
 Use actor agents for multi‑agent collaboration, routing, or background workflows.
 

--- a/docs/content/faq.md
+++ b/docs/content/faq.md
@@ -1,0 +1,59 @@
+# FAQ
+
+## General
+
+**What is AutoAgents?**
+AutoAgents is a production-grade, multi-agent framework written in Rust. It provides a modular architecture for building intelligent systems with type-safe agent models, structured tool calling, configurable memory, and pluggable LLM backends — designed for performance, safety, and composability across server and edge environments.
+
+**How does AutoAgents differ from other agent frameworks?**
+AutoAgents is Rust-first, offering memory safety, zero-cost abstractions, and high performance. It provides a unified interface for cloud and local LLM providers, built-in guardrails, optimization passes (cache/retry), and a WASM sandbox for tool execution — all in a single framework.
+
+**Is there a Python version?**
+Yes. AutoAgents provides Python bindings via `autoagents-py` on PyPI, enabling Python developers to leverage the Rust core with a familiar API.
+
+## Setup & Configuration
+
+**How do I install AutoAgents?**
+Install via Cargo: `cargo add autoagents`, or via PyPI for Python: `pip install autoagents-py`. See the [documentation](https://liquidos-ai.github.io/AutoAgents/) for detailed setup guides.
+
+**Which LLM providers are supported?**
+AutoAgents supports OpenAI, OpenRouter, Anthropic, DeepSeek, xAI, and local models via a unified interface. Configure your API keys in the environment or configuration file.
+
+**Can I use local models?**
+Yes. AutoAgents supports local LLM backends through its unified provider interface, enabling fully offline agent operation.
+
+## Agent Development
+
+**What is the ReAct executor?**
+The ReAct (Reasoning + Acting) executor is AutoAgents' primary agent execution model. It alternates between reasoning steps and tool calls, enabling agents to plan, execute, and observe results in a loop until the task is complete.
+
+**How does the tool system work?**
+Tools are defined using derive macros (`#[derive(Tool)]`) for type-safe input/output. AutoAgents also provides a sandboxed WASM runtime for executing untrusted tools securely.
+
+**What memory backends are available?**
+AutoAgents uses a sliding window memory model by default, with extensible backends for custom memory strategies — enabling fine-grained control over context management.
+
+## Multi-Agent Orchestration
+
+**How do agents communicate?**
+AutoAgents provides typed pub/sub communication between agents, enabling structured message passing with compile-time type safety. Agents can publish events and subscribe to topics in a decoupled architecture.
+
+**What is the environment system?**
+The environment system manages shared state and resources across multiple agents. It provides a controlled space where agents can interact, share observations, and coordinate actions. Register runtimes with `register_runtime`, start them with `run()`, await completion with `wait().await?`, or stop them with `shutdown().await?`. See [Actor Agents — Environment lifecycle](./core-concepts/actor_agents.md#environment-lifecycle) for patterns.
+
+**Can I restart the same runtime after shutdown?**
+`SingleThreadedRuntime` is single-cycle: its event loop cannot re-enter after it finishes. To run again, register a new runtime instance (or create a fresh `Environment`).
+
+**Is `wait()` safe inside `tokio::select!`?**
+Yes. If another branch wins and `wait()` is cancelled, the join handle is restored on the environment so `shutdown()` can still stop runtimes and join the run task.
+
+## Troubleshooting
+
+**Build fails with Rust version errors. What should I do?**
+AutoAgents requires Rust 1.75+. Run `rustup update` to get the latest stable version. Check the [documentation](https://liquidos-ai.github.io/AutoAgents/) for minimum version requirements.
+
+**Where can I get help?**
+- Documentation: https://liquidos-ai.github.io/AutoAgents/
+- Examples: `examples/` directory in the repository
+- DeepWiki: https://deepwiki.com/liquidos-ai/AutoAgents
+- GitHub Issues: https://github.com/liquidos-ai/AutoAgents/issues

--- a/docs/content/getting-started/python-bindings.md
+++ b/docs/content/getting-started/python-bindings.md
@@ -298,6 +298,11 @@ The actor example mirrors the Rust runtime model: create a `Runtime`, register
 it with an `Environment`, build the actor against the runtime, listen on the
 environment event stream, then publish a `Task` to the topic.
 
+In Rust, call `environment.run()?` followed by `environment.wait().await?` to
+join the background runtime task (see [Environment Lifecycle](https://liquidos-ai.github.io/AutoAgents/core-concepts/actor_agents#environment-lifecycle)).
+The Python `Environment.run()` helper starts runtimes in the background without
+blocking; the example exits once a `TaskComplete` event is received.
+
 The CodeAct example mirrors the Rust `examples/code_mode` sample: it exposes
 typed Python tools to the LLM, lets the model write sandboxed TypeScript, and
 prints the captured execution trace after the run.

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -3,6 +3,7 @@ import type {SidebarsConfig} from '@docusaurus/plugin-content-docs';
 const sidebars: SidebarsConfig = {
   docsSidebar: [
     'index',
+    'faq',
     {
       type: 'category',
       label: 'Getting Started',

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -16,7 +16,9 @@ export OPENAI_API_KEY=your_openai_api_key_here
 cargo run --package basic-example -- --usecase simple
 ```
 
-Shows a basic event-driven agent.
+Shows a basic event-driven agent with `DirectAgent::run()` and a background event listener.
+
+**Return value vs `TaskComplete`:** `agent.run()` returns the agent output type (`MathAgentOutput` in this example). The `TaskComplete` event on `handle.rx` carries the **executor** payload instead (for ReAct, `ReActAgentOutput` with `response`, `tool_calls`, and `done`). The `response` field is often a JSON string that maps to the agent output after parsing — the example's `handle_events` helper pretty-prints that nested JSON so it matches the structured `Result:` line below it.
 
 ### Add hooks to agents
 

--- a/examples/basic/src/actor.rs
+++ b/examples/basic/src/actor.rs
@@ -133,7 +133,8 @@ pub async fn run(_llm: Arc<dyn LLMProvider>) -> Result<(), Error> {
     //Send Direct Message
     runtime.send_message(general_message, actor1_ref).await?;
 
-    let _ = environment.run().await;
+    environment.run()?;
+    let _ = environment.wait().await;
 
     println!("\n✅ All messages sent successfully!");
 

--- a/examples/basic/src/utils.rs
+++ b/examples/basic/src/utils.rs
@@ -1,5 +1,6 @@
 use autoagents::core::utils::BoxEventStream;
 use autoagents::protocol::Event;
+use serde_json::Value;
 use tokio_stream::StreamExt;
 
 pub fn handle_events(mut event_stream: BoxEventStream<Event>) {
@@ -17,7 +18,7 @@ pub fn handle_events(mut event_stream: BoxEventStream<Event>) {
                     );
                 }
                 Event::TaskComplete { result, .. } => {
-                    println!("✅ Task Completed: {:?}", result);
+                    print_task_complete(&result);
                 }
                 Event::StreamChunk { chunk, .. } => {
                     println!("Chunk: {:?}", chunk);
@@ -28,4 +29,43 @@ pub fn handle_events(mut event_stream: BoxEventStream<Event>) {
             }
         }
     });
+}
+
+/// Pretty-print a `TaskComplete` payload for console demos.
+///
+/// Direct and actor agents emit the **executor** output shape in `TaskComplete`
+/// (for example `ReActAgentOutput` with `response`, `tool_calls`, `done`).
+/// The typed value returned from `agent.run()` uses the agent's `Output` type
+/// (for example `MathAgentOutput`) after `From` conversion — see the README.
+fn print_task_complete(result: &str) {
+    let Ok(value) = serde_json::from_str::<Value>(result) else {
+        println!("✅ Task Completed: {result}");
+        return;
+    };
+
+    // ReAct-style executor payloads nest the agent JSON inside `response`.
+    if let Some(response) = value.get("response").and_then(Value::as_str) {
+        println!("✅ Task Completed (executor event):");
+        match serde_json::from_str::<Value>(response) {
+            Ok(agent_json) => {
+                println!(
+                    "{}",
+                    serde_json::to_string_pretty(&agent_json).unwrap_or_else(|_| response.into())
+                );
+            }
+            Err(_) => println!("  {response}"),
+        }
+        if let Some(tool_calls) = value.get("tool_calls").and_then(Value::as_array)
+            && !tool_calls.is_empty()
+        {
+            println!("  tool_calls: {} invocation(s)", tool_calls.len());
+        }
+        return;
+    }
+
+    println!("✅ Task Completed:");
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&value).unwrap_or_else(|_| result.to_string())
+    );
 }

--- a/examples/coding_agent/src/interactive.rs
+++ b/examples/coding_agent/src/interactive.rs
@@ -52,7 +52,7 @@ pub async fn run_interactive_session(llm: Arc<dyn LLMProvider>) -> Result<(), Er
     handle_events(receiver);
 
     // Start the environment in the background
-    let _handle = environment.run();
+    environment.run()?;
 
     let stdin = io::stdin();
     let mut stdout = io::stdout();

--- a/examples/coding_agent/src/interactive.rs
+++ b/examples/coding_agent/src/interactive.rs
@@ -102,6 +102,8 @@ pub async fn run_interactive_session(llm: Arc<dyn LLMProvider>) -> Result<(), Er
         }
     }
 
+    environment.shutdown().await?;
+
     Ok(())
 }
 

--- a/examples/design_patterns/src/chaining.rs
+++ b/examples/design_patterns/src/chaining.rs
@@ -120,16 +120,11 @@ pub async fn run(llm: Arc<dyn LLMProvider>) -> Result<(), Error> {
 
     environment.run()?;
 
-    // Run the environment and wait for completion or interruption
-    tokio::select! {
-        _ = environment.wait() => {
-            println!("\nChaining pipeline completed successfully.");
-        }
-        _ = tokio::signal::ctrl_c() => {
-            println!("\nCtrl+C detected. Shutting down...");
-            let _ = environment.shutdown().await;
-        }
-    }
+    crate::environment_lifecycle::wait_or_ctrl_c(
+        &mut environment,
+        "\nChaining pipeline completed successfully.",
+    )
+    .await;
 
     Ok(())
 }

--- a/examples/design_patterns/src/chaining.rs
+++ b/examples/design_patterns/src/chaining.rs
@@ -127,7 +127,7 @@ pub async fn run(llm: Arc<dyn LLMProvider>) -> Result<(), Error> {
         }
         _ = tokio::signal::ctrl_c() => {
             println!("\nCtrl+C detected. Shutting down...");
-            environment.shutdown().await;
+            let _ = environment.shutdown().await;
         }
     }
 

--- a/examples/design_patterns/src/chaining.rs
+++ b/examples/design_patterns/src/chaining.rs
@@ -118,9 +118,11 @@ pub async fn run(llm: Arc<dyn LLMProvider>) -> Result<(), Error> {
         .publish(&topic1, Task::new("The new laptop model features a 3.5 GHz octa-core processor, 16GB of RAM, and a 1TB NVMe SSD."))
         .await?;
 
+    environment.run()?;
+
     // Run the environment and wait for completion or interruption
     tokio::select! {
-        _ = environment.run() => {
+        _ = environment.wait() => {
             println!("\nChaining pipeline completed successfully.");
         }
         _ = tokio::signal::ctrl_c() => {

--- a/examples/design_patterns/src/environment_lifecycle.rs
+++ b/examples/design_patterns/src/environment_lifecycle.rs
@@ -1,0 +1,62 @@
+//! Helpers for [`Environment`](autoagents::core::environment::Environment) lifecycle
+//! in long-running examples.
+//!
+//! `Environment::wait()` is safe inside `tokio::select!`: if another branch wins,
+//! the join handle is restored so [`shutdown_environment`] can still drain runtimes.
+
+use autoagents::core::environment::Environment;
+use autoagents::core::runtime::RuntimeError;
+use std::time::Duration;
+use tokio::task::JoinError;
+
+/// Shut down the environment and log failures instead of discarding them.
+pub async fn shutdown_environment(environment: &mut Environment) {
+    if let Err(err) = environment.shutdown().await {
+        eprintln!("Environment shutdown failed: {err}");
+    }
+}
+
+fn log_wait_result(result: Result<Result<(), RuntimeError>, JoinError>) {
+    match result {
+        Ok(Ok(())) => {}
+        Ok(Err(err)) => eprintln!("Environment run failed: {err}"),
+        Err(err) => eprintln!("Environment run task join failed: {err}"),
+    }
+}
+
+/// Wait for the managed run task to finish, or shut down gracefully on Ctrl+C.
+pub async fn wait_or_ctrl_c(environment: &mut Environment, success_message: &str) {
+    tokio::select! {
+        result = environment.wait() => {
+            log_wait_result(result);
+            println!("{success_message}");
+        }
+        _ = tokio::signal::ctrl_c() => {
+            println!("\nCtrl+C detected. Shutting down...");
+            shutdown_environment(environment).await;
+        }
+    }
+}
+
+/// Wait for the managed run task to finish, or shut down on Ctrl+C or after `timeout`.
+pub async fn wait_ctrl_c_or_timeout(
+    environment: &mut Environment,
+    timeout: Duration,
+    success_message: &str,
+    timeout_message: &str,
+) {
+    tokio::select! {
+        result = environment.wait() => {
+            log_wait_result(result);
+            println!("{success_message}");
+        }
+        _ = tokio::time::sleep(timeout) => {
+            println!("{timeout_message}");
+            shutdown_environment(environment).await;
+        }
+        _ = tokio::signal::ctrl_c() => {
+            println!("\nCtrl+C detected. Shutting down...");
+            shutdown_environment(environment).await;
+        }
+    }
+}

--- a/examples/design_patterns/src/main.rs
+++ b/examples/design_patterns/src/main.rs
@@ -3,6 +3,7 @@
 //! This example demonstrates different Agentic AI Design Patterns
 
 mod chaining;
+mod environment_lifecycle;
 mod parallel;
 mod planning;
 mod reflection;

--- a/examples/design_patterns/src/parallel.rs
+++ b/examples/design_patterns/src/parallel.rs
@@ -183,9 +183,11 @@ pub async fn run(llm: Arc<dyn LLMProvider>) -> Result<(), Error> {
 
     runtime.publish(&terms_topic, task.clone()).await?;
 
+    environment.run()?;
+
     // Run the environment
     tokio::select! {
-        _ = environment.run() => {
+        _ = environment.wait() => {
             println!("Environment finished running.");
         }
         _ = tokio::signal::ctrl_c() => {

--- a/examples/design_patterns/src/parallel.rs
+++ b/examples/design_patterns/src/parallel.rs
@@ -185,16 +185,8 @@ pub async fn run(llm: Arc<dyn LLMProvider>) -> Result<(), Error> {
 
     environment.run()?;
 
-    // Run the environment
-    tokio::select! {
-        _ = environment.wait() => {
-            println!("Environment finished running.");
-        }
-        _ = tokio::signal::ctrl_c() => {
-            println!("Ctrl+C detected. Shutting down...");
-            let _ = environment.shutdown().await;
-        }
-    }
+    crate::environment_lifecycle::wait_or_ctrl_c(&mut environment, "Environment finished running.")
+        .await;
 
     Ok(())
 }

--- a/examples/design_patterns/src/parallel.rs
+++ b/examples/design_patterns/src/parallel.rs
@@ -192,7 +192,7 @@ pub async fn run(llm: Arc<dyn LLMProvider>) -> Result<(), Error> {
         }
         _ = tokio::signal::ctrl_c() => {
             println!("Ctrl+C detected. Shutting down...");
-            environment.shutdown().await;
+            let _ = environment.shutdown().await;
         }
     }
 

--- a/examples/design_patterns/src/planning.rs
+++ b/examples/design_patterns/src/planning.rs
@@ -379,9 +379,11 @@ pub async fn run(llm: Arc<dyn LLMProvider>) -> Result<(), Error> {
         .publish(&planner_topic, Task::new(complex_task))
         .await?;
 
+    environment.run()?;
+
     // Run the environment with extended timeout for complex planning
     tokio::select! {
-        _ = environment.run() => {
+        _ = environment.wait() => {
             println!("\nStrategic planning process completed successfully.");
         }
         _ = tokio::time::sleep(tokio::time::Duration::from_secs(90)) => {

--- a/examples/design_patterns/src/planning.rs
+++ b/examples/design_patterns/src/planning.rs
@@ -388,11 +388,11 @@ pub async fn run(llm: Arc<dyn LLMProvider>) -> Result<(), Error> {
         }
         _ = tokio::time::sleep(tokio::time::Duration::from_secs(90)) => {
             println!("\nPlanning process timeout - shutting down.");
-            environment.shutdown().await;
+            let _ = environment.shutdown().await;
         }
         _ = tokio::signal::ctrl_c() => {
             println!("\nCtrl+C detected. Shutting down...");
-            environment.shutdown().await;
+            let _ = environment.shutdown().await;
         }
     }
 

--- a/examples/design_patterns/src/planning.rs
+++ b/examples/design_patterns/src/planning.rs
@@ -381,20 +381,13 @@ pub async fn run(llm: Arc<dyn LLMProvider>) -> Result<(), Error> {
 
     environment.run()?;
 
-    // Run the environment with extended timeout for complex planning
-    tokio::select! {
-        _ = environment.wait() => {
-            println!("\nStrategic planning process completed successfully.");
-        }
-        _ = tokio::time::sleep(tokio::time::Duration::from_secs(90)) => {
-            println!("\nPlanning process timeout - shutting down.");
-            let _ = environment.shutdown().await;
-        }
-        _ = tokio::signal::ctrl_c() => {
-            println!("\nCtrl+C detected. Shutting down...");
-            let _ = environment.shutdown().await;
-        }
-    }
+    crate::environment_lifecycle::wait_ctrl_c_or_timeout(
+        &mut environment,
+        tokio::time::Duration::from_secs(90),
+        "\nStrategic planning process completed successfully.",
+        "\nPlanning process timeout - shutting down.",
+    )
+    .await;
 
     Ok(())
 }

--- a/examples/design_patterns/src/reflection.rs
+++ b/examples/design_patterns/src/reflection.rs
@@ -252,11 +252,11 @@ pub async fn run(llm: Arc<dyn LLMProvider>) -> Result<(), Error> {
         }
         _ = tokio::time::sleep(tokio::time::Duration::from_secs(30)) => {
             println!("\nReflection loop timeout - shutting down.");
-            environment.shutdown().await;
+            let _ = environment.shutdown().await;
         }
         _ = tokio::signal::ctrl_c() => {
             println!("\nCtrl+C detected. Shutting down...");
-            environment.shutdown().await;
+            let _ = environment.shutdown().await;
         }
     }
 

--- a/examples/design_patterns/src/reflection.rs
+++ b/examples/design_patterns/src/reflection.rs
@@ -245,20 +245,13 @@ pub async fn run(llm: Arc<dyn LLMProvider>) -> Result<(), Error> {
 
     environment.run()?;
 
-    // Run for a limited time to allow the reflection loop to complete
-    tokio::select! {
-        _ = environment.wait() => {
-            println!("\nReflection loop completed.");
-        }
-        _ = tokio::time::sleep(tokio::time::Duration::from_secs(30)) => {
-            println!("\nReflection loop timeout - shutting down.");
-            let _ = environment.shutdown().await;
-        }
-        _ = tokio::signal::ctrl_c() => {
-            println!("\nCtrl+C detected. Shutting down...");
-            let _ = environment.shutdown().await;
-        }
-    }
+    crate::environment_lifecycle::wait_ctrl_c_or_timeout(
+        &mut environment,
+        tokio::time::Duration::from_secs(30),
+        "\nReflection loop completed.",
+        "\nReflection loop timeout - shutting down.",
+    )
+    .await;
 
     Ok(())
 }

--- a/examples/design_patterns/src/reflection.rs
+++ b/examples/design_patterns/src/reflection.rs
@@ -243,9 +243,11 @@ pub async fn run(llm: Arc<dyn LLMProvider>) -> Result<(), Error> {
         )
         .await?;
 
+    environment.run()?;
+
     // Run for a limited time to allow the reflection loop to complete
     tokio::select! {
-        _ = environment.run() => {
+        _ = environment.wait() => {
             println!("\nReflection loop completed.");
         }
         _ = tokio::time::sleep(tokio::time::Duration::from_secs(30)) => {

--- a/examples/telemetry/src/main.rs
+++ b/examples/telemetry/src/main.rs
@@ -215,7 +215,7 @@ async fn run_actor(llm: Arc<dyn LLMProvider>, args: &Args) -> Result<(), Error> 
         .await
         .map_err(|err| Error::CustomError(err.to_string()))?;
 
-    environment.shutdown().await;
+    environment.shutdown().await?;
     Ok(())
 }
 

--- a/examples/wasm_runner/src/wasm.rs
+++ b/examples/wasm_runner/src/wasm.rs
@@ -150,6 +150,8 @@ pub async fn wasm_agent(llm: Arc<dyn LLMProvider>) -> Result<(), Error> {
     // Give time for processing
     tokio::time::sleep(tokio::time::Duration::from_secs(10)).await;
 
+    environment.shutdown().await?;
+
     println!("\n✅ WASM Agent example completed!");
     Ok(())
 }

--- a/examples/wasm_runner/src/wasm.rs
+++ b/examples/wasm_runner/src/wasm.rs
@@ -124,7 +124,7 @@ pub async fn wasm_agent(llm: Arc<dyn LLMProvider>) -> Result<(), Error> {
     handle_events(receiver);
 
     // Start the environment
-    let _handle = environment.run();
+    environment.run()?;
 
     // Send WASM computation tasks
     println!("\n📤 Sending WASM computation tasks...");


### PR DESCRIPTION
Replace runtime lookup panics with structured errors, store the run task handle for reliable shutdown, drain actor streaming tasks to completion, and update examples to the run/wait lifecycle API.