### PR TITLE
[BUG]: Add typed HTTP error mapping and retry-after semantics

### DIFF
--- a/bindings/python/autoagents/src/agent/builder.rs
+++ b/bindings/python/autoagents/src/agent/builder.rs
@@ -867,7 +867,10 @@ mod tests {
             let app_meta = task
                 .app_meta
                 .expect("app_meta should round-trip from python payload");
-            assert_eq!(app_meta.get("session_id").and_then(|v| v.as_str()), Some("s1"));
+            assert_eq!(
+                app_meta.get("session_id").and_then(|v| v.as_str()),
+                Some("s1")
+            );
             assert_eq!(app_meta.get("chat_id").and_then(|v| v.as_str()), Some("c1"));
 
             let err = py_task_to_rust_task(

--- a/crates/autoagents-core/src/environment.rs
+++ b/crates/autoagents-core/src/environment.rs
@@ -21,7 +21,7 @@ pub enum EnvironmentError {
     AlreadyRunning,
 
     #[error("Runtime error: {0}")]
-    RuntimeError(#[from] RuntimeError),
+    RuntimeError(#[from] Box<RuntimeError>),
 
     #[error("Error when consuming receiver")]
     EventError,
@@ -217,7 +217,7 @@ impl Environment {
         manager
             .run_background()
             .await
-            .map_err(EnvironmentError::RuntimeError)?;
+            .map_err(|e| EnvironmentError::RuntimeError(Box::new(e)))?;
         self.launch_state = RuntimeLaunchState::Background;
         Ok(())
     }
@@ -270,12 +270,12 @@ impl Environment {
         self.launch_state = RuntimeLaunchState::Idle;
 
         if let Err(e) = stop_result {
-            return Err(EnvironmentError::RuntimeError(e));
+            return Err(EnvironmentError::RuntimeError(Box::new(e)));
         }
 
         match join_result {
             None | Some(Ok(Ok(()))) => Ok(()),
-            Some(Ok(Err(e))) => Err(EnvironmentError::RuntimeError(e)),
+            Some(Ok(Err(e))) => Err(EnvironmentError::RuntimeError(Box::new(e))),
             Some(Err(e)) => Err(EnvironmentError::JoinError(e)),
         }
     }
@@ -333,7 +333,7 @@ impl Environment {
 
         match handle.now_or_never() {
             Some(Ok(Ok(()))) => Ok(()),
-            Some(Ok(Err(e))) => Err(EnvironmentError::RuntimeError(e)),
+            Some(Ok(Err(e))) => Err(EnvironmentError::RuntimeError(Box::new(e))),
             Some(Err(e)) => Err(EnvironmentError::JoinError(e)),
             None => Err(EnvironmentError::RunResultNotReady),
         }

--- a/crates/autoagents-core/src/runtime/mod.rs
+++ b/crates/autoagents-core/src/runtime/mod.rs
@@ -45,7 +45,7 @@ pub enum RuntimeError {
     OperationFailed(String),
 
     #[error("Event error: {0}")]
-    EventError(#[from] SendError<Event>),
+    EventError(#[from] Box<SendError<Event>>),
 }
 
 /// Abstract runtime that manages actor subscriptions, pub/sub delivery, and

--- a/crates/autoagents-core/src/runtime/single_threaded.rs
+++ b/crates/autoagents-core/src/runtime/single_threaded.rs
@@ -87,7 +87,7 @@ impl SingleThreadedRuntime {
         debug!("Received internal event: {event:?}");
         match event {
             InternalEvent::ProtocolEvent(event) => {
-                self.process_protocol_event(event).await?;
+                self.process_protocol_event(*event).await?;
             }
             InternalEvent::Shutdown => {
                 self.shutdown_flag.store(true, Ordering::SeqCst);
@@ -113,7 +113,7 @@ impl SingleThreadedRuntime {
             self.external_tx
                 .send(event)
                 .await
-                .map_err(RuntimeError::EventError)?;
+                .map_err(|e| RuntimeError::EventError(Box::new(e)))?;
         }
         Ok(())
     }
@@ -285,7 +285,10 @@ impl Runtime for SingleThreadedRuntime {
 
         tokio::spawn(async move {
             while let Some(event) = interceptor_rx.recv().await {
-                if let Err(e) = internal_tx.send(InternalEvent::ProtocolEvent(event)).await {
+                if let Err(e) = internal_tx
+                    .send(InternalEvent::ProtocolEvent(Box::new(event)))
+                    .await
+                {
                     error!("Failed to forward event to internal channel: {e}");
                     break;
                 }

--- a/crates/autoagents-llamacpp/src/error.rs
+++ b/crates/autoagents-llamacpp/src/error.rs
@@ -60,10 +60,10 @@ impl From<LlamaCppProviderError> for LLMError {
                 LLMError::ProviderError(format!("Inference failed: {}", e))
             }
             LlamaCppProviderError::Config(e) => {
-                LLMError::InvalidRequest(format!("Invalid configuration: {}", e))
+                LLMError::invalid_request(format!("Invalid configuration: {}", e))
             }
             LlamaCppProviderError::Template(e) => {
-                LLMError::InvalidRequest(format!("Template error: {}", e))
+                LLMError::invalid_request(format!("Template error: {}", e))
             }
             LlamaCppProviderError::Embedding(e) => {
                 LLMError::ProviderError(format!("Embedding failed: {}", e))

--- a/crates/autoagents-llamacpp/src/provider.rs
+++ b/crates/autoagents-llamacpp/src/provider.rs
@@ -691,12 +691,12 @@ impl LlamaCppProvider {
                 }
                 //TODO: Get a FIX
                 MessageType::ToolUse(_) | MessageType::ToolResult(_) => {
-                    return Err(LLMError::InvalidRequest(
+                    return Err(LLMError::invalid_request(
                         "MTMD path does not support tool calls".to_string(),
                     ));
                 }
                 MessageType::ImageURL(_) | MessageType::Pdf(_) => {
-                    return Err(LLMError::InvalidRequest(
+                    return Err(LLMError::invalid_request(
                         "MTMD path only supports raw image inputs".to_string(),
                     ));
                 }
@@ -1172,7 +1172,7 @@ impl LlamaCppProvider {
 
         if Self::has_mtmd_media(messages) {
             if tools.is_some() || json_schema.is_some() {
-                return Err(LLMError::InvalidRequest(
+                return Err(LLMError::invalid_request(
                     "MTMD path does not support tools or structured outputs".to_string(),
                 ));
             }
@@ -1222,7 +1222,7 @@ impl LlamaCppProvider {
             }
             #[cfg(not(feature = "mtmd"))]
             {
-                return Err(LLMError::InvalidRequest(
+                return Err(LLMError::invalid_request(
                     "MTMD feature is not enabled for llama.cpp backend".to_string(),
                 ));
             }
@@ -1341,7 +1341,7 @@ impl LlamaCppProvider {
             }
             #[cfg(not(feature = "mtmd"))]
             {
-                return Err(LLMError::InvalidRequest(
+                return Err(LLMError::invalid_request(
                     "MTMD feature is not enabled for llama.cpp backend".to_string(),
                 ));
             }
@@ -1402,7 +1402,7 @@ impl LlamaCppProvider {
             #[cfg(feature = "mtmd")]
             {
                 if tools.is_some() || json_schema.is_some() {
-                    return Err(LLMError::InvalidRequest(
+                    return Err(LLMError::invalid_request(
                         "MTMD path does not support tools or structured outputs".to_string(),
                     ));
                 }
@@ -1420,7 +1420,7 @@ impl LlamaCppProvider {
             }
             #[cfg(not(feature = "mtmd"))]
             {
-                return Err(LLMError::InvalidRequest(
+                return Err(LLMError::invalid_request(
                     "MTMD feature is not enabled for llama.cpp backend".to_string(),
                 ));
             }
@@ -1470,7 +1470,7 @@ impl LlamaCppProvider {
 
         if Self::has_mtmd_media(messages) {
             if tools.is_some() || json_schema.is_some() {
-                return Err(LLMError::InvalidRequest(
+                return Err(LLMError::invalid_request(
                     "MTMD path does not support tools or structured outputs".to_string(),
                 ));
             }
@@ -1490,7 +1490,7 @@ impl LlamaCppProvider {
             }
             #[cfg(not(feature = "mtmd"))]
             {
-                return Err(LLMError::InvalidRequest(
+                return Err(LLMError::invalid_request(
                     "MTMD feature is not enabled for llama.cpp backend".to_string(),
                 ));
             }
@@ -1722,13 +1722,13 @@ fn ensure_supported_messages_for_config(
                         continue;
                     }
                 }
-                return Err(LLMError::InvalidRequest(
+                return Err(LLMError::invalid_request(
                     "llama.cpp backend does not support image inputs without MTMD and mmproj configured"
                         .to_string(),
                 ));
             }
             MessageType::ImageURL(_) | MessageType::Pdf(_) => {
-                return Err(LLMError::InvalidRequest(
+                return Err(LLMError::invalid_request(
                     "llama.cpp backend does not support image URL or PDF inputs".to_string(),
                 ));
             }

--- a/crates/autoagents-llm/src/backends/anthropic.rs
+++ b/crates/autoagents-llm/src/backends/anthropic.rs
@@ -667,8 +667,11 @@ impl ChatProvider for Anthropic {
         let resp = ensure_success(resp, "Anthropic").await?;
 
         let body = resp.text().await?;
-        let json_resp: AnthropicCompleteResponse = serde_json::from_str(&body)
-            .map_err(|e| LLMError::HttpError(format!("Failed to parse JSON: {e}")))?;
+        let json_resp: AnthropicCompleteResponse =
+            serde_json::from_str(&body).map_err(|e| LLMError::ResponseFormatError {
+                message: format!("Failed to decode Anthropic response: {e}"),
+                raw_response: body,
+            })?;
         Ok(Box::new(json_resp))
     }
 

--- a/crates/autoagents-llm/src/backends/anthropic.rs
+++ b/crates/autoagents-llm/src/backends/anthropic.rs
@@ -12,8 +12,10 @@ use crate::{
         StructuredOutputFormat, Tool, ToolChoice, Usage,
     },
     completion::{CompletionProvider, CompletionRequest, CompletionResponse},
+    config::resolve_request_timeout,
     embedding::EmbeddingProvider,
     error::LLMError,
+    http::ensure_success,
     models::{ModelListRawEntry, ModelListRequest, ModelListResponse, ModelsProvider},
 };
 use async_trait::async_trait;
@@ -451,7 +453,7 @@ impl Anthropic {
             .collect();
 
         if anthropic_messages.is_empty() {
-            return Err(LLMError::InvalidRequest(
+            return Err(LLMError::invalid_request(
                 "At least one non-system message is required".to_string(),
             ));
         }
@@ -547,7 +549,7 @@ impl Anthropic {
     /// * `model` - Model identifier (defaults to "claude-3-sonnet-20240229")
     /// * `max_tokens` - Maximum tokens in response (defaults to 300)
     /// * `temperature` - Sampling temperature (defaults to 0.7)
-    /// * `timeout_seconds` - Request timeout in seconds (defaults to 30)
+    /// * `timeout_seconds` - Request timeout in seconds (defaults to 120)
     /// *
     /// * `thinking_budget_tokens` - Budget tokens for thinking (optional)
     #[allow(clippy::too_many_arguments)]
@@ -563,22 +565,23 @@ impl Anthropic {
         reasoning: Option<bool>,
         thinking_budget_tokens: Option<u32>,
     ) -> Self {
-        let mut builder = Client::builder();
-        if let Some(sec) = timeout_seconds {
-            builder = builder.timeout(std::time::Duration::from_secs(sec));
-        }
+        let timeout_seconds = resolve_request_timeout(timeout_seconds);
+        let client = Client::builder()
+            .timeout(std::time::Duration::from_secs(timeout_seconds))
+            .build()
+            .expect("Failed to build reqwest Client");
         Self {
             api_key: api_key.into(),
             model: model.unwrap_or_else(|| "claude-3-sonnet-20240229".to_string()),
             max_tokens: max_tokens.unwrap_or(300),
             temperature: temperature.unwrap_or(0.7),
-            timeout_seconds: timeout_seconds.unwrap_or(30),
+            timeout_seconds,
             top_p,
             top_k,
             tool_choice,
             reasoning: reasoning.unwrap_or(false),
             thinking_budget_tokens,
-            client: builder.build().expect("Failed to build reqwest Client"),
+            client,
         }
     }
 }
@@ -603,7 +606,9 @@ impl ChatProvider for Anthropic {
         json_schema: Option<StructuredOutputFormat>,
     ) -> Result<Box<dyn ChatResponse>, LLMError> {
         if self.api_key.is_empty() {
-            return Err(LLMError::AuthError("Missing Anthropic API key".to_string()));
+            return Err(LLMError::missing_api_key(
+                "Missing Anthropic API key".to_string(),
+            ));
         }
 
         let anthropic_messages = Self::convert_messages_to_anthropic(messages)?;
@@ -641,17 +646,13 @@ impl ChatProvider for Anthropic {
             output_config,
         };
 
-        let mut request = self
+        let request = self
             .client
             .post("https://api.anthropic.com/v1/messages")
             .header("x-api-key", &self.api_key)
             .header("Content-Type", "application/json")
             .header("anthropic-version", "2023-06-01")
             .json(&req_body);
-
-        if self.timeout_seconds > 0 {
-            request = request.timeout(std::time::Duration::from_secs(self.timeout_seconds));
-        }
 
         if log::log_enabled!(log::Level::Trace)
             && let Ok(json) = serde_json::to_string(&req_body)
@@ -663,7 +664,7 @@ impl ChatProvider for Anthropic {
         let resp = request.send().await?;
         log::debug!("Anthropic HTTP status: {}", resp.status());
 
-        let resp = resp.error_for_status()?;
+        let resp = ensure_success(resp, "Anthropic").await?;
 
         let body = resp.text().await?;
         let json_resp: AnthropicCompleteResponse = serde_json::from_str(&body)
@@ -706,12 +707,14 @@ impl ChatProvider for Anthropic {
     ) -> Result<std::pin::Pin<Box<dyn Stream<Item = Result<String, LLMError>> + Send>>, LLMError>
     {
         if self.api_key.is_empty() {
-            return Err(LLMError::AuthError("Missing Anthropic API key".to_string()));
+            return Err(LLMError::missing_api_key(
+                "Missing Anthropic API key".to_string(),
+            ));
         }
 
         let req_body = self.build_stream_request(messages, json_schema)?;
 
-        let mut request = self
+        let request = self
             .client
             .post("https://api.anthropic.com/v1/messages")
             .header("x-api-key", &self.api_key)
@@ -719,19 +722,8 @@ impl ChatProvider for Anthropic {
             .header("anthropic-version", "2023-06-01")
             .json(&req_body);
 
-        if self.timeout_seconds > 0 {
-            request = request.timeout(std::time::Duration::from_secs(self.timeout_seconds));
-        }
-
         let response = request.send().await?;
-        if !response.status().is_success() {
-            let status = response.status();
-            let error_text = response.text().await?;
-            return Err(LLMError::ResponseFormatError {
-                message: format!("Anthropic API returned error status: {status}"),
-                raw_response: error_text,
-            });
-        }
+        let response = ensure_success(response, "Anthropic").await?;
         Ok(crate::chat::create_sse_stream(
             response,
             parse_anthropic_sse_chunk,
@@ -758,7 +750,9 @@ impl ChatProvider for Anthropic {
     ) -> Result<std::pin::Pin<Box<dyn Stream<Item = Result<StreamChunk, LLMError>> + Send>>, LLMError>
     {
         if self.api_key.is_empty() {
-            return Err(LLMError::AuthError("Missing Anthropic API key".to_string()));
+            return Err(LLMError::missing_api_key(
+                "Missing Anthropic API key".to_string(),
+            ));
         }
 
         let anthropic_messages = Self::convert_messages_to_anthropic(messages)?;
@@ -789,17 +783,13 @@ impl ChatProvider for Anthropic {
             output_config: build_output_config(json_schema),
         };
 
-        let mut request = self
+        let request = self
             .client
             .post("https://api.anthropic.com/v1/messages")
             .header("x-api-key", &self.api_key)
             .header("Content-Type", "application/json")
             .header("anthropic-version", "2023-06-01")
             .json(&req_body);
-
-        if self.timeout_seconds > 0 {
-            request = request.timeout(std::time::Duration::from_secs(self.timeout_seconds));
-        }
 
         if log::log_enabled!(log::Level::Trace)
             && let Ok(json) = serde_json::to_string(&req_body)
@@ -811,14 +801,7 @@ impl ChatProvider for Anthropic {
         let response = request.send().await?;
         log::debug!("Anthropic HTTP status: {}", response.status());
 
-        if !response.status().is_success() {
-            let status = response.status();
-            let error_text = response.text().await?;
-            return Err(LLMError::ResponseFormatError {
-                message: format!("Anthropic API returned error status: {status}"),
-                raw_response: error_text,
-            });
-        }
+        let response = ensure_success(response, "Anthropic").await?;
 
         Ok(create_anthropic_tool_stream(response))
     }
@@ -1147,7 +1130,7 @@ fn parse_anthropic_sse_chunk_with_tools(
 impl LLMBuilder<Anthropic> {
     pub fn build(self) -> Result<Arc<Anthropic>, LLMError> {
         let api_key = self.api_key.ok_or_else(|| {
-            LLMError::InvalidRequest("No API key provided for Anthropic".to_string())
+            LLMError::invalid_request("No API key provided for Anthropic".to_string())
         })?;
 
         let anthro = Anthropic::new(
@@ -1737,7 +1720,7 @@ data: {"type": "ping"}
 
         assert!(matches!(
             err,
-            LLMError::InvalidRequest(message)
+            LLMError::InvalidRequest { message, .. }
                 if message == "At least one non-system message is required"
         ));
     }
@@ -1826,7 +1809,7 @@ data: {"type": "ping"}
             .chat_with_tools(&[ChatMessage::user().content("hello").build()], None, None)
             .await
             .expect_err("missing api key should fail");
-        assert!(matches!(auth_err, LLMError::AuthError(_)));
+        assert!(matches!(auth_err, LLMError::AuthError { .. }));
 
         let invalid = Anthropic::new("key", None, None, None, None, None, None, None, None, None)
             .chat_with_tools(
@@ -1840,7 +1823,7 @@ data: {"type": "ping"}
             )
             .await
             .expect_err("system-only messages should be rejected");
-        assert!(matches!(invalid, LLMError::InvalidRequest(_)));
+        assert!(matches!(invalid, LLMError::InvalidRequest { .. }));
 
         let stream_auth_err =
             match Anthropic::new("", None, None, None, None, None, None, None, None, None)
@@ -1850,7 +1833,7 @@ data: {"type": "ping"}
                 Ok(_) => panic!("missing api key should fail for chat_stream"),
                 Err(err) => err,
             };
-        assert!(matches!(stream_auth_err, LLMError::AuthError(_)));
+        assert!(matches!(stream_auth_err, LLMError::AuthError { .. }));
 
         let stream_invalid =
             match Anthropic::new("key", None, None, None, None, None, None, None, None, None)
@@ -1867,7 +1850,7 @@ data: {"type": "ping"}
                 Ok(_) => panic!("system-only streaming messages should be rejected"),
                 Err(err) => err,
             };
-        assert!(matches!(stream_invalid, LLMError::InvalidRequest(_)));
+        assert!(matches!(stream_invalid, LLMError::InvalidRequest { .. }));
     }
 
     #[tokio::test]

--- a/crates/autoagents-llm/src/backends/anthropic.rs
+++ b/crates/autoagents-llm/src/backends/anthropic.rs
@@ -952,6 +952,7 @@ impl ModelsProvider for Anthropic {
             .send()
             .await?;
 
+        let resp = ensure_success(resp, "Anthropic").await?;
         let result: AnthropicModelListResponse = resp.json().await?;
 
         Ok(Box::new(result))
@@ -1705,6 +1706,29 @@ data: {"type": "ping"}
             tool_use.tool_input,
             Some(Value::String("not-json".to_string()))
         );
+    }
+
+    #[tokio::test]
+    async fn test_list_models_maps_401_to_auth_error() {
+        let server = httpmock::MockServer::start();
+        let _mock = server.mock(|when, then| {
+            when.method(httpmock::Method::GET).path("/v1/models");
+            then.status(401)
+                .body(r#"{"error":{"message":"invalid key"}}"#);
+        });
+
+        let client = reqwest::Client::new();
+        let resp = client
+            .get(format!("{}/v1/models", server.base_url()))
+            .header("x-api-key", "key")
+            .send()
+            .await
+            .expect("request should complete");
+
+        let err = ensure_success(resp, "Anthropic")
+            .await
+            .expect_err("401 should map to AuthError");
+        assert!(matches!(err, LLMError::AuthError { .. }));
     }
 
     #[test]

--- a/crates/autoagents-llm/src/backends/azure_openai.rs
+++ b/crates/autoagents-llm/src/backends/azure_openai.rs
@@ -8,7 +8,9 @@ use crate::{
     FunctionCall, ToolCall,
     builder::LLMBuilder,
     chat::{ChatResponse, ToolChoice},
+    config::resolve_request_timeout,
     embedding::EmbeddingBuilder,
+    http::ensure_success,
 };
 #[cfg(feature = "azure_openai")]
 use crate::{
@@ -35,7 +37,7 @@ pub struct AzureOpenAI {
     pub model: String,
     pub max_tokens: Option<u32>,
     pub temperature: Option<f32>,
-    pub timeout_seconds: Option<u64>,
+    pub timeout_seconds: u64,
     pub top_p: Option<f32>,
     pub top_k: Option<u32>,
     pub tool_choice: Option<ToolChoice>,
@@ -83,13 +85,13 @@ impl<'a> TryFrom<&'a ChatMessage> for AzureOpenAIChatMessage<'a> {
             content: match &chat_msg.message_type {
                 MessageType::Text => Some(Right(chat_msg.content.clone())),
                 MessageType::Image(_) => {
-                    return Err(LLMError::InvalidRequest(
+                    return Err(LLMError::invalid_request(
                         "Raw image input is not supported by the Azure OpenAI chat backend"
                             .to_string(),
                     ));
                 }
                 MessageType::Pdf(_) => {
-                    return Err(LLMError::InvalidRequest(
+                    return Err(LLMError::invalid_request(
                         "PDF input is not supported by the Azure OpenAI chat backend".to_string(),
                     ));
                 }
@@ -389,10 +391,11 @@ impl AzureOpenAI {
         tool_choice: Option<ToolChoice>,
         reasoning_effort: Option<String>,
     ) -> Self {
-        let mut builder = Client::builder();
-        if let Some(sec) = timeout_seconds {
-            builder = builder.timeout(std::time::Duration::from_secs(sec));
-        }
+        let timeout_seconds = resolve_request_timeout(timeout_seconds);
+        let client = Client::builder()
+            .timeout(std::time::Duration::from_secs(timeout_seconds))
+            .build()
+            .expect("Failed to build reqwest Client");
 
         let endpoint = endpoint.into();
         let deployment_id = deployment_id.into();
@@ -411,7 +414,7 @@ impl AzureOpenAI {
             tool_choice,
             embedding_encoding_format,
             embedding_dimensions,
-            client: builder.build().expect("Failed to build reqwest Client"),
+            client,
             reasoning_effort,
         }
     }
@@ -435,7 +438,7 @@ impl ChatProvider for AzureOpenAI {
         json_schema: Option<StructuredOutputFormat>,
     ) -> Result<Box<dyn ChatResponse>, LLMError> {
         if self.api_key.is_empty() {
-            return Err(LLMError::AuthError(
+            return Err(LLMError::missing_api_key(
                 "Missing Azure OpenAI API key".to_string(),
             ));
         }
@@ -480,30 +483,18 @@ impl ChatProvider for AzureOpenAI {
         url.query_pairs_mut()
             .append_pair("api-version", &self.api_version);
 
-        let mut request = self
+        let request = self
             .client
             .post(url)
             .header("api-key", &self.api_key)
             .json(&body);
-
-        if let Some(timeout) = self.timeout_seconds {
-            request = request.timeout(std::time::Duration::from_secs(timeout));
-        }
 
         // Send the request
         let response = request.send().await?;
 
         log::debug!("Azure OpenAI HTTP status: {}", response.status());
 
-        // If we got a non-200 response, let's get the error details
-        if !response.status().is_success() {
-            let status = response.status();
-            let error_text = response.text().await?;
-            return Err(LLMError::ResponseFormatError {
-                message: format!("OpenAI API returned error status: {status}"),
-                raw_response: error_text,
-            });
-        }
+        let response = ensure_success(response, "Azure OpenAI").await?;
 
         // Parse the successful response
         let resp_text = response.text().await?;
@@ -559,7 +550,9 @@ impl crate::HasConfig for AzureOpenAI {
 impl EmbeddingProvider for AzureOpenAI {
     async fn embed(&self, input: Vec<String>) -> Result<Vec<Vec<f32>>, LLMError> {
         if self.api_key.is_empty() {
-            return Err(LLMError::AuthError("Missing OpenAI API key".into()));
+            return Err(LLMError::missing_api_key(
+                "Missing OpenAI API key".to_string(),
+            ));
         }
 
         let emb_format = self
@@ -588,8 +581,8 @@ impl EmbeddingProvider for AzureOpenAI {
             .header("api-key", &self.api_key)
             .json(&body)
             .send()
-            .await?
-            .error_for_status()?;
+            .await?;
+        let resp = ensure_success(resp, "Azure OpenAI").await?;
 
         let json_resp: OpenAIEmbeddingResponse = resp.json().await?;
 
@@ -604,19 +597,19 @@ impl ModelsProvider for AzureOpenAI {}
 impl LLMBuilder<AzureOpenAI> {
     pub fn build(self) -> Result<Arc<AzureOpenAI>, LLMError> {
         let endpoint = self.base_url.ok_or_else(|| {
-            LLMError::InvalidRequest("No API endpoint provided for Azure OpenAI".into())
+            LLMError::invalid_request("No API endpoint provided for Azure OpenAI")
         })?;
 
         let key = self.api_key.ok_or_else(|| {
-            LLMError::InvalidRequest("No API key provided for Azure OpenAI".to_string())
+            LLMError::invalid_request("No API key provided for Azure OpenAI".to_string())
         })?;
 
         let api_version = self.api_version.ok_or_else(|| {
-            LLMError::InvalidRequest("No API version provided for Azure OpenAI".to_string())
+            LLMError::invalid_request("No API version provided for Azure OpenAI".to_string())
         })?;
 
         let deployment = self.deployment_id.ok_or_else(|| {
-            LLMError::InvalidRequest("No deployment ID provided for Azure OpenAI".into())
+            LLMError::invalid_request("No deployment ID provided for Azure OpenAI")
         })?;
 
         let provider = AzureOpenAI::new(
@@ -644,16 +637,16 @@ impl EmbeddingBuilder<AzureOpenAI> {
     /// Build an Azure OpenAI embedding provider.
     pub fn build(self) -> Result<Arc<AzureOpenAI>, LLMError> {
         let api_key = self.api_key.ok_or_else(|| {
-            LLMError::InvalidRequest("No API key provided for Azure OpenAI".to_string())
+            LLMError::invalid_request("No API key provided for Azure OpenAI".to_string())
         })?;
         let api_version = self.api_version.ok_or_else(|| {
-            LLMError::InvalidRequest("No API version provided for Azure OpenAI".to_string())
+            LLMError::invalid_request("No API version provided for Azure OpenAI".to_string())
         })?;
         let deployment_id = self.deployment_id.ok_or_else(|| {
-            LLMError::InvalidRequest("No deployment ID provided for Azure OpenAI".to_string())
+            LLMError::invalid_request("No deployment ID provided for Azure OpenAI".to_string())
         })?;
         let endpoint = self.base_url.ok_or_else(|| {
-            LLMError::InvalidRequest("No API endpoint provided for Azure OpenAI".to_string())
+            LLMError::invalid_request("No API endpoint provided for Azure OpenAI".to_string())
         })?;
 
         let provider = AzureOpenAI::new(
@@ -716,7 +709,7 @@ mod tests {
 
         assert!(matches!(
             err,
-            LLMError::InvalidRequest(message)
+            LLMError::InvalidRequest { message, .. }
                 if message == "Raw image input is not supported by the Azure OpenAI chat backend"
         ));
     }
@@ -763,7 +756,7 @@ mod tests {
 
         assert!(matches!(
             err,
-            LLMError::InvalidRequest(message)
+            LLMError::InvalidRequest { message, .. }
                 if message == "Raw image input is not supported by the Azure OpenAI chat backend"
         ));
     }
@@ -780,7 +773,7 @@ mod tests {
 
         assert!(matches!(
             err,
-            LLMError::InvalidRequest(message)
+            LLMError::InvalidRequest { message, .. }
                 if message == "PDF input is not supported by the Azure OpenAI chat backend"
         ));
     }
@@ -975,12 +968,13 @@ mod tests {
             .await
             .expect_err("error status should fail");
         match err {
-            LLMError::ResponseFormatError {
-                message,
-                raw_response,
+            LLMError::HttpStatusError {
+                status_code,
+                response_body,
+                ..
             } => {
-                assert!(message.contains("returned error status"));
-                assert_eq!(raw_response, "azure down");
+                assert_eq!(status_code, 500);
+                assert_eq!(response_body.as_ref(), "azure down");
             }
             other => panic!("unexpected error: {other:?}"),
         }

--- a/crates/autoagents-llm/src/backends/deepseek.rs
+++ b/crates/autoagents-llm/src/backends/deepseek.rs
@@ -184,7 +184,9 @@ impl CompletionProvider for DeepSeek {
         _json_schema: Option<StructuredOutputFormat>,
     ) -> Result<CompletionResponse, LLMError> {
         if self.api_key().is_empty() {
-            return Err(LLMError::AuthError("Missing DeepSeek API key".into()));
+            return Err(LLMError::missing_api_key(
+                "Missing DeepSeek API key".to_string(),
+            ));
         }
         Err(LLMError::ProviderError(
             "DeepSeek completion not implemented yet".into(),
@@ -213,7 +215,7 @@ impl crate::HasConfig for DeepSeek {
 impl LLMBuilder<DeepSeek> {
     pub fn build(self) -> Result<Arc<DeepSeek>, LLMError> {
         let api_key = self.api_key.ok_or_else(|| {
-            LLMError::InvalidRequest("No API key provided for DeepSeek".to_string())
+            LLMError::invalid_request("No API key provided for DeepSeek".to_string())
         })?;
 
         let deepseek = DeepSeek::new(

--- a/crates/autoagents-llm/src/backends/google.rs
+++ b/crates/autoagents-llm/src/backends/google.rs
@@ -21,8 +21,10 @@ use crate::{
         Tool,
     },
     completion::{CompletionProvider, CompletionRequest, CompletionResponse},
+    config::resolve_request_timeout,
     embedding::{EmbeddingBuilder, EmbeddingProvider},
     error::LLMError,
+    http::ensure_success,
     models::ModelsProvider,
 };
 use async_trait::async_trait;
@@ -48,7 +50,7 @@ pub struct Google {
     /// Sampling temperature between 0.0 and 1.0
     pub temperature: Option<f32>,
     /// Request timeout in seconds
-    pub timeout_seconds: Option<u64>,
+    pub timeout_seconds: u64,
     /// Top-p sampling parameter
     pub top_p: Option<f32>,
     /// Top-k sampling parameter
@@ -461,10 +463,11 @@ impl Google {
         top_p: Option<f32>,
         top_k: Option<u32>,
     ) -> Self {
-        let mut builder = Client::builder();
-        if let Some(sec) = timeout_seconds {
-            builder = builder.timeout(std::time::Duration::from_secs(sec));
-        }
+        let timeout_seconds = resolve_request_timeout(timeout_seconds);
+        let client = Client::builder()
+            .timeout(std::time::Duration::from_secs(timeout_seconds))
+            .build()
+            .expect("Failed to build reqwest Client");
         Self {
             api_key: api_key.into(),
             model: model.unwrap_or_else(|| "gemini-1.5-flash".to_string()),
@@ -473,7 +476,7 @@ impl Google {
             timeout_seconds,
             top_p,
             top_k,
-            client: builder.build().expect("Failed to build reqwest Client"),
+            client,
         }
     }
 
@@ -494,7 +497,9 @@ impl Google {
         json_schema: Option<StructuredOutputFormat>,
     ) -> Result<Box<dyn ChatResponse>, LLMError> {
         if self.api_key.is_empty() {
-            return Err(LLMError::AuthError("Missing Google API key".to_string()));
+            return Err(LLMError::missing_api_key(
+                "Missing Google API key".to_string(),
+            ));
         }
 
         let chat_contents = build_google_chat_contents(messages)?;
@@ -525,17 +530,11 @@ impl Google {
             key = self.api_key
         );
 
-        let mut request = self.client.post(&url).json(&req_body);
-
-        if let Some(timeout) = self.timeout_seconds {
-            request = request.timeout(std::time::Duration::from_secs(timeout));
-        }
-
-        let resp = request.send().await?;
+        let resp = self.client.post(&url).json(&req_body).send().await?;
 
         log::debug!("Google Gemini HTTP status (tool): {}", resp.status());
 
-        let resp = resp.error_for_status()?;
+        let resp = ensure_success(resp, "Google").await?;
 
         // Get the raw response text for debugging
         let resp_text = resp.text().await?;
@@ -603,7 +602,9 @@ impl ChatProvider for Google {
     ) -> Result<std::pin::Pin<Box<dyn Stream<Item = Result<String, LLMError>> + Send>>, LLMError>
     {
         if self.api_key.is_empty() {
-            return Err(LLMError::AuthError("Missing Google API key".to_string()));
+            return Err(LLMError::missing_api_key(
+                "Missing Google API key".to_string(),
+            ));
         }
 
         let chat_contents = build_google_stream_contents(messages)?;
@@ -626,22 +627,9 @@ impl ChatProvider for Google {
             key = self.api_key
         );
 
-        let mut request = self.client.post(&url).json(&req_body);
+        let response = self.client.post(&url).json(&req_body).send().await?;
 
-        if let Some(timeout) = self.timeout_seconds {
-            request = request.timeout(std::time::Duration::from_secs(timeout));
-        }
-
-        let response = request.send().await?;
-
-        if !response.status().is_success() {
-            let status = response.status();
-            let error_text = response.text().await?;
-            return Err(LLMError::ResponseFormatError {
-                message: format!("Google API returned error status: {status}"),
-                raw_response: error_text,
-            });
-        }
+        let response = ensure_success(response, "Google").await?;
 
         Ok(crate::chat::create_sse_stream(
             response,
@@ -685,7 +673,9 @@ impl CompletionProvider for Google {
 impl EmbeddingProvider for Google {
     async fn embed(&self, texts: Vec<String>) -> Result<Vec<Vec<f32>>, LLMError> {
         if self.api_key.is_empty() {
-            return Err(LLMError::AuthError("Missing Google API key".to_string()));
+            return Err(LLMError::missing_api_key(
+                "Missing Google API key".to_string(),
+            ));
         }
 
         let mut embeddings = Vec::new();
@@ -704,13 +694,8 @@ impl EmbeddingProvider for Google {
                 self.api_key
             );
 
-            let resp = self
-                .client
-                .post(&url)
-                .json(&req_body)
-                .send()
-                .await?
-                .error_for_status()?;
+            let resp = self.client.post(&url).json(&req_body).send().await?;
+            let resp = ensure_success(resp, "Google").await?;
 
             let embedding_resp: GoogleEmbeddingResponse = resp.json().await?;
             embeddings.push(embedding_resp.embedding.values);
@@ -788,7 +773,7 @@ fn build_google_chat_contents(
                     })]
                 }
                 MessageType::ImageURL(_) => {
-                    return Err(LLMError::InvalidRequest(
+                    return Err(LLMError::invalid_request(
                         "Image URL input is not supported by the Google Gemini backend".to_string(),
                     ));
                 }
@@ -901,7 +886,7 @@ impl ModelsProvider for Google {}
 impl LLMBuilder<Google> {
     pub fn build(self) -> Result<Arc<Google>, LLMError> {
         let api_key = self.api_key.ok_or_else(|| {
-            LLMError::InvalidRequest("No API key provided for Google".to_string())
+            LLMError::invalid_request("No API key provided for Google".to_string())
         })?;
 
         let google = Google::new(
@@ -922,7 +907,7 @@ impl EmbeddingBuilder<Google> {
     /// Build a Google embedding provider.
     pub fn build(self) -> Result<Arc<Google>, LLMError> {
         let api_key = self.api_key.ok_or_else(|| {
-            LLMError::InvalidRequest("No API key provided for Google".to_string())
+            LLMError::invalid_request("No API key provided for Google".to_string())
         })?;
 
         let provider = Google::new(
@@ -1146,7 +1131,7 @@ mod tests {
 
         assert!(matches!(
             err,
-            LLMError::InvalidRequest(message)
+            LLMError::InvalidRequest { message, .. }
                 if message == "Image URL input is not supported by the Google Gemini backend"
         ));
     }
@@ -1166,7 +1151,7 @@ mod tests {
 
         assert!(matches!(
             err,
-            LLMError::InvalidRequest(message)
+            LLMError::InvalidRequest { message, .. }
                 if message == "Image URL input is not supported by the Google Gemini backend"
         ));
     }

--- a/crates/autoagents-llm/src/backends/groq.rs
+++ b/crates/autoagents-llm/src/backends/groq.rs
@@ -3,6 +3,7 @@
 //! This module provides integration with Groq's LLM models through their API.
 
 use crate::builder::LLMBuilder;
+use crate::http::ensure_success;
 use crate::{
     LLMProvider,
     builder::LLMBackend,
@@ -120,7 +121,9 @@ impl ModelsProvider for Groq {
         _request: Option<&ModelListRequest>,
     ) -> Result<Box<dyn ModelListResponse>, LLMError> {
         if self.api_key.is_empty() {
-            return Err(LLMError::AuthError("Missing Groq API key".to_string()));
+            return Err(LLMError::missing_api_key(
+                "Missing Groq API key".to_string(),
+            ));
         }
 
         let url = format!("{}/models", GroqConfig::DEFAULT_BASE_URL);
@@ -130,8 +133,8 @@ impl ModelsProvider for Groq {
             .get(&url)
             .bearer_auth(&self.api_key)
             .send()
-            .await?
-            .error_for_status()?;
+            .await?;
+        let resp = ensure_success(resp, "Groq").await?;
 
         let result = StandardModelListResponse {
             inner: resp.json().await?,
@@ -145,7 +148,7 @@ impl LLMBuilder<Groq> {
     pub fn build(self) -> Result<Arc<Groq>, LLMError> {
         let api_key = self
             .api_key
-            .ok_or_else(|| LLMError::InvalidRequest("No API key provided for Groq".to_string()))?;
+            .ok_or_else(|| LLMError::invalid_request("No API key provided for Groq".to_string()))?;
 
         let groq = Groq::with_config(
             api_key,
@@ -199,7 +202,7 @@ mod tests {
         assert_eq!(provider.model, GroqConfig::DEFAULT_MODEL);
         assert_eq!(provider.max_tokens, Some(200));
         assert_eq!(provider.temperature, Some(0.5));
-        assert_eq!(provider.timeout_seconds, Some(12));
+        assert_eq!(provider.timeout_seconds, 12);
     }
 
     #[tokio::test]

--- a/crates/autoagents-llm/src/backends/minimax.rs
+++ b/crates/autoagents-llm/src/backends/minimax.rs
@@ -4,6 +4,7 @@
 //! OpenAI-compatible API. Supports MiniMax-M2.5 and MiniMax-M2.5-highspeed models.
 
 use crate::builder::LLMBuilder;
+use crate::http::ensure_success;
 use crate::{
     LLMProvider,
     builder::LLMBackend,
@@ -107,7 +108,9 @@ impl ModelsProvider for MiniMax {
         _request: Option<&ModelListRequest>,
     ) -> Result<Box<dyn ModelListResponse>, LLMError> {
         if self.api_key.is_empty() {
-            return Err(LLMError::AuthError("Missing MiniMax API key".to_string()));
+            return Err(LLMError::missing_api_key(
+                "Missing MiniMax API key".to_string(),
+            ));
         }
 
         let url = format!("{}models", MiniMaxConfig::DEFAULT_BASE_URL);
@@ -117,8 +120,8 @@ impl ModelsProvider for MiniMax {
             .get(&url)
             .bearer_auth(&self.api_key)
             .send()
-            .await?
-            .error_for_status()?;
+            .await?;
+        let resp = ensure_success(resp, "MiniMax").await?;
 
         let result = StandardModelListResponse {
             inner: resp.json().await?,
@@ -132,7 +135,7 @@ impl LLMBuilder<MiniMax> {
     /// Builds the MiniMax provider from the configured builder.
     pub fn build(self) -> Result<Arc<MiniMax>, LLMError> {
         let api_key = self.api_key.ok_or_else(|| {
-            LLMError::InvalidRequest("No API key provided for MiniMax".to_string())
+            LLMError::invalid_request("No API key provided for MiniMax".to_string())
         })?;
 
         let minimax = MiniMax::with_config(
@@ -183,7 +186,7 @@ mod tests {
         assert_eq!(provider.model, MiniMaxConfig::DEFAULT_MODEL);
         assert_eq!(provider.max_tokens, Some(200));
         assert_eq!(provider.temperature, Some(0.5));
-        assert_eq!(provider.timeout_seconds, Some(12));
+        assert_eq!(provider.timeout_seconds, 12);
     }
 
     #[test]

--- a/crates/autoagents-llm/src/backends/ollama.rs
+++ b/crates/autoagents-llm/src/backends/ollama.rs
@@ -10,8 +10,10 @@ use crate::{
         Tool,
     },
     completion::{CompletionProvider, CompletionRequest, CompletionResponse},
+    config::resolve_request_timeout,
     embedding::{EmbeddingBuilder, EmbeddingProvider},
     error::LLMError,
+    http::ensure_success,
     models::ModelsProvider,
 };
 use async_trait::async_trait;
@@ -45,7 +47,7 @@ pub struct Ollama {
     pub model: String,
     pub max_tokens: Option<u32>,
     pub temperature: Option<f32>,
-    pub timeout_seconds: Option<u64>,
+    pub timeout_seconds: u64,
     pub top_p: Option<f32>,
     pub top_k: Option<u32>,
     pub keep_alive: Option<String>,
@@ -447,10 +449,11 @@ impl Ollama {
         repeat_last_n: Option<i32>,
         min_p: Option<f32>,
     ) -> Self {
-        let mut builder = Client::builder();
-        if let Some(sec) = timeout_seconds {
-            builder = builder.timeout(std::time::Duration::from_secs(sec));
-        }
+        let timeout_seconds = resolve_request_timeout(timeout_seconds);
+        let client = Client::builder()
+            .timeout(std::time::Duration::from_secs(timeout_seconds))
+            .build()
+            .expect("Failed to build reqwest Client");
         Self {
             base_url: base_url.into(),
             api_key,
@@ -471,7 +474,7 @@ impl Ollama {
             repeat_penalty,
             repeat_last_n,
             min_p,
-            client: builder.build().expect("Failed to build reqwest Client"),
+            client,
         }
     }
 
@@ -482,7 +485,7 @@ impl Ollama {
         json_schema: Option<StructuredOutputFormat>,
     ) -> Result<Box<dyn ChatResponse>, LLMError> {
         if self.base_url.is_empty() {
-            return Err(LLMError::InvalidRequest("Missing base_url".to_string()));
+            return Err(LLMError::invalid_request("Missing base_url".to_string()));
         }
 
         let chat_messages: Vec<OllamaChatMessage> = messages
@@ -550,17 +553,11 @@ impl Ollama {
 
         let url = format!("{}/api/chat", self.base_url);
 
-        let mut request = self.client.post(&url).json(&req_body);
-
-        if let Some(timeout) = self.timeout_seconds {
-            request = request.timeout(std::time::Duration::from_secs(timeout));
-        }
-
-        let resp = request.send().await?;
+        let resp = self.client.post(&url).json(&req_body).send().await?;
 
         log::debug!("Ollama HTTP status (tools): {}", resp.status());
 
-        let resp = resp.error_for_status()?;
+        let resp = ensure_success(resp, "Ollama").await?;
         let json_resp = resp.json::<OllamaResponse>().await?;
 
         Ok(Box::new(json_resp))
@@ -617,7 +614,7 @@ impl CompletionProvider for Ollama {
         _json_schema: Option<StructuredOutputFormat>,
     ) -> Result<CompletionResponse, LLMError> {
         if self.base_url.is_empty() {
-            return Err(LLMError::InvalidRequest("Missing base_url".to_string()));
+            return Err(LLMError::invalid_request("Missing base_url".to_string()));
         }
         let url = format!("{}/api/generate", self.base_url);
 
@@ -644,13 +641,8 @@ impl CompletionProvider for Ollama {
             }),
         };
 
-        let resp = self
-            .client
-            .post(&url)
-            .json(&req_body)
-            .send()
-            .await?
-            .error_for_status()?;
+        let resp = self.client.post(&url).json(&req_body).send().await?;
+        let resp = ensure_success(resp, "Ollama").await?;
         let json_resp: OllamaResponse = resp.json().await?;
 
         if let Some(answer) = json_resp.response.or(json_resp.content) {
@@ -667,7 +659,7 @@ impl CompletionProvider for Ollama {
 impl EmbeddingProvider for Ollama {
     async fn embed(&self, text: Vec<String>) -> Result<Vec<Vec<f32>>, LLMError> {
         if self.base_url.is_empty() {
-            return Err(LLMError::InvalidRequest("Missing base_url".to_string()));
+            return Err(LLMError::invalid_request("Missing base_url".to_string()));
         }
         let url = format!("{}/api/embed", self.base_url);
 
@@ -676,13 +668,8 @@ impl EmbeddingProvider for Ollama {
             input: text,
         };
 
-        let resp = self
-            .client
-            .post(&url)
-            .json(&body)
-            .send()
-            .await?
-            .error_for_status()?;
+        let resp = self.client.post(&url).json(&body).send().await?;
+        let resp = ensure_success(resp, "Ollama").await?;
 
         let json_resp: OllamaEmbeddingResponse = resp.json().await?;
         Ok(json_resp.embeddings)
@@ -799,7 +786,7 @@ impl EmbeddingBuilder<Ollama> {
     /// Build an Ollama embedding provider.
     pub fn build(self) -> Result<Arc<Ollama>, LLMError> {
         let model = self.model.ok_or_else(|| {
-            LLMError::InvalidRequest("No model provided for Ollama embeddings".to_string())
+            LLMError::invalid_request("No model provided for Ollama embeddings".to_string())
         })?;
 
         let provider = Ollama::new(
@@ -1079,7 +1066,7 @@ mod tests {
         let messages = vec![ChatMessage::user().content("hello").build()];
         assert!(matches!(
             provider.chat_with_tools(&messages, None, None).await,
-            Err(LLMError::InvalidRequest(message)) if message == "Missing base_url"
+            Err(LLMError::InvalidRequest { message, .. }) if message == "Missing base_url"
         ));
         assert!(matches!(
             provider
@@ -1092,11 +1079,11 @@ mod tests {
                     None
                 )
                 .await,
-            Err(LLMError::InvalidRequest(message)) if message == "Missing base_url"
+            Err(LLMError::InvalidRequest { message, .. }) if message == "Missing base_url"
         ));
         assert!(matches!(
             provider.embed(vec!["hello".to_string()]).await,
-            Err(LLMError::InvalidRequest(message)) if message == "Missing base_url"
+            Err(LLMError::InvalidRequest { message, .. }) if message == "Missing base_url"
         ));
 
         let server = MockServer::start();

--- a/crates/autoagents-llm/src/backends/openai.rs
+++ b/crates/autoagents-llm/src/backends/openai.rs
@@ -5,6 +5,7 @@
 use crate::builder::{LLMBackend, LLMBuilder};
 use crate::chat::Usage;
 use crate::embedding::EmbeddingBuilder;
+use crate::http::ensure_success;
 use crate::providers::openai_compatible::{
     OpenAIChatMessage, OpenAIChatResponse, OpenAICompatibleProvider, OpenAIProviderConfig,
     OpenAIResponseFormat, OpenAIStreamOptions, create_sse_stream,
@@ -568,7 +569,9 @@ impl OpenAI {
     ) -> Result<Self, LLMError> {
         let api_key_str = api_key.into();
         if api_key_str.is_empty() {
-            return Err(LLMError::AuthError("Missing OpenAI API key".to_string()));
+            return Err(LLMError::missing_api_key(
+                "Missing OpenAI API key".to_string(),
+            ));
         }
 
         Ok(Self {
@@ -794,8 +797,8 @@ impl ModelsProvider for OpenAI {
             .get(url)
             .bearer_auth(self.api_key())
             .send()
-            .await?
-            .error_for_status()?;
+            .await?;
+        let resp = ensure_success(resp, "OpenAI").await?;
 
         let result = StandardModelListResponse {
             inner: resp.json().await?,
@@ -824,7 +827,7 @@ impl OpenAI {
         &self.provider.base_url
     }
 
-    pub fn timeout_seconds(&self) -> Option<u64> {
+    pub fn timeout_seconds(&self) -> u64 {
         self.provider.timeout_seconds
     }
 
@@ -1056,7 +1059,7 @@ impl OpenAI {
                     ));
                 }
                 MessageType::Pdf(_) => {
-                    return Err(LLMError::InvalidRequest(
+                    return Err(LLMError::invalid_request(
                         "PDF input is not supported by the OpenAI Responses backend".to_string(),
                     ));
                 }
@@ -1120,7 +1123,7 @@ impl OpenAI {
             .base_url
             .join("responses")
             .map_err(|e| LLMError::HttpError(e.to_string()))?;
-        let mut request = self
+        let request = self
             .provider
             .client
             .post(url)
@@ -1133,21 +1136,9 @@ impl OpenAI {
             log::trace!("OpenAI Responses payload: {}", json);
         }
 
-        if let Some(timeout) = self.provider.timeout_seconds {
-            request = request.timeout(std::time::Duration::from_secs(timeout));
-        }
-
         let response = request.send().await?;
         log::debug!("OpenAI Responses HTTP status: {}", response.status());
-        if !response.status().is_success() {
-            let status = response.status();
-            let error_text = response.text().await?;
-            return Err(LLMError::ResponseFormatError {
-                message: format!("OpenAI Responses API returned error status: {status}"),
-                raw_response: error_text,
-            });
-        }
-        Ok(response)
+        ensure_success(response, "OpenAI").await
     }
 
     async fn chat_with_tools_responses(
@@ -1202,7 +1193,7 @@ impl OpenAI {
             .base_url
             .join("chat/completions")
             .map_err(|e| LLMError::HttpError(e.to_string()))?;
-        let mut request = self
+        let request = self
             .provider
             .client
             .post(url)
@@ -1213,19 +1204,9 @@ impl OpenAI {
         {
             log::trace!("OpenAI request payload: {}", json);
         }
-        if let Some(timeout) = self.provider.timeout_seconds {
-            request = request.timeout(std::time::Duration::from_secs(timeout));
-        }
         let response = request.send().await?;
         log::debug!("OpenAI HTTP status: {}", response.status());
-        if !response.status().is_success() {
-            let status = response.status();
-            let error_text = response.text().await?;
-            return Err(LLMError::ResponseFormatError {
-                message: format!("OpenAI API returned error status: {status}"),
-                raw_response: error_text,
-            });
-        }
+        let response = ensure_success(response, "OpenAI").await?;
         let resp_text = response.text().await?;
         let json_resp: Result<OpenAIChatResponse, serde_json::Error> =
             serde_json::from_str(&resp_text);
@@ -1272,24 +1253,14 @@ impl OpenAI {
             .base_url
             .join("chat/completions")
             .map_err(|e| LLMError::HttpError(e.to_string()))?;
-        let mut request = self
+        let request = self
             .provider
             .client
             .post(url)
             .bearer_auth(&self.provider.api_key)
             .json(&body);
-        if let Some(timeout) = self.provider.timeout_seconds {
-            request = request.timeout(std::time::Duration::from_secs(timeout));
-        }
         let response = request.send().await?;
-        if !response.status().is_success() {
-            let status = response.status();
-            let error_text = response.text().await?;
-            return Err(LLMError::ResponseFormatError {
-                message: format!("OpenAI API returned error status: {status}"),
-                raw_response: error_text,
-            });
-        }
+        let response = ensure_success(response, "OpenAI").await?;
         Ok(create_sse_stream(
             response,
             self.provider.normalize_response,
@@ -1679,7 +1650,7 @@ impl LLMBuilder<OpenAI> {
 
     pub fn build(self) -> Result<Arc<OpenAI>, LLMError> {
         let key = self.api_key.ok_or_else(|| {
-            LLMError::InvalidRequest("No API key provided for OpenAI".to_string())
+            LLMError::invalid_request("No API key provided for OpenAI".to_string())
         })?;
         let openai = OpenAI::new(
             key,
@@ -1715,7 +1686,9 @@ impl LLMBuilder<OpenAI> {
 impl EmbeddingProvider for OpenAI {
     async fn embed(&self, input: Vec<String>) -> Result<Vec<Vec<f32>>, LLMError> {
         if self.provider.api_key.is_empty() {
-            return Err(LLMError::AuthError("Missing OpenAI API key".into()));
+            return Err(LLMError::missing_api_key(
+                "Missing OpenAI API key".to_string(),
+            ));
         }
 
         let emb_format = self
@@ -1744,8 +1717,8 @@ impl EmbeddingProvider for OpenAI {
             .bearer_auth(&self.provider.api_key)
             .json(&body)
             .send()
-            .await?
-            .error_for_status()?;
+            .await?;
+        let resp = ensure_success(resp, "OpenAI").await?;
 
         let json_resp: OpenAIEmbeddingResponse = resp.json().await?;
 
@@ -1758,7 +1731,7 @@ impl EmbeddingBuilder<OpenAI> {
     /// Build an OpenAI embedding provider.
     pub fn build(self) -> Result<Arc<OpenAI>, LLMError> {
         let api_key = self.api_key.ok_or_else(|| {
-            LLMError::InvalidRequest("No API key provided for OpenAI".to_string())
+            LLMError::invalid_request("No API key provided for OpenAI".to_string())
         })?;
 
         let model = self
@@ -1946,7 +1919,7 @@ mod tests {
             None,
             None,
         );
-        assert!(matches!(result, Err(LLMError::AuthError(_))));
+        assert!(matches!(result, Err(LLMError::AuthError { .. })));
     }
 
     #[test]
@@ -2668,12 +2641,13 @@ mod tests {
             .await
             .expect_err("error status should fail");
         match err {
-            LLMError::ResponseFormatError {
-                message,
-                raw_response,
+            LLMError::HttpStatusError {
+                status_code,
+                response_body,
+                ..
             } => {
-                assert!(message.contains("returned error status"));
-                assert_eq!(raw_response, "bad gateway");
+                assert_eq!(status_code, 502);
+                assert_eq!(response_body.as_ref(), "bad gateway");
             }
             other => panic!("unexpected error: {other:?}"),
         }

--- a/crates/autoagents-llm/src/backends/openrouter.rs
+++ b/crates/autoagents-llm/src/backends/openrouter.rs
@@ -3,6 +3,7 @@
 //! This module provides integration with OpenRouter's LLM models through their API.
 
 use crate::builder::LLMBuilder;
+use crate::http::ensure_success;
 use crate::{
     LLMProvider,
     builder::LLMBackend,
@@ -106,7 +107,7 @@ impl ModelsProvider for OpenRouter {
         _request: Option<&ModelListRequest>,
     ) -> Result<Box<dyn ModelListResponse>, LLMError> {
         if self.api_key.is_empty() {
-            return Err(LLMError::AuthError(
+            return Err(LLMError::missing_api_key(
                 "Missing OpenRouter API key".to_string(),
             ));
         }
@@ -118,8 +119,8 @@ impl ModelsProvider for OpenRouter {
             .get(&url)
             .bearer_auth(&self.api_key)
             .send()
-            .await?
-            .error_for_status()?;
+            .await?;
+        let resp = ensure_success(resp, "OpenRouter").await?;
 
         let result = StandardModelListResponse {
             inner: resp.json().await?,
@@ -132,7 +133,7 @@ impl ModelsProvider for OpenRouter {
 impl LLMBuilder<OpenRouter> {
     pub fn build(self) -> Result<Arc<OpenRouter>, LLMError> {
         let api_key = self.api_key.ok_or_else(|| {
-            LLMError::InvalidRequest("No API key provided for OpenRouter".to_string())
+            LLMError::invalid_request("No API key provided for OpenRouter".to_string())
         })?;
 
         let openrouter = OpenRouter::with_config(

--- a/crates/autoagents-llm/src/backends/phind.rs
+++ b/crates/autoagents-llm/src/backends/phind.rs
@@ -2,8 +2,10 @@ use crate::{
     LLMProvider,
     chat::{ChatMessage, ChatProvider, ChatRole, MessageType},
     completion::{CompletionProvider, CompletionRequest, CompletionResponse},
+    config::resolve_request_timeout,
     embedding::EmbeddingProvider,
     error::LLMError,
+    http::ensure_success,
     models::ModelsProvider,
 };
 /// Implementation of the Phind LLM provider.
@@ -14,7 +16,6 @@ use crate::{
     chat::{ChatResponse, StructuredOutputFormat, Tool},
 };
 use async_trait::async_trait;
-use reqwest::StatusCode;
 use reqwest::header::{HeaderMap, HeaderValue};
 use reqwest::{Client, Response};
 use serde_json::{Value, json};
@@ -29,7 +30,7 @@ pub struct Phind {
     /// Temperature for controlling randomness (0.0-1.0)
     pub temperature: Option<f32>,
     /// Request timeout in seconds
-    pub timeout_seconds: Option<u64>,
+    pub timeout_seconds: u64,
     /// Top-p sampling parameter
     pub top_p: Option<f32>,
     /// Top-k sampling parameter
@@ -73,10 +74,11 @@ impl Phind {
         top_k: Option<u32>,
         api_base_url: Option<String>,
     ) -> Self {
-        let mut builder = Client::builder();
-        if let Some(sec) = timeout_seconds {
-            builder = builder.timeout(std::time::Duration::from_secs(sec));
-        }
+        let timeout_seconds = resolve_request_timeout(timeout_seconds);
+        let client = Client::builder()
+            .timeout(std::time::Duration::from_secs(timeout_seconds))
+            .build()
+            .expect("Failed to build reqwest Client");
         Self {
             model: model.unwrap_or_else(|| "Phind-70B".to_string()),
             max_tokens,
@@ -86,7 +88,7 @@ impl Phind {
             top_k,
             api_base_url: api_base_url
                 .unwrap_or_else(|| "https://extension.phind.com/agent/".to_string()),
-            client: builder.build().expect("Failed to build reqwest Client"),
+            client,
         }
     }
 
@@ -128,32 +130,15 @@ impl Phind {
         &self,
         response: Response,
     ) -> Result<Box<dyn ChatResponse>, LLMError> {
-        let status = response.status();
-        if let StatusCode::OK = status {
-            let response_text = response.text().await?;
-            let full_text = Self::parse_stream_response(&response_text);
-            if full_text.is_empty() {
-                Err(LLMError::ProviderError(
-                    "No completion choice returned.".to_string(),
-                ))
-            } else {
-                Ok(Box::new(PhindResponse { content: full_text }))
-            }
+        let response = ensure_success(response, "Phind").await?;
+        let response_text = response.text().await?;
+        let full_text = Self::parse_stream_response(&response_text);
+        if full_text.is_empty() {
+            Err(LLMError::ProviderError(
+                "No completion choice returned.".to_string(),
+            ))
         } else {
-            let error_text = response.text().await?;
-            let error_json: Value = serde_json::from_str(&error_text)
-                .unwrap_or_else(|_| json!({"error": {"message": "Unknown error"}}));
-
-            let error_message = error_json
-                .get("error")
-                .and_then(|err| err.get("message"))
-                .and_then(|msg| msg.as_str())
-                .unwrap_or("Unexpected error from Phind")
-                .to_string();
-
-            Err(LLMError::ProviderError(format!(
-                "APIError {status}: {error_message}"
-            )))
+            Ok(Box::new(PhindResponse { content: full_text }))
         }
     }
 }
@@ -210,17 +195,13 @@ impl ChatProvider for Phind {
         }
 
         let headers = Self::create_headers()?;
-        let mut request = self
+        let response = self
             .client
             .post(&self.api_base_url)
             .headers(headers)
-            .json(&payload);
-
-        if let Some(timeout) = self.timeout_seconds {
-            request = request.timeout(std::time::Duration::from_secs(timeout));
-        }
-
-        let response = request.send().await?;
+            .json(&payload)
+            .send()
+            .await?;
 
         log::debug!("Phind HTTP status: {}", response.status());
 
@@ -300,7 +281,7 @@ fn validate_text_only_messages(messages: &[ChatMessage]) -> Result<(), LLMError>
                 ));
             }
             _ => {
-                return Err(LLMError::InvalidRequest(
+                return Err(LLMError::invalid_request(
                     "Multimodal input is not supported by the Phind backend".to_string(),
                 ));
             }
@@ -369,7 +350,7 @@ mod tests {
 
         assert!(matches!(
             err,
-            LLMError::InvalidRequest(message)
+            LLMError::InvalidRequest { message, .. }
                 if message == "Multimodal input is not supported by the Phind backend"
         ));
     }

--- a/crates/autoagents-llm/src/backends/xai.rs
+++ b/crates/autoagents-llm/src/backends/xai.rs
@@ -10,8 +10,10 @@ use crate::{
     LLMProvider,
     chat::{ChatMessage, ChatProvider, ChatRole, MessageType, StructuredOutputFormat},
     completion::{CompletionProvider, CompletionRequest, CompletionResponse},
+    config::resolve_request_timeout,
     embedding::EmbeddingProvider,
     error::LLMError,
+    http::ensure_success,
     models::ModelsProvider,
 };
 use crate::{ToolCall, builder::LLMBuilder, chat::ChatResponse};
@@ -35,7 +37,7 @@ pub struct XAI {
     /// Temperature parameter for controlling response randomness (0.0 to 1.0)
     pub temperature: Option<f32>,
     /// Request timeout duration in seconds
-    pub timeout_seconds: Option<u64>,
+    pub timeout_seconds: u64,
     /// Top-p sampling parameter for controlling response diversity
     pub top_p: Option<f32>,
     /// Top-k sampling parameter for controlling response diversity
@@ -260,10 +262,11 @@ impl XAI {
         xai_search_from_date: Option<String>,
         xai_search_to_date: Option<String>,
     ) -> Self {
-        let mut builder = Client::builder();
-        if let Some(sec) = timeout_seconds {
-            builder = builder.timeout(std::time::Duration::from_secs(sec));
-        }
+        let timeout_seconds = resolve_request_timeout(timeout_seconds);
+        let client = Client::builder()
+            .timeout(std::time::Duration::from_secs(timeout_seconds))
+            .build()
+            .expect("Failed to build reqwest Client");
         Self {
             api_key: api_key.into(),
             model: model.unwrap_or_else(|| "grok-2-latest".to_string()),
@@ -280,7 +283,7 @@ impl XAI {
             xai_search_max_results,
             xai_search_from_date,
             xai_search_to_date,
-            client: builder.build().expect("Failed to build reqwest Client"),
+            client,
         }
     }
 
@@ -297,7 +300,7 @@ impl XAI {
                     ));
                 }
                 _ => {
-                    return Err(LLMError::InvalidRequest(
+                    return Err(LLMError::invalid_request(
                         "Multimodal input is not supported by the X.AI backend".to_string(),
                     ));
                 }
@@ -392,7 +395,9 @@ impl ChatProvider for XAI {
         json_schema: Option<StructuredOutputFormat>,
     ) -> Result<Box<dyn ChatResponse>, LLMError> {
         if self.api_key.is_empty() {
-            return Err(LLMError::AuthError("Missing X.AI API key".to_string()));
+            return Err(LLMError::missing_api_key(
+                "Missing X.AI API key".to_string(),
+            ));
         }
 
         let xai_msgs = XAI::try_build_chat_messages(messages)?;
@@ -426,21 +431,17 @@ impl ChatProvider for XAI {
             log::trace!("XAI request payload: {json}");
         }
 
-        let mut request = self
+        let resp = self
             .client
             .post("https://api.x.ai/v1/chat/completions")
             .bearer_auth(&self.api_key)
-            .json(&body);
-
-        if let Some(timeout) = self.timeout_seconds {
-            request = request.timeout(std::time::Duration::from_secs(timeout));
-        }
-
-        let resp = request.send().await?;
+            .json(&body)
+            .send()
+            .await?;
 
         log::debug!("XAI HTTP status: {}", resp.status());
 
-        let resp = resp.error_for_status()?;
+        let resp = ensure_success(resp, "X.AI").await?;
 
         let json_resp: XAIChatResponse = resp.json().await?;
         Ok(Box::new(json_resp))
@@ -462,7 +463,9 @@ impl ChatProvider for XAI {
     ) -> Result<std::pin::Pin<Box<dyn Stream<Item = Result<String, LLMError>> + Send>>, LLMError>
     {
         if self.api_key.is_empty() {
-            return Err(LLMError::AuthError("Missing X.AI API key".to_string()));
+            return Err(LLMError::missing_api_key(
+                "Missing X.AI API key".to_string(),
+            ));
         }
 
         let xai_msgs = XAI::try_build_chat_messages(messages)?;
@@ -479,26 +482,15 @@ impl ChatProvider for XAI {
             search_parameters: None,
         };
 
-        let mut request = self
+        let response = self
             .client
             .post("https://api.x.ai/v1/chat/completions")
             .bearer_auth(&self.api_key)
-            .json(&body);
+            .json(&body)
+            .send()
+            .await?;
 
-        if let Some(timeout) = self.timeout_seconds {
-            request = request.timeout(std::time::Duration::from_secs(timeout));
-        }
-
-        let response = request.send().await?;
-
-        if !response.status().is_success() {
-            let status = response.status();
-            let error_text = response.text().await?;
-            return Err(LLMError::ResponseFormatError {
-                message: format!("X.AI API returned error status: {status}"),
-                raw_response: error_text,
-            });
-        }
+        let response = ensure_success(response, "X.AI").await?;
 
         Ok(crate::chat::create_sse_stream(
             response,
@@ -541,7 +533,9 @@ impl CompletionProvider for XAI {
         _json_schema: Option<StructuredOutputFormat>,
     ) -> Result<CompletionResponse, LLMError> {
         if self.api_key.is_empty() {
-            return Err(LLMError::AuthError("Missing X.AI API key".into()));
+            return Err(LLMError::missing_api_key(
+                "Missing X.AI API key".to_string(),
+            ));
         }
         Err(LLMError::ProviderError(
             "X.AI completion not implemented yet".into(),
@@ -553,7 +547,9 @@ impl CompletionProvider for XAI {
 impl EmbeddingProvider for XAI {
     async fn embed(&self, text: Vec<String>) -> Result<Vec<Vec<f32>>, LLMError> {
         if self.api_key.is_empty() {
-            return Err(LLMError::AuthError("Missing X.AI API key".into()));
+            return Err(LLMError::missing_api_key(
+                "Missing X.AI API key".to_string(),
+            ));
         }
 
         let emb_format = self
@@ -574,8 +570,8 @@ impl EmbeddingProvider for XAI {
             .bearer_auth(&self.api_key)
             .json(&body)
             .send()
-            .await?
-            .error_for_status()?;
+            .await?;
+        let resp = ensure_success(resp, "X.AI").await?;
 
         let json_resp: XAIEmbeddingResponse = resp.json().await?;
 
@@ -591,7 +587,9 @@ impl ModelsProvider for XAI {
         _request: Option<&crate::models::ModelListRequest>,
     ) -> Result<Box<dyn crate::models::ModelListResponse>, LLMError> {
         if self.api_key.is_empty() {
-            return Err(LLMError::AuthError("Missing X.AI API key".into()));
+            return Err(LLMError::missing_api_key(
+                "Missing X.AI API key".to_string(),
+            ));
         }
         Err(LLMError::ProviderError("List Models not supported".into()))
     }
@@ -644,7 +642,7 @@ impl LLMBuilder<XAI> {
     pub fn build(self) -> Result<Arc<XAI>, LLMError> {
         let api_key = self
             .api_key
-            .ok_or_else(|| LLMError::InvalidRequest("No API key provided for XAI".to_string()))?;
+            .ok_or_else(|| LLMError::invalid_request("No API key provided for XAI".to_string()))?;
 
         let xai = XAI::new(
             api_key,
@@ -673,7 +671,7 @@ impl EmbeddingBuilder<XAI> {
     pub fn build(self) -> Result<Arc<XAI>, LLMError> {
         let api_key = self
             .api_key
-            .ok_or_else(|| LLMError::InvalidRequest("No API key provided for XAI".to_string()))?;
+            .ok_or_else(|| LLMError::invalid_request("No API key provided for XAI".to_string()))?;
 
         let provider = XAI::new(
             api_key,
@@ -822,7 +820,7 @@ mod tests {
 
         assert!(matches!(
             err,
-            LLMError::InvalidRequest(message)
+            LLMError::InvalidRequest { message, .. }
                 if message == "Multimodal input is not supported by the X.AI backend"
         ));
     }

--- a/crates/autoagents-llm/src/builder.rs
+++ b/crates/autoagents-llm/src/builder.rs
@@ -83,7 +83,7 @@ impl std::str::FromStr for LLMBackend {
             "azure-openai" => Ok(LLMBackend::AzureOpenAI),
             "openrouter" => Ok(LLMBackend::OpenRouter),
             "minimax" => Ok(LLMBackend::MiniMax),
-            _ => Err(LLMError::InvalidRequest(format!(
+            _ => Err(LLMError::invalid_request(format!(
                 "Unknown LLM backend: {s}"
             ))),
         }
@@ -253,6 +253,9 @@ impl<L: LLMProvider + HasConfig> LLMBuilder<L> {
     }
 
     /// Sets the request timeout in seconds.
+    ///
+    /// When unset, providers resolve to [`DEFAULT_REQUEST_TIMEOUT_SECS`](crate::config::DEFAULT_REQUEST_TIMEOUT_SECS)
+    /// (120 seconds) at build time.
     pub fn timeout_seconds(mut self, timeout_seconds: u64) -> Self {
         self.timeout_seconds = Some(timeout_seconds);
         self

--- a/crates/autoagents-llm/src/chat/mod.rs
+++ b/crates/autoagents-llm/src/chat/mod.rs
@@ -853,23 +853,6 @@ where
     Box::pin(stream)
 }
 
-#[cfg(not(target_arch = "wasm32"))]
-pub mod utils {
-    use crate::error::LLMError;
-    use reqwest::Response;
-    pub async fn check_response_status(response: Response) -> Result<Response, LLMError> {
-        if !response.status().is_success() {
-            let status = response.status();
-            let error_text = response.text().await?;
-            return Err(LLMError::ResponseFormatError {
-                message: format!("API returned error status: {status}"),
-                raw_response: error_text,
-            });
-        }
-        Ok(response)
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/autoagents-llm/src/config.rs
+++ b/crates/autoagents-llm/src/config.rs
@@ -8,3 +8,18 @@ pub const DEFAULT_REQUEST_TIMEOUT_SECS: u64 = 120;
 pub fn resolve_request_timeout(explicit: Option<u64>) -> u64 {
     explicit.unwrap_or(DEFAULT_REQUEST_TIMEOUT_SECS)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_request_timeout_uses_explicit_value() {
+        assert_eq!(resolve_request_timeout(Some(30)), 30);
+    }
+
+    #[test]
+    fn resolve_request_timeout_defaults_when_unset() {
+        assert_eq!(resolve_request_timeout(None), DEFAULT_REQUEST_TIMEOUT_SECS);
+    }
+}

--- a/crates/autoagents-llm/src/config.rs
+++ b/crates/autoagents-llm/src/config.rs
@@ -1,0 +1,10 @@
+//! Shared configuration constants for LLM providers.
+
+/// Default HTTP request timeout in seconds when none is explicitly configured.
+pub const DEFAULT_REQUEST_TIMEOUT_SECS: u64 = 120;
+
+/// Resolves the effective request timeout from an optional explicit value.
+#[inline]
+pub fn resolve_request_timeout(explicit: Option<u64>) -> u64 {
+    explicit.unwrap_or(DEFAULT_REQUEST_TIMEOUT_SECS)
+}

--- a/crates/autoagents-llm/src/embedding/model_provider.rs
+++ b/crates/autoagents-llm/src/embedding/model_provider.rs
@@ -1,5 +1,6 @@
 use std::marker::PhantomData;
 
+use crate::config::resolve_request_timeout;
 use crate::embedding::EmbeddingProvider;
 
 /// Builder for creating embedding-only providers without going through the LLM builder.
@@ -80,9 +81,17 @@ impl<P: EmbeddingProvider> EmbeddingBuilder<P> {
     }
 
     /// Set a request timeout in seconds.
+    ///
+    /// When unset, [`resolved_timeout_seconds`](Self::resolved_timeout_seconds) returns
+    /// [`DEFAULT_REQUEST_TIMEOUT_SECS`](crate::config::DEFAULT_REQUEST_TIMEOUT_SECS) (120 seconds).
     pub fn timeout_seconds(mut self, timeout: u64) -> Self {
         self.timeout_seconds = Some(timeout);
         self
+    }
+
+    /// Returns the effective HTTP request timeout in seconds.
+    pub fn resolved_timeout_seconds(&self) -> u64 {
+        resolve_request_timeout(self.timeout_seconds)
     }
 }
 
@@ -122,5 +131,15 @@ mod tests {
         assert_eq!(builder.api_version.as_deref(), Some("v1"));
         assert_eq!(builder.deployment_id.as_deref(), Some("dep"));
         assert_eq!(builder.timeout_seconds, Some(10));
+        assert_eq!(builder.resolved_timeout_seconds(), 10);
+    }
+
+    #[test]
+    fn test_embedding_builder_default_timeout() {
+        let builder = EmbeddingBuilder::<DummyProvider>::new();
+        assert_eq!(
+            builder.resolved_timeout_seconds(),
+            crate::config::DEFAULT_REQUEST_TIMEOUT_SECS
+        );
     }
 }

--- a/crates/autoagents-llm/src/error.rs
+++ b/crates/autoagents-llm/src/error.rs
@@ -284,18 +284,116 @@ pub fn is_fallbackable(err: &LLMError) -> bool {
     match err {
         LLMError::RateLimitError { .. } => true,
         LLMError::HttpStatusError { status_code, .. } => is_http_status_retryable(*status_code),
-        LLMError::HttpError(msg) => is_transport_retryable_message(msg),
+        LLMError::HttpError(_) => true,
         LLMError::ProviderError(_)
         | LLMError::ResponseFormatError { .. }
-        | LLMError::NoToolSupport(_) => true,
+        | LLMError::NoToolSupport(_)
+        | LLMError::Generic(_) => true,
         LLMError::AuthError { .. }
         | LLMError::InvalidRequest { .. }
         | LLMError::JsonError(_)
         | LLMError::ToolConfigError(_)
-        | LLMError::Generic(_)
         | LLMError::GuardrailBlocked { .. }
         | LLMError::GuardrailExecutionFailed { .. } => false,
     }
+}
+
+fn write_status_prefixed_error(
+    f: &mut fmt::Formatter<'_>,
+    label: &str,
+    message: &str,
+    status_code: Option<u16>,
+    response_body: Option<&str>,
+) -> fmt::Result {
+    if let Some(status) = status_code {
+        write!(f, "{label} ({status}): {message}")?;
+    } else {
+        write!(f, "{label}: {message}")?;
+    }
+    if let Some(body) = response_body {
+        write_truncated_body(f, "Response", body)?;
+    }
+    Ok(())
+}
+
+fn display_auth_error(
+    f: &mut fmt::Formatter<'_>,
+    message: &str,
+    status_code: Option<u16>,
+    response_body: Option<&str>,
+) -> fmt::Result {
+    write_status_prefixed_error(f, "Auth Error", message, status_code, response_body)
+}
+
+fn display_rate_limit_error(
+    f: &mut fmt::Formatter<'_>,
+    status_code: u16,
+    message: &str,
+    response_body: &str,
+    retry_after: Option<Duration>,
+    provider_code: Option<&str>,
+) -> fmt::Result {
+    write!(f, "Rate Limit Error ({status_code}): {message}")?;
+    write_truncated_body(f, "Response", response_body)?;
+    if let Some(code) = provider_code {
+        write!(f, ". Provider code: {code}")?;
+    }
+    if let Some(retry_after) = retry_after {
+        write!(f, ". Retry-After: {}s", retry_after.as_secs())?;
+    }
+    Ok(())
+}
+
+fn display_http_status_error(
+    f: &mut fmt::Formatter<'_>,
+    status_code: u16,
+    message: &str,
+    response_body: &str,
+    provider_code: Option<&str>,
+) -> fmt::Result {
+    write!(f, "HTTP Status Error ({status_code}): {message}")?;
+    write_truncated_body(f, "Response", response_body)?;
+    if let Some(code) = provider_code {
+        write!(f, ". Provider code: {code}")?;
+    }
+    Ok(())
+}
+
+fn display_invalid_request(
+    f: &mut fmt::Formatter<'_>,
+    message: &str,
+    status_code: Option<u16>,
+    response_body: Option<&str>,
+) -> fmt::Result {
+    write_status_prefixed_error(f, "Invalid Request", message, status_code, response_body)
+}
+
+fn display_response_format_error(
+    f: &mut fmt::Formatter<'_>,
+    message: &str,
+    raw_response: &str,
+) -> fmt::Result {
+    write!(f, "Response Format Error: {message}")?;
+    write_truncated_body(f, "Raw response", raw_response)
+}
+
+fn display_guardrail_blocked(
+    f: &mut fmt::Formatter<'_>,
+    phase: GuardrailPhase,
+    guard: &str,
+    rule_id: &str,
+    category: &str,
+    severity: &str,
+    message: &str,
+) -> fmt::Result {
+    let phase = match phase {
+        GuardrailPhase::Input => "input",
+        GuardrailPhase::Output => "output",
+    };
+    write!(
+        f,
+        "guardrail blocked {phase}: guard={guard}, rule={rule_id}, category={category}, severity={severity}, message={message}"
+    )
 }
 
 impl fmt::Display for LLMError {
@@ -306,71 +404,44 @@ impl fmt::Display for LLMError {
                 message,
                 status_code,
                 response_body,
-            } => {
-                if let Some(status) = status_code {
-                    write!(f, "Auth Error ({status}): {message}")?;
-                } else {
-                    write!(f, "Auth Error: {message}")?;
-                }
-                if let Some(body) = response_body {
-                    write_truncated_body(f, "Response", body)?;
-                }
-                Ok(())
-            }
+            } => display_auth_error(f, message, *status_code, response_body.as_deref()),
             LLMError::RateLimitError {
                 status_code,
                 message,
                 response_body,
                 retry_after,
                 provider_code,
-            } => {
-                write!(f, "Rate Limit Error ({status_code}): {message}")?;
-                write_truncated_body(f, "Response", response_body)?;
-                if let Some(code) = provider_code {
-                    write!(f, ". Provider code: {code}")?;
-                }
-                if let Some(retry_after) = retry_after {
-                    write!(f, ". Retry-After: {}s", retry_after.as_secs())?;
-                }
-                Ok(())
-            }
+            } => display_rate_limit_error(
+                f,
+                *status_code,
+                message,
+                response_body,
+                *retry_after,
+                provider_code.as_deref(),
+            ),
             LLMError::HttpStatusError {
                 status_code,
                 message,
                 response_body,
                 provider_code,
-            } => {
-                write!(f, "HTTP Status Error ({status_code}): {message}")?;
-                write_truncated_body(f, "Response", response_body)?;
-                if let Some(code) = provider_code {
-                    write!(f, ". Provider code: {code}")?;
-                }
-                Ok(())
-            }
+            } => display_http_status_error(
+                f,
+                *status_code,
+                message,
+                response_body,
+                provider_code.as_deref(),
+            ),
             LLMError::InvalidRequest {
                 message,
                 status_code,
                 response_body,
-            } => {
-                if let Some(status) = status_code {
-                    write!(f, "Invalid Request ({status}): {message}")?;
-                } else {
-                    write!(f, "Invalid Request: {message}")?;
-                }
-                if let Some(body) = response_body {
-                    write_truncated_body(f, "Response", body)?;
-                }
-                Ok(())
-            }
+            } => display_invalid_request(f, message, *status_code, response_body.as_deref()),
             LLMError::ProviderError(e) => write!(f, "Provider Error: {e}"),
             LLMError::Generic(e) => write!(f, "Generic Error : {e}"),
             LLMError::ResponseFormatError {
                 message,
                 raw_response,
-            } => {
-                write!(f, "Response Format Error: {message}")?;
-                write_truncated_body(f, "Raw response", raw_response)
-            }
+            } => display_response_format_error(f, message, raw_response),
             LLMError::JsonError(e) => write!(f, "JSON Parse Error: {e}"),
             LLMError::ToolConfigError(e) => write!(f, "Tool Configuration Error: {e}"),
             LLMError::NoToolSupport(e) => write!(f, "No Tool Support: {e}"),
@@ -381,22 +452,11 @@ impl fmt::Display for LLMError {
                 category,
                 severity,
                 message,
-            } => {
-                let phase = match phase {
-                    GuardrailPhase::Input => "input",
-                    GuardrailPhase::Output => "output",
-                };
-                write!(
-                    f,
-                    "guardrail blocked {phase}: guard={guard}, rule={rule_id}, category={category}, severity={severity}, message={message}"
-                )
-            }
-            LLMError::GuardrailExecutionFailed { guard, message } => {
-                write!(
-                    f,
-                    "guardrail execution failed: guard={guard}, error={message}"
-                )
-            }
+            } => display_guardrail_blocked(f, *phase, guard, rule_id, category, severity, message),
+            LLMError::GuardrailExecutionFailed { guard, message } => write!(
+                f,
+                "guardrail execution failed: guard={guard}, error={message}"
+            ),
         }
     }
 }

--- a/crates/autoagents-llm/src/error.rs
+++ b/crates/autoagents-llm/src/error.rs
@@ -1,4 +1,8 @@
 use std::fmt;
+use std::time::Duration;
+
+/// Maximum bytes of a provider response body included in [`Display`](fmt::Display) output.
+pub const MAX_ERROR_BODY_DISPLAY_BYTES: usize = 512;
 
 /// Phase where a guardrail violation occurred.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -8,30 +12,53 @@ pub enum GuardrailPhase {
 }
 
 /// Error types that can occur when interacting with LLM providers.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub enum LLMError {
-    /// HTTP request/response errors
+    /// HTTP transport failures (connection, timeout, DNS, etc.).
     HttpError(String),
-    /// Authentication and authorization errors
-    AuthError(String),
-    /// Invalid request parameters or format
-    InvalidRequest(String),
-    /// Errors returned by the LLM provider
+    /// Authentication and authorization errors (missing local API key or HTTP 401/403).
+    AuthError {
+        message: String,
+        status_code: Option<u16>,
+        response_body: Option<Box<str>>,
+    },
+    /// Rate limit or provider overload (HTTP 429, 529).
+    RateLimitError {
+        status_code: u16,
+        message: String,
+        response_body: Box<str>,
+        retry_after: Option<Duration>,
+        provider_code: Option<Box<str>>,
+    },
+    /// Non-success HTTP response that is not auth or rate-limit.
+    HttpStatusError {
+        status_code: u16,
+        message: String,
+        response_body: Box<str>,
+        provider_code: Option<Box<str>>,
+    },
+    /// Invalid request parameters, format, or client-side HTTP 4xx rejection.
+    InvalidRequest {
+        message: String,
+        status_code: Option<u16>,
+        response_body: Option<Box<str>>,
+    },
+    /// Errors returned by the LLM provider in a parsed response payload.
     ProviderError(String),
-    /// API response parsing or format error
+    /// API response parsing or format error on a successful HTTP response.
     ResponseFormatError {
         message: String,
         raw_response: String,
     },
-    /// Generic error
+    /// Generic error (unsupported features, internal stubs).
     Generic(String),
-    /// JSON serialization/deserialization errors
+    /// JSON serialization/deserialization errors.
     JsonError(String),
-    /// Tool configuration error
+    /// Tool configuration error.
     ToolConfigError(String),
-    /// No Tool Support
+    /// Provider does not support tool calling.
     NoToolSupport(String),
-    /// Guardrail blocked the request/response
+    /// Guardrail blocked the request/response.
     GuardrailBlocked {
         phase: GuardrailPhase,
         guard: Box<str>,
@@ -40,26 +67,309 @@ pub enum LLMError {
         severity: Box<str>,
         message: Box<str>,
     },
-    /// Guardrail execution failed unexpectedly
+    /// Guardrail execution failed unexpectedly.
     GuardrailExecutionFailed { guard: String, message: String },
+}
+
+impl LLMError {
+    /// Local configuration error when an API key is missing.
+    pub fn missing_api_key(message: impl Into<String>) -> Self {
+        Self::AuthError {
+            message: message.into(),
+            status_code: None,
+            response_body: None,
+        }
+    }
+
+    /// Local validation error for invalid request parameters or configuration.
+    pub fn invalid_request(message: impl Into<String>) -> Self {
+        Self::InvalidRequest {
+            message: message.into(),
+            status_code: None,
+            response_body: None,
+        }
+    }
+
+    /// Returns `true` when the error represents a transient failure worth retrying.
+    pub fn is_retryable(&self) -> bool {
+        is_retryable(self)
+    }
+
+    /// HTTP status code when the error originated from a non-success response.
+    pub fn http_status_code(&self) -> Option<u16> {
+        match self {
+            Self::AuthError { status_code, .. } => *status_code,
+            Self::RateLimitError { status_code, .. } => Some(*status_code),
+            Self::HttpStatusError { status_code, .. } => Some(*status_code),
+            Self::InvalidRequest { status_code, .. } => *status_code,
+            _ => None,
+        }
+    }
+
+    /// Provider response body attached to HTTP-related errors.
+    pub fn response_body(&self) -> Option<&str> {
+        match self {
+            Self::AuthError { response_body, .. } => response_body.as_deref(),
+            Self::RateLimitError { response_body, .. } => Some(response_body),
+            Self::HttpStatusError { response_body, .. } => Some(response_body),
+            Self::InvalidRequest { response_body, .. } => response_body.as_deref(),
+            Self::ResponseFormatError { raw_response, .. } => Some(raw_response),
+            _ => None,
+        }
+    }
+
+    /// Returns `true` when this `HttpError` represents a retryable transport failure.
+    pub fn is_transport_retryable(&self) -> bool {
+        match self {
+            Self::HttpError(msg) => is_transport_retryable_message(msg),
+            _ => false,
+        }
+    }
+}
+
+/// Returns `true` when a transport error message represents a retryable failure.
+pub fn is_transport_retryable_message(message: &str) -> bool {
+    let m = message.to_ascii_lowercase();
+    m.starts_with("request timed out:")
+        || m.starts_with("connection failed:")
+        || m.contains("connection reset")
+        || m.contains("broken pipe")
+        || m.contains("dns error")
+        || m.contains("dns lookup")
+        || m.contains("name or service not known")
+}
+
+/// Truncates a response body for safe inclusion in log-oriented display output.
+pub fn truncate_for_display(body: &str) -> String {
+    if body.len() <= MAX_ERROR_BODY_DISPLAY_BYTES {
+        return body.to_string();
+    }
+
+    let mut end = MAX_ERROR_BODY_DISPLAY_BYTES;
+    while end > 0 && !body.is_char_boundary(end) {
+        end -= 1;
+    }
+
+    format!(
+        "{}... [truncated, {} bytes total]",
+        &body[..end],
+        body.len()
+    )
+}
+
+fn write_truncated_body(f: &mut fmt::Formatter<'_>, label: &str, body: &str) -> fmt::Result {
+    write!(f, ". {label}: {}", truncate_for_display(body))
+}
+
+fn debug_optional_body(body: &Option<Box<str>>) -> Option<String> {
+    body.as_deref().map(truncate_for_display)
+}
+
+impl fmt::Debug for LLMError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::HttpError(message) => f.debug_tuple("HttpError").field(message).finish(),
+            Self::AuthError {
+                message,
+                status_code,
+                response_body,
+            } => f
+                .debug_struct("AuthError")
+                .field("message", message)
+                .field("status_code", status_code)
+                .field("response_body", &debug_optional_body(response_body))
+                .finish(),
+            Self::RateLimitError {
+                status_code,
+                message,
+                response_body,
+                retry_after,
+                provider_code,
+            } => f
+                .debug_struct("RateLimitError")
+                .field("status_code", status_code)
+                .field("message", message)
+                .field("response_body", &truncate_for_display(response_body))
+                .field("retry_after", retry_after)
+                .field("provider_code", provider_code)
+                .finish(),
+            Self::HttpStatusError {
+                status_code,
+                message,
+                response_body,
+                provider_code,
+            } => f
+                .debug_struct("HttpStatusError")
+                .field("status_code", status_code)
+                .field("message", message)
+                .field("response_body", &truncate_for_display(response_body))
+                .field("provider_code", provider_code)
+                .finish(),
+            Self::InvalidRequest {
+                message,
+                status_code,
+                response_body,
+            } => f
+                .debug_struct("InvalidRequest")
+                .field("message", message)
+                .field("status_code", status_code)
+                .field("response_body", &debug_optional_body(response_body))
+                .finish(),
+            Self::ProviderError(message) => f.debug_tuple("ProviderError").field(message).finish(),
+            Self::ResponseFormatError {
+                message,
+                raw_response,
+            } => f
+                .debug_struct("ResponseFormatError")
+                .field("message", message)
+                .field("raw_response", &truncate_for_display(raw_response))
+                .finish(),
+            Self::Generic(message) => f.debug_tuple("Generic").field(message).finish(),
+            Self::JsonError(message) => f.debug_tuple("JsonError").field(message).finish(),
+            Self::ToolConfigError(message) => {
+                f.debug_tuple("ToolConfigError").field(message).finish()
+            }
+            Self::NoToolSupport(message) => f.debug_tuple("NoToolSupport").field(message).finish(),
+            Self::GuardrailBlocked {
+                phase,
+                guard,
+                rule_id,
+                category,
+                severity,
+                message,
+            } => f
+                .debug_struct("GuardrailBlocked")
+                .field("phase", phase)
+                .field("guard", guard)
+                .field("rule_id", rule_id)
+                .field("category", category)
+                .field("severity", severity)
+                .field("message", message)
+                .finish(),
+            Self::GuardrailExecutionFailed { guard, message } => f
+                .debug_struct("GuardrailExecutionFailed")
+                .field("guard", guard)
+                .field("message", message)
+                .finish(),
+        }
+    }
+}
+
+/// Returns `true` when an HTTP status code represents a retryable server/transient error.
+pub fn is_http_status_retryable(status_code: u16) -> bool {
+    matches!(status_code, 408 | 500..=599)
+}
+
+/// Default retryability predicate shared by the retry layer.
+pub fn is_retryable(err: &LLMError) -> bool {
+    match err {
+        LLMError::RateLimitError { .. } => true,
+        LLMError::HttpStatusError { status_code, .. } => is_http_status_retryable(*status_code),
+        LLMError::HttpError(msg) => is_transport_retryable_message(msg),
+        LLMError::Generic(_)
+        | LLMError::AuthError { .. }
+        | LLMError::InvalidRequest { .. }
+        | LLMError::GuardrailBlocked { .. }
+        | LLMError::GuardrailExecutionFailed { .. }
+        | LLMError::ResponseFormatError { .. }
+        | LLMError::JsonError(_)
+        | LLMError::ToolConfigError(_)
+        | LLMError::NoToolSupport(_)
+        | LLMError::ProviderError(_) => false,
+    }
+}
+
+/// Default fallbackability predicate shared by the fallback layer.
+pub fn is_fallbackable(err: &LLMError) -> bool {
+    match err {
+        LLMError::RateLimitError { .. } => true,
+        LLMError::HttpStatusError { status_code, .. } => is_http_status_retryable(*status_code),
+        LLMError::HttpError(msg) => is_transport_retryable_message(msg),
+        LLMError::ProviderError(_)
+        | LLMError::ResponseFormatError { .. }
+        | LLMError::NoToolSupport(_) => true,
+        LLMError::AuthError { .. }
+        | LLMError::InvalidRequest { .. }
+        | LLMError::JsonError(_)
+        | LLMError::ToolConfigError(_)
+        | LLMError::Generic(_)
+        | LLMError::GuardrailBlocked { .. }
+        | LLMError::GuardrailExecutionFailed { .. } => false,
+    }
 }
 
 impl fmt::Display for LLMError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             LLMError::HttpError(e) => write!(f, "HTTP Error: {e}"),
-            LLMError::AuthError(e) => write!(f, "Auth Error: {e}"),
-            LLMError::InvalidRequest(e) => write!(f, "Invalid Request: {e}"),
+            LLMError::AuthError {
+                message,
+                status_code,
+                response_body,
+            } => {
+                if let Some(status) = status_code {
+                    write!(f, "Auth Error ({status}): {message}")?;
+                } else {
+                    write!(f, "Auth Error: {message}")?;
+                }
+                if let Some(body) = response_body {
+                    write_truncated_body(f, "Response", body)?;
+                }
+                Ok(())
+            }
+            LLMError::RateLimitError {
+                status_code,
+                message,
+                response_body,
+                retry_after,
+                provider_code,
+            } => {
+                write!(f, "Rate Limit Error ({status_code}): {message}")?;
+                write_truncated_body(f, "Response", response_body)?;
+                if let Some(code) = provider_code {
+                    write!(f, ". Provider code: {code}")?;
+                }
+                if let Some(retry_after) = retry_after {
+                    write!(f, ". Retry-After: {}s", retry_after.as_secs())?;
+                }
+                Ok(())
+            }
+            LLMError::HttpStatusError {
+                status_code,
+                message,
+                response_body,
+                provider_code,
+            } => {
+                write!(f, "HTTP Status Error ({status_code}): {message}")?;
+                write_truncated_body(f, "Response", response_body)?;
+                if let Some(code) = provider_code {
+                    write!(f, ". Provider code: {code}")?;
+                }
+                Ok(())
+            }
+            LLMError::InvalidRequest {
+                message,
+                status_code,
+                response_body,
+            } => {
+                if let Some(status) = status_code {
+                    write!(f, "Invalid Request ({status}): {message}")?;
+                } else {
+                    write!(f, "Invalid Request: {message}")?;
+                }
+                if let Some(body) = response_body {
+                    write_truncated_body(f, "Response", body)?;
+                }
+                Ok(())
+            }
             LLMError::ProviderError(e) => write!(f, "Provider Error: {e}"),
             LLMError::Generic(e) => write!(f, "Generic Error : {e}"),
             LLMError::ResponseFormatError {
                 message,
                 raw_response,
             } => {
-                write!(
-                    f,
-                    "Response Format Error: {message}. Raw response: {raw_response}"
-                )
+                write!(f, "Response Format Error: {message}")?;
+                write_truncated_body(f, "Raw response", raw_response)
             }
             LLMError::JsonError(e) => write!(f, "JSON Parse Error: {e}"),
             LLMError::ToolConfigError(e) => write!(f, "Tool Configuration Error: {e}"),
@@ -93,11 +403,17 @@ impl fmt::Display for LLMError {
 
 impl std::error::Error for LLMError {}
 
-/// Converts reqwest HTTP errors into LLMErrors
+/// Converts reqwest HTTP errors into LLMErrors, preserving transport context.
 #[cfg(not(target_arch = "wasm32"))]
 impl From<reqwest::Error> for LLMError {
     fn from(err: reqwest::Error) -> Self {
-        LLMError::HttpError(err.to_string())
+        if err.is_timeout() {
+            LLMError::HttpError(format!("request timed out: {err}"))
+        } else if err.is_connect() {
+            LLMError::HttpError(format!("connection failed: {err}"))
+        } else {
+            LLMError::HttpError(err.to_string())
+        }
     }
 }
 
@@ -116,108 +432,120 @@ impl From<serde_json::Error> for LLMError {
 mod tests {
     use super::*;
     use serde_json::Error as JsonError;
-    use std::error::Error;
 
     #[test]
-    fn test_llm_error_display_http_error() {
-        let error = LLMError::HttpError("Connection failed".to_string());
-        assert_eq!(error.to_string(), "HTTP Error: Connection failed");
+    fn test_truncate_for_display_short_body_unchanged() {
+        assert_eq!(truncate_for_display("short"), "short");
     }
 
     #[test]
-    fn test_llm_error_display_auth_error() {
-        let error = LLMError::AuthError("Invalid API key".to_string());
-        assert_eq!(error.to_string(), "Auth Error: Invalid API key");
+    fn test_truncate_for_display_long_body() {
+        let body = "x".repeat(MAX_ERROR_BODY_DISPLAY_BYTES + 10);
+        let truncated = truncate_for_display(&body);
+        assert!(truncated.contains("truncated"));
+        assert!(truncated.starts_with(&"x".repeat(MAX_ERROR_BODY_DISPLAY_BYTES)));
     }
 
     #[test]
-    fn test_llm_error_display_invalid_request() {
-        let error = LLMError::InvalidRequest("Missing required parameter".to_string());
-        assert_eq!(
-            error.to_string(),
-            "Invalid Request: Missing required parameter"
-        );
+    fn test_is_transport_retryable_message_prefixed_forms() {
+        assert!(is_transport_retryable_message(
+            "request timed out: operation timed out"
+        ));
+        assert!(is_transport_retryable_message(
+            "connection failed: tcp connect error"
+        ));
+        assert!(!is_transport_retryable_message(
+            "HTTP Status Error (400): bad request"
+        ));
     }
 
     #[test]
-    fn test_llm_error_display_provider_error() {
-        let error = LLMError::ProviderError("Model not found".to_string());
-        assert_eq!(error.to_string(), "Provider Error: Model not found");
-    }
-
-    #[test]
-    fn test_llm_error_display_generic_error() {
-        let error = LLMError::Generic("Something went wrong".to_string());
-        assert_eq!(error.to_string(), "Generic Error : Something went wrong");
-    }
-
-    #[test]
-    fn test_llm_error_display_response_format_error() {
-        let error = LLMError::ResponseFormatError {
-            message: "Invalid JSON".to_string(),
-            raw_response: "{invalid json}".to_string(),
+    fn test_llm_error_display_auth_error_with_status_truncates_body() {
+        let body = "secret".repeat(200);
+        let error = LLMError::AuthError {
+            message: "Unauthorized".to_string(),
+            status_code: Some(401),
+            response_body: Some(body.clone().into_boxed_str()),
         };
-        assert_eq!(
-            error.to_string(),
-            "Response Format Error: Invalid JSON. Raw response: {invalid json}"
-        );
+        let display = error.to_string();
+        assert!(display.contains("401"));
+        assert!(display.contains("truncated"));
+        assert_eq!(error.response_body(), Some(body.as_str()));
     }
 
     #[test]
-    fn test_llm_error_display_json_error() {
-        let error = LLMError::JsonError("Parse error at line 5 column 10".to_string());
-        assert_eq!(
-            error.to_string(),
-            "JSON Parse Error: Parse error at line 5 column 10"
-        );
+    fn test_llm_error_display_rate_limit_error_includes_status() {
+        let error = LLMError::RateLimitError {
+            status_code: 529,
+            message: "Overloaded".to_string(),
+            response_body: "overload".into(),
+            retry_after: Some(Duration::from_secs(30)),
+            provider_code: Some("overloaded".into()),
+        };
+        let display = error.to_string();
+        assert!(display.contains("529"));
+        assert!(display.contains("overloaded"));
+        assert_eq!(error.http_status_code(), Some(529));
     }
 
     #[test]
-    fn test_llm_error_display_tool_config_error() {
-        let error = LLMError::ToolConfigError("Invalid tool configuration".to_string());
-        assert_eq!(
-            error.to_string(),
-            "Tool Configuration Error: Invalid tool configuration"
-        );
+    fn test_invalid_request_preserves_response_body() {
+        let err = LLMError::InvalidRequest {
+            message: "bad request".into(),
+            status_code: Some(400),
+            response_body: Some(r#"{"error":"details"}"#.into()),
+        };
+        assert_eq!(err.http_status_code(), Some(400));
+        assert_eq!(err.response_body(), Some(r#"{"error":"details"}"#));
     }
 
     #[test]
-    fn test_llm_error_is_error_trait() {
-        let error = LLMError::Generic("test error".to_string());
-        assert!(error.source().is_none());
-    }
-
-    #[test]
-    fn test_llm_error_debug_format() {
-        let error = LLMError::HttpError("test".to_string());
-        let debug_str = format!("{error:?}");
-        assert!(debug_str.contains("HttpError"));
-        assert!(debug_str.contains("test"));
-    }
-
-    #[test]
-    fn test_from_reqwest_error() {
-        // Create a mock reqwest error by trying to make a request to an invalid URL
-        let client = reqwest::Client::new();
-        let rt = tokio::runtime::Runtime::new().unwrap();
-        let reqwest_error = rt
-            .block_on(async {
-                client
-                    .get("https://invalid-url-that-does-not-exist-12345.com/")
-                    .timeout(std::time::Duration::from_millis(100))
-                    .send()
-                    .await
-            })
-            .unwrap_err();
-
-        let llm_error: LLMError = reqwest_error.into();
-
-        match llm_error {
-            LLMError::HttpError(msg) => {
-                assert!(!msg.is_empty());
+    fn test_is_retryable_matrix() {
+        assert!(
+            LLMError::RateLimitError {
+                status_code: 429,
+                message: "limit".into(),
+                response_body: "body".into(),
+                retry_after: None,
+                provider_code: None,
             }
-            _ => panic!("Expected HttpError"),
-        }
+            .is_retryable()
+        );
+        assert!(
+            LLMError::HttpStatusError {
+                status_code: 503,
+                message: "down".into(),
+                response_body: "body".into(),
+                provider_code: None,
+            }
+            .is_retryable()
+        );
+        assert!(
+            !LLMError::HttpStatusError {
+                status_code: 400,
+                message: "bad".into(),
+                response_body: "body".into(),
+                provider_code: None,
+            }
+            .is_retryable()
+        );
+        assert!(!LLMError::Generic("unsupported".into()).is_retryable());
+        assert!(LLMError::HttpError("request timed out: elapsed".into()).is_retryable());
+    }
+
+    #[test]
+    fn test_llm_error_debug_truncates_response_body() {
+        let body = "secret".repeat(MAX_ERROR_BODY_DISPLAY_BYTES + 10);
+        let error = LLMError::RateLimitError {
+            status_code: 429,
+            message: "limit".into(),
+            response_body: body.clone().into_boxed_str(),
+            retry_after: None,
+            provider_code: None,
+        };
+        let debug = format!("{error:?}");
+        assert!(debug.contains("truncated"));
+        assert!(!debug.contains(&body));
     }
 
     #[test]
@@ -234,78 +562,6 @@ mod tests {
                 assert!(msg.contains("column"));
             }
             _ => panic!("Expected JsonError"),
-        }
-    }
-
-    #[test]
-    fn test_error_variants_equality() {
-        let error1 = LLMError::HttpError("test".to_string());
-        let error2 = LLMError::HttpError("test".to_string());
-        let error3 = LLMError::HttpError("different".to_string());
-        let error4 = LLMError::AuthError("test".to_string());
-
-        // Note: LLMError doesn't implement PartialEq, so we test via string representation
-        assert_eq!(error1.to_string(), error2.to_string());
-        assert_ne!(error1.to_string(), error3.to_string());
-        assert_ne!(error1.to_string(), error4.to_string());
-    }
-
-    #[test]
-    fn test_response_format_error_fields() {
-        let error = LLMError::ResponseFormatError {
-            message: "Parse failed".to_string(),
-            raw_response: "raw content".to_string(),
-        };
-
-        let display_str = error.to_string();
-        assert!(display_str.contains("Parse failed"));
-        assert!(display_str.contains("raw content"));
-    }
-
-    #[test]
-    fn test_all_error_variants_have_display() {
-        let errors = vec![
-            LLMError::HttpError("http".to_string()),
-            LLMError::AuthError("auth".to_string()),
-            LLMError::InvalidRequest("invalid".to_string()),
-            LLMError::ProviderError("provider".to_string()),
-            LLMError::Generic("generic".to_string()),
-            LLMError::ResponseFormatError {
-                message: "format".to_string(),
-                raw_response: "raw".to_string(),
-            },
-            LLMError::JsonError("json".to_string()),
-            LLMError::ToolConfigError("tool".to_string()),
-        ];
-
-        for error in errors {
-            let display_str = error.to_string();
-            assert!(!display_str.is_empty());
-        }
-    }
-
-    #[test]
-    fn test_error_type_classification() {
-        // Test that we can pattern match on different error types
-        let http_error = LLMError::HttpError("test".to_string());
-        match http_error {
-            LLMError::HttpError(_) => {}
-            _ => panic!("Expected HttpError"),
-        }
-
-        let auth_error = LLMError::AuthError("test".to_string());
-        match auth_error {
-            LLMError::AuthError(_) => {}
-            _ => panic!("Expected AuthError"),
-        }
-
-        let response_error = LLMError::ResponseFormatError {
-            message: "test".to_string(),
-            raw_response: "test".to_string(),
-        };
-        match response_error {
-            LLMError::ResponseFormatError { .. } => {}
-            _ => panic!("Expected ResponseFormatError"),
         }
     }
 }

--- a/crates/autoagents-llm/src/error.rs
+++ b/crates/autoagents-llm/src/error.rs
@@ -35,6 +35,7 @@ pub enum LLMError {
         status_code: u16,
         message: String,
         response_body: Box<str>,
+        retry_after: Option<Duration>,
         provider_code: Option<Box<str>>,
     },
     /// Invalid request parameters, format, or client-side HTTP 4xx rejection.
@@ -197,12 +198,14 @@ impl fmt::Debug for LLMError {
                 status_code,
                 message,
                 response_body,
+                retry_after,
                 provider_code,
             } => f
                 .debug_struct("HttpStatusError")
                 .field("status_code", status_code)
                 .field("message", message)
                 .field("response_body", &truncate_for_display(response_body))
+                .field("retry_after", retry_after)
                 .field("provider_code", provider_code)
                 .finish(),
             Self::InvalidRequest {
@@ -280,6 +283,11 @@ pub fn is_retryable(err: &LLMError) -> bool {
 }
 
 /// Default fallbackability predicate shared by the fallback layer.
+///
+/// Unlike [`is_retryable`], every [`LLMError::HttpError`] is fallbackable regardless
+/// of message content so callers can route any transport failure to a backup provider.
+/// Retryability still requires a transport-failure message via
+/// [`is_transport_retryable_message`].
 pub fn is_fallbackable(err: &LLMError) -> bool {
     match err {
         LLMError::RateLimitError { .. } => true,
@@ -349,12 +357,16 @@ fn display_http_status_error(
     status_code: u16,
     message: &str,
     response_body: &str,
+    retry_after: Option<Duration>,
     provider_code: Option<&str>,
 ) -> fmt::Result {
     write!(f, "HTTP Status Error ({status_code}): {message}")?;
     write_truncated_body(f, "Response", response_body)?;
     if let Some(code) = provider_code {
         write!(f, ". Provider code: {code}")?;
+    }
+    if let Some(retry_after) = retry_after {
+        write!(f, ". Retry-After: {}s", retry_after.as_secs())?;
     }
     Ok(())
 }
@@ -423,12 +435,14 @@ impl fmt::Display for LLMError {
                 status_code,
                 message,
                 response_body,
+                retry_after,
                 provider_code,
             } => display_http_status_error(
                 f,
                 *status_code,
                 message,
                 response_body,
+                *retry_after,
                 provider_code.as_deref(),
             ),
             LLMError::InvalidRequest {
@@ -576,6 +590,7 @@ mod tests {
                 status_code: 503,
                 message: "down".into(),
                 response_body: "body".into(),
+                retry_after: None,
                 provider_code: None,
             }
             .is_retryable()
@@ -585,6 +600,7 @@ mod tests {
                 status_code: 400,
                 message: "bad".into(),
                 response_body: "body".into(),
+                retry_after: None,
                 provider_code: None,
             }
             .is_retryable()
@@ -648,6 +664,7 @@ mod tests {
             status_code: 502,
             message: "bad gateway".into(),
             response_body: "html".into(),
+            retry_after: None,
             provider_code: None,
         };
         assert_eq!(http_status.http_status_code(), Some(502));
@@ -710,6 +727,7 @@ mod tests {
                 status_code: 500,
                 message: "fail".into(),
                 response_body: "body".into(),
+                retry_after: None,
                 provider_code: Some("internal".into()),
             },
             LLMError::InvalidRequest {
@@ -758,10 +776,12 @@ mod tests {
             status_code: 500,
             message: "fail".into(),
             response_body: "body".into(),
+            retry_after: Some(Duration::from_secs(120)),
             provider_code: Some("INTERNAL".into()),
         };
         let status_display = status.to_string();
         assert!(status_display.contains("Provider code: INTERNAL"));
+        assert!(status_display.contains("Retry-After: 120s"));
 
         let format_error = LLMError::ResponseFormatError {
             message: "bad json".into(),

--- a/crates/autoagents-llm/src/error.rs
+++ b/crates/autoagents-llm/src/error.rs
@@ -624,4 +624,203 @@ mod tests {
             _ => panic!("Expected JsonError"),
         }
     }
+
+    #[test]
+    fn test_http_status_code_and_response_body_accessors() {
+        let auth = LLMError::AuthError {
+            message: "denied".into(),
+            status_code: Some(403),
+            response_body: Some("body".into()),
+        };
+        assert_eq!(auth.http_status_code(), Some(403));
+        assert_eq!(auth.response_body(), Some("body"));
+
+        let rate_limit = LLMError::RateLimitError {
+            status_code: 429,
+            message: "limit".into(),
+            response_body: "payload".into(),
+            retry_after: None,
+            provider_code: None,
+        };
+        assert_eq!(rate_limit.response_body(), Some("payload"));
+
+        let http_status = LLMError::HttpStatusError {
+            status_code: 502,
+            message: "bad gateway".into(),
+            response_body: "html".into(),
+            provider_code: None,
+        };
+        assert_eq!(http_status.http_status_code(), Some(502));
+        assert_eq!(http_status.response_body(), Some("html"));
+
+        let format_error = LLMError::ResponseFormatError {
+            message: "invalid json".into(),
+            raw_response: "not-json".into(),
+        };
+        assert_eq!(format_error.response_body(), Some("not-json"));
+        assert_eq!(LLMError::Generic("x".into()).http_status_code(), None);
+        assert_eq!(LLMError::JsonError("parse".into()).response_body(), None);
+    }
+
+    #[test]
+    fn test_is_transport_retryable_method() {
+        assert!(LLMError::HttpError("request timed out: elapsed".into()).is_transport_retryable());
+        assert!(!LLMError::Generic("timeout".into()).is_transport_retryable());
+    }
+
+    #[test]
+    fn test_truncate_for_display_respects_utf8_boundary() {
+        let body = format!("{}€{}", "a".repeat(511), "z".repeat(20));
+        let truncated = truncate_for_display(&body);
+        assert!(truncated.contains("truncated"));
+        assert!(std::str::from_utf8(truncated.as_bytes()).is_ok());
+    }
+
+    #[test]
+    fn test_is_fallbackable_matrix() {
+        assert!(is_fallbackable(&LLMError::HttpError("down".into())));
+        assert!(is_fallbackable(&LLMError::RateLimitError {
+            status_code: 429,
+            message: "limit".into(),
+            response_body: "body".into(),
+            retry_after: None,
+            provider_code: None,
+        }));
+        assert!(!is_fallbackable(&LLMError::missing_api_key("missing")));
+        assert!(!is_fallbackable(&LLMError::GuardrailBlocked {
+            phase: GuardrailPhase::Input,
+            guard: "g".into(),
+            rule_id: "r".into(),
+            category: "c".into(),
+            severity: "high".into(),
+            message: "blocked".into(),
+        }));
+    }
+
+    #[test]
+    fn test_llm_error_debug_covers_struct_variants() {
+        let cases: Vec<LLMError> = vec![
+            LLMError::HttpError("transport".into()),
+            LLMError::AuthError {
+                message: "denied".into(),
+                status_code: Some(401),
+                response_body: Some("secret".into()),
+            },
+            LLMError::HttpStatusError {
+                status_code: 500,
+                message: "fail".into(),
+                response_body: "body".into(),
+                provider_code: Some("internal".into()),
+            },
+            LLMError::InvalidRequest {
+                message: "bad".into(),
+                status_code: Some(422),
+                response_body: Some("details".into()),
+            },
+            LLMError::ProviderError("provider".into()),
+            LLMError::ResponseFormatError {
+                message: "parse".into(),
+                raw_response: "raw".into(),
+            },
+            LLMError::Generic("generic".into()),
+            LLMError::JsonError("json".into()),
+            LLMError::ToolConfigError("tool".into()),
+            LLMError::NoToolSupport("tools".into()),
+            LLMError::GuardrailBlocked {
+                phase: GuardrailPhase::Output,
+                guard: "guard".into(),
+                rule_id: "rule".into(),
+                category: "cat".into(),
+                severity: "low".into(),
+                message: "msg".into(),
+            },
+            LLMError::GuardrailExecutionFailed {
+                guard: "guard".into(),
+                message: "runtime".into(),
+            },
+        ];
+
+        for error in cases {
+            let debug = format!("{error:?}");
+            assert!(!debug.is_empty());
+        }
+    }
+
+    #[test]
+    fn test_llm_error_display_covers_remaining_variants() {
+        assert!(
+            LLMError::HttpError("transport".into())
+                .to_string()
+                .contains("HTTP Error")
+        );
+
+        let status = LLMError::HttpStatusError {
+            status_code: 500,
+            message: "fail".into(),
+            response_body: "body".into(),
+            provider_code: Some("INTERNAL".into()),
+        };
+        let status_display = status.to_string();
+        assert!(status_display.contains("Provider code: INTERNAL"));
+
+        let format_error = LLMError::ResponseFormatError {
+            message: "bad json".into(),
+            raw_response: "not-json".into(),
+        };
+        assert!(format_error.to_string().contains("Response Format Error"));
+        assert!(format_error.to_string().contains("Raw response"));
+
+        let input_block = LLMError::GuardrailBlocked {
+            phase: GuardrailPhase::Input,
+            guard: "g".into(),
+            rule_id: "r".into(),
+            category: "c".into(),
+            severity: "high".into(),
+            message: "blocked".into(),
+        };
+        assert!(input_block.to_string().contains("guardrail blocked input"));
+
+        let output_block = LLMError::GuardrailBlocked {
+            phase: GuardrailPhase::Output,
+            guard: "g".into(),
+            rule_id: "r".into(),
+            category: "c".into(),
+            severity: "high".into(),
+            message: "blocked".into(),
+        };
+        assert!(
+            output_block
+                .to_string()
+                .contains("guardrail blocked output")
+        );
+
+        let execution_failed = LLMError::GuardrailExecutionFailed {
+            guard: "g".into(),
+            message: "runtime".into(),
+        };
+        assert!(
+            execution_failed
+                .to_string()
+                .contains("guardrail execution failed")
+        );
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[tokio::test]
+    async fn test_from_reqwest_connection_error() {
+        let client = reqwest::Client::new();
+        let err = client
+            .get("http://127.0.0.1:1")
+            .send()
+            .await
+            .expect_err("connection should fail");
+
+        let llm_err = LLMError::from(err);
+        match llm_err {
+            LLMError::HttpError(message) => {
+                assert!(message.starts_with("connection failed:"));
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
 }

--- a/crates/autoagents-llm/src/http.rs
+++ b/crates/autoagents-llm/src/http.rs
@@ -3,6 +3,7 @@
 use std::time::Duration;
 
 use chrono::{DateTime, Utc};
+use futures::StreamExt;
 use reqwest::{Response, StatusCode};
 
 use crate::error::LLMError;
@@ -58,16 +59,52 @@ fn http_status_error(
 }
 
 async fn read_bounded_error_body(response: Response) -> Result<String, LLMError> {
-    let bytes = response.bytes().await?;
-    if bytes.len() <= MAX_HTTP_ERROR_BODY_BYTES {
-        return Ok(String::from_utf8_lossy(&bytes).into_owned());
+    if let Some(content_length) = response.content_length()
+        && content_length as usize > MAX_HTTP_ERROR_BODY_BYTES
+    {
+        return Ok(format!(
+            "... [body omitted, Content-Length: {content_length} bytes]"
+        ));
     }
 
-    let truncated = String::from_utf8_lossy(&bytes[..MAX_HTTP_ERROR_BODY_BYTES]).into_owned();
-    Ok(format!(
-        "{truncated}... [truncated, {} bytes total]",
-        bytes.len()
-    ))
+    let mut stream = response.bytes_stream();
+    let mut collected = Vec::with_capacity(MAX_HTTP_ERROR_BODY_BYTES.min(8192));
+    let mut total_received = 0usize;
+    let mut at_capacity = false;
+
+    while let Some(chunk_result) = stream.next().await {
+        let chunk = chunk_result?;
+        let chunk_len = chunk.len();
+        total_received += chunk_len;
+
+        if !at_capacity {
+            let remaining = MAX_HTTP_ERROR_BODY_BYTES.saturating_sub(collected.len());
+            if chunk_len <= remaining {
+                collected.extend_from_slice(&chunk);
+                if collected.len() == MAX_HTTP_ERROR_BODY_BYTES {
+                    at_capacity = true;
+                }
+            } else {
+                collected.extend_from_slice(&chunk[..remaining]);
+                at_capacity = true;
+            }
+        }
+
+        if at_capacity {
+            break;
+        }
+    }
+
+    if at_capacity {
+        Ok(format_truncated_error_body(&collected, total_received))
+    } else {
+        Ok(String::from_utf8_lossy(&collected).into_owned())
+    }
+}
+
+fn format_truncated_error_body(collected: &[u8], bytes_read: usize) -> String {
+    let truncated = String::from_utf8_lossy(collected).into_owned();
+    format!("{truncated}... [truncated after reading {bytes_read} bytes]")
 }
 
 fn map_http_status_error(
@@ -363,6 +400,78 @@ mod tests {
                     "TestProvider API returned error status: 503 Service Unavailable"
                 );
                 assert_eq!(response_body.as_ref(), "service unavailable");
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn read_bounded_error_body_skips_oversized_content_length() {
+        let server = httpmock::MockServer::start();
+        let oversized_body = "x".repeat(MAX_HTTP_ERROR_BODY_BYTES + 1);
+        let _mock = server.mock(|when, then| {
+            when.method(httpmock::Method::GET).path("/huge");
+            then.status(500).body(&oversized_body);
+        });
+
+        let client = Client::new();
+        let response = client
+            .get(format!("{}/huge", server.base_url()))
+            .send()
+            .await
+            .unwrap();
+        let err = ensure_success(response, "TestProvider")
+            .await
+            .expect_err("expected error");
+
+        match err {
+            LLMError::HttpStatusError { response_body, .. } => {
+                assert!(response_body.contains("body omitted"));
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn read_bounded_error_body_truncates_chunked_response() {
+        let server = httpmock::MockServer::start();
+        let oversized_body = "y".repeat(MAX_HTTP_ERROR_BODY_BYTES + 8_192);
+        let _mock = server.mock(|when, then| {
+            when.method(httpmock::Method::GET).path("/chunked");
+            then.status(500)
+                .header("Transfer-Encoding", "chunked")
+                .body(&oversized_body);
+        });
+
+        let client = Client::new();
+        let response = client
+            .get(format!("{}/chunked", server.base_url()))
+            .send()
+            .await
+            .unwrap();
+        let err = ensure_success(response, "TestProvider")
+            .await
+            .expect_err("expected error");
+
+        match err {
+            LLMError::HttpStatusError { response_body, .. } => {
+                assert!(
+                    response_body.contains("truncated after reading")
+                        || response_body.contains("body omitted"),
+                    "unexpected body: {response_body}"
+                );
+                assert!(response_body.len() < oversized_body.len());
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn read_bounded_error_body_returns_small_body_unchanged() {
+        let err = error_for_status(500, "small error", None).await;
+        match err {
+            LLMError::HttpStatusError { response_body, .. } => {
+                assert_eq!(response_body.as_ref(), "small error");
             }
             other => panic!("unexpected error: {other:?}"),
         }

--- a/crates/autoagents-llm/src/http.rs
+++ b/crates/autoagents-llm/src/http.rs
@@ -49,11 +49,13 @@ fn http_status_error(
     message: String,
     response_body: impl Into<Box<str>>,
     provider_code: Option<Box<str>>,
+    retry_after: Option<Duration>,
 ) -> LLMError {
     LLMError::HttpStatusError {
         status_code,
         message,
         response_body: response_body.into(),
+        retry_after,
         provider_code,
     }
 }
@@ -68,7 +70,7 @@ async fn read_bounded_error_body(response: Response) -> Result<String, LLMError>
     // drained, so the connection may not be reused; that tradeoff is intentional on the
     // error path where bounded memory use matters more than keep-alive reuse.
     if let Some(content_length) = response.content_length()
-        && content_length as usize > MAX_HTTP_ERROR_BODY_BYTES
+        && content_length > MAX_HTTP_ERROR_BODY_BYTES as u64
     {
         return Ok(format!(
             "... [body omitted, Content-Length: {content_length} bytes]"
@@ -151,6 +153,7 @@ fn map_http_status_error(
             message,
             response_body,
             provider_code,
+            retry_after,
         )),
     }
 }
@@ -453,6 +456,22 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn maps_503_to_http_status_error_with_retry_after() {
+        let err = error_for_status(503, "service unavailable", Some("300")).await;
+        match err {
+            LLMError::HttpStatusError {
+                status_code,
+                retry_after,
+                ..
+            } => {
+                assert_eq!(status_code, 503);
+                assert_eq!(retry_after, Some(Duration::from_secs(300)));
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
     async fn maps_plain_text_503_to_http_status_error() {
         let err = error_for_status(503, "service unavailable", None).await;
         match err {
@@ -524,7 +543,7 @@ mod tests {
         match response.content_length() {
             None => {}
             Some(content_length) => assert!(
-                content_length as usize <= MAX_HTTP_ERROR_BODY_BYTES,
+                content_length <= MAX_HTTP_ERROR_BODY_BYTES as u64,
                 "unexpected Content-Length for streaming test: {content_length}"
             ),
         }

--- a/crates/autoagents-llm/src/http.rs
+++ b/crates/autoagents-llm/src/http.rs
@@ -1,0 +1,390 @@
+//! Centralized HTTP response handling for LLM provider backends.
+
+use std::time::Duration;
+
+use chrono::{DateTime, Utc};
+use reqwest::{Response, StatusCode};
+
+use crate::error::LLMError;
+
+/// Maximum bytes read from a non-success HTTP response body.
+const MAX_HTTP_ERROR_BODY_BYTES: usize = 65_536;
+
+/// Parsed provider error payload extracted from a non-success response body.
+#[derive(Debug, Default)]
+struct ProviderErrorDetails {
+    message: Option<String>,
+    provider_code: Option<String>,
+}
+
+/// Ensures an HTTP response has a success status, mapping failures to typed errors.
+///
+/// On success, returns the original response unchanged so callers can decode the body.
+/// On failure, reads the response body once and maps status codes to
+/// [`AuthError`](LLMError::AuthError), [`RateLimitError`](LLMError::RateLimitError),
+/// [`HttpStatusError`](LLMError::HttpStatusError), or [`InvalidRequest`](LLMError::InvalidRequest).
+pub async fn ensure_success(response: Response, provider: &str) -> Result<Response, LLMError> {
+    if response.status().is_success() {
+        return Ok(response);
+    }
+
+    let status_code = response.status().as_u16();
+    let retry_after = parse_retry_after(response.headers());
+    let body = read_bounded_error_body(response).await?;
+    let details = parse_provider_error_body(&body);
+
+    map_http_status_error(provider, status_code, body, details, retry_after)
+}
+
+fn default_error_message(provider: &str, status_code: u16) -> String {
+    match StatusCode::from_u16(status_code) {
+        Ok(status) => format!("{provider} API returned error status: {status}"),
+        Err(_) => format!("{provider} API returned error status: {status_code}"),
+    }
+}
+
+fn http_status_error(
+    status_code: u16,
+    message: String,
+    response_body: impl Into<Box<str>>,
+    provider_code: Option<Box<str>>,
+) -> LLMError {
+    LLMError::HttpStatusError {
+        status_code,
+        message,
+        response_body: response_body.into(),
+        provider_code,
+    }
+}
+
+async fn read_bounded_error_body(response: Response) -> Result<String, LLMError> {
+    let bytes = response.bytes().await?;
+    if bytes.len() <= MAX_HTTP_ERROR_BODY_BYTES {
+        return Ok(String::from_utf8_lossy(&bytes).into_owned());
+    }
+
+    let truncated = String::from_utf8_lossy(&bytes[..MAX_HTTP_ERROR_BODY_BYTES]).into_owned();
+    Ok(format!(
+        "{truncated}... [truncated, {} bytes total]",
+        bytes.len()
+    ))
+}
+
+fn map_http_status_error(
+    provider: &str,
+    status_code: u16,
+    body: String,
+    details: ProviderErrorDetails,
+    retry_after: Option<Duration>,
+) -> Result<Response, LLMError> {
+    let message = details
+        .message
+        .unwrap_or_else(|| default_error_message(provider, status_code));
+    let provider_code = details.provider_code.map(String::into_boxed_str);
+    let response_body = body.into_boxed_str();
+
+    match status_code {
+        401 | 403 => Err(LLMError::AuthError {
+            message,
+            status_code: Some(status_code),
+            response_body: Some(response_body),
+        }),
+        429 | 529 => Err(LLMError::RateLimitError {
+            status_code,
+            message,
+            response_body,
+            retry_after,
+            provider_code,
+        }),
+        400 | 404 | 413 | 422 => Err(LLMError::InvalidRequest {
+            message,
+            status_code: Some(status_code),
+            response_body: Some(response_body),
+        }),
+        _ => Err(http_status_error(
+            status_code,
+            message,
+            response_body,
+            provider_code,
+        )),
+    }
+}
+
+fn parse_retry_after(headers: &reqwest::header::HeaderMap) -> Option<Duration> {
+    let value = headers
+        .get(reqwest::header::RETRY_AFTER)?
+        .to_str()
+        .ok()?
+        .trim();
+
+    if let Ok(seconds) = value.parse::<u64>() {
+        return Some(Duration::from_secs(seconds));
+    }
+
+    parse_retry_after_http_date(value)
+}
+
+fn parse_retry_after_http_date(value: &str) -> Option<Duration> {
+    let retry_at = DateTime::parse_from_rfc2822(value)
+        .ok()
+        .map(|dt| dt.with_timezone(&Utc))
+        .or_else(|| {
+            DateTime::parse_from_rfc3339(value)
+                .ok()
+                .map(|dt| dt.with_timezone(&Utc))
+        })?;
+
+    let now = Utc::now();
+    if retry_at > now {
+        retry_at.signed_duration_since(now).to_std().ok()
+    } else {
+        None
+    }
+}
+
+fn parse_provider_error_body(body: &str) -> ProviderErrorDetails {
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(body) else {
+        return ProviderErrorDetails::default();
+    };
+
+    // OpenAI-compatible: { "error": { "message", "type", "code" } }
+    if let Some(error) = value.get("error") {
+        return ProviderErrorDetails {
+            message: error
+                .get("message")
+                .and_then(|v| v.as_str())
+                .map(str::to_string),
+            provider_code: error
+                .get("code")
+                .or_else(|| error.get("type"))
+                .and_then(|v| v.as_str())
+                .map(str::to_string),
+        };
+    }
+
+    ProviderErrorDetails {
+        message: value
+            .get("message")
+            .and_then(|v| v.as_str())
+            .map(str::to_string),
+        provider_code: value
+            .get("type")
+            .and_then(|v| v.as_str())
+            .map(str::to_string),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use reqwest::Client;
+
+    async fn error_for_status(status: u16, body: &str, retry_after: Option<&str>) -> LLMError {
+        let server = httpmock::MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(httpmock::Method::GET).path("/error");
+            if let Some(value) = retry_after {
+                then.status(status).body(body).header("Retry-After", value);
+            } else {
+                then.status(status).body(body);
+            }
+        });
+
+        let client = Client::new();
+        let response = client
+            .get(format!("{}/error", server.base_url()))
+            .send()
+            .await
+            .unwrap();
+        mock.assert();
+        ensure_success(response, "TestProvider")
+            .await
+            .expect_err("expected error")
+    }
+
+    #[test]
+    fn parse_retry_after_accepts_delay_seconds() {
+        let mut headers = reqwest::header::HeaderMap::new();
+        headers.insert(reqwest::header::RETRY_AFTER, "45".parse().unwrap());
+        assert_eq!(parse_retry_after(&headers), Some(Duration::from_secs(45)));
+    }
+
+    #[test]
+    fn parse_retry_after_accepts_http_date() {
+        let mut headers = reqwest::header::HeaderMap::new();
+        let future = (Utc::now() + chrono::Duration::seconds(60))
+            .format("%a, %d %b %Y %H:%M:%S GMT")
+            .to_string();
+        headers.insert(
+            reqwest::header::RETRY_AFTER,
+            future.parse().expect("valid header value"),
+        );
+        let parsed = parse_retry_after(&headers).expect("retry-after should parse");
+        assert!(parsed >= Duration::from_secs(55));
+        assert!(parsed <= Duration::from_secs(65));
+    }
+
+    #[tokio::test]
+    async fn maps_401_to_auth_error() {
+        let err = error_for_status(401, r#"{"error":{"message":"invalid key"}}"#, None).await;
+        match err {
+            LLMError::AuthError {
+                status_code,
+                message,
+                ..
+            } => {
+                assert_eq!(status_code, Some(401));
+                assert_eq!(message, "invalid key");
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn maps_403_to_auth_error() {
+        let err = error_for_status(403, r#"{"error":{"message":"forbidden"}}"#, None).await;
+        match err {
+            LLMError::AuthError {
+                status_code,
+                message,
+                ..
+            } => {
+                assert_eq!(status_code, Some(403));
+                assert_eq!(message, "forbidden");
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn maps_429_to_rate_limit_error_with_retry_after() {
+        let err = error_for_status(
+            429,
+            r#"{"error":{"message":"rate limited","code":"rate_limit_exceeded"}}"#,
+            Some("30"),
+        )
+        .await;
+        match err {
+            LLMError::RateLimitError {
+                status_code,
+                message,
+                retry_after,
+                provider_code,
+                ..
+            } => {
+                assert_eq!(status_code, 429);
+                assert_eq!(message, "rate limited");
+                assert_eq!(provider_code.as_deref(), Some("rate_limit_exceeded"));
+                assert_eq!(retry_after, Some(Duration::from_secs(30)));
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn maps_529_to_rate_limit_error() {
+        let err = error_for_status(
+            529,
+            r#"{"error":{"message":"overloaded","type":"overloaded_error"}}"#,
+            None,
+        )
+        .await;
+        match err {
+            LLMError::RateLimitError {
+                status_code,
+                message,
+                provider_code,
+                ..
+            } => {
+                assert_eq!(status_code, 529);
+                assert_eq!(message, "overloaded");
+                assert_eq!(provider_code.as_deref(), Some("overloaded_error"));
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn maps_408_to_retryable_http_status_error() {
+        let err = error_for_status(408, "request timeout", None).await;
+        match err {
+            LLMError::HttpStatusError { status_code, .. } => assert_eq!(status_code, 408),
+            other => panic!("unexpected error: {other:?}"),
+        }
+        assert!(err.is_retryable());
+    }
+
+    #[tokio::test]
+    async fn maps_500_to_http_status_error() {
+        let err = error_for_status(500, "provider exploded", None).await;
+        match err {
+            LLMError::HttpStatusError {
+                status_code,
+                response_body,
+                ..
+            } => {
+                assert_eq!(status_code, 500);
+                assert_eq!(response_body.as_ref(), "provider exploded");
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn maps_400_to_invalid_request_with_body() {
+        let err = error_for_status(400, r#"{"error":{"message":"bad request"}}"#, None).await;
+        match err {
+            LLMError::InvalidRequest {
+                message,
+                status_code,
+                response_body,
+            } => {
+                assert_eq!(message, "bad request");
+                assert_eq!(status_code, Some(400));
+                assert!(response_body.is_some());
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn maps_plain_text_503_to_http_status_error() {
+        let err = error_for_status(503, "service unavailable", None).await;
+        match err {
+            LLMError::HttpStatusError {
+                status_code,
+                message,
+                response_body,
+                ..
+            } => {
+                assert_eq!(status_code, 503);
+                assert_eq!(
+                    message,
+                    "TestProvider API returned error status: 503 Service Unavailable"
+                );
+                assert_eq!(response_body.as_ref(), "service unavailable");
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn success_response_passes_through() {
+        let server = httpmock::MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(httpmock::Method::GET).path("/ok");
+            then.status(200).body(r#"{"ok":true}"#);
+        });
+
+        let client = Client::new();
+        let response = client
+            .get(format!("{}/ok", server.base_url()))
+            .send()
+            .await
+            .unwrap();
+        let response = ensure_success(response, "TestProvider").await.unwrap();
+        mock.assert();
+        assert_eq!(response.status(), 200);
+        assert_eq!(response.text().await.unwrap(), r#"{"ok":true}"#);
+    }
+}

--- a/crates/autoagents-llm/src/http.rs
+++ b/crates/autoagents-llm/src/http.rs
@@ -59,6 +59,14 @@ fn http_status_error(
 }
 
 async fn read_bounded_error_body(response: Response) -> Result<String, LLMError> {
+    // Reads at most `MAX_HTTP_ERROR_BODY_BYTES` from the wire on error responses.
+    //
+    // When `Content-Length` exceeds the cap, the body is not read at all and a placeholder
+    // is returned instead. This avoids pulling multi-megabyte CDN/WAF HTML pages into memory.
+    //
+    // Otherwise the body is streamed and accumulation stops at the cap. The remainder is not
+    // drained, so the connection may not be reused; that tradeoff is intentional on the
+    // error path where bounded memory use matters more than keep-alive reuse.
     if let Some(content_length) = response.content_length()
         && content_length as usize > MAX_HTTP_ERROR_BODY_BYTES
     {
@@ -185,6 +193,7 @@ fn parse_provider_error_body(body: &str) -> ProviderErrorDetails {
     };
 
     // OpenAI-compatible: { "error": { "message", "type", "code" } }
+    // Google: { "error": { "message", "code" (numeric), "status" } }
     if let Some(error) = value.get("error") {
         return ProviderErrorDetails {
             message: error
@@ -193,8 +202,9 @@ fn parse_provider_error_body(body: &str) -> ProviderErrorDetails {
                 .map(str::to_string),
             provider_code: error
                 .get("code")
-                .or_else(|| error.get("type"))
                 .and_then(|v| v.as_str())
+                .or_else(|| error.get("type").and_then(|v| v.as_str()))
+                .or_else(|| error.get("status").and_then(|v| v.as_str()))
                 .map(str::to_string),
         };
     }
@@ -237,6 +247,15 @@ mod tests {
         ensure_success(response, "TestProvider")
             .await
             .expect_err("expected error")
+    }
+
+    #[test]
+    fn parse_provider_error_body_extracts_google_status() {
+        let details = parse_provider_error_body(
+            r#"{"error":{"code":429,"message":"Resource exhausted","status":"RESOURCE_EXHAUSTED"}}"#,
+        );
+        assert_eq!(details.message.as_deref(), Some("Resource exhausted"));
+        assert_eq!(details.provider_code.as_deref(), Some("RESOURCE_EXHAUSTED"));
     }
 
     #[test]
@@ -435,7 +454,8 @@ mod tests {
     #[tokio::test]
     async fn read_bounded_error_body_truncates_chunked_response() {
         let server = httpmock::MockServer::start();
-        let oversized_body = "y".repeat(MAX_HTTP_ERROR_BODY_BYTES + 8_192);
+        let overflow = 8_192;
+        let oversized_body = "y".repeat(MAX_HTTP_ERROR_BODY_BYTES + overflow);
         let _mock = server.mock(|when, then| {
             when.method(httpmock::Method::GET).path("/chunked");
             then.status(500)
@@ -449,16 +469,35 @@ mod tests {
             .send()
             .await
             .unwrap();
+
+        // Chunked responses must not advertise a Content-Length above the cap; otherwise
+        // the fast-path skip would run instead of the streaming truncation under test.
+        match response.content_length() {
+            None => {}
+            Some(content_length) => assert!(
+                content_length as usize <= MAX_HTTP_ERROR_BODY_BYTES,
+                "unexpected Content-Length for streaming test: {content_length}"
+            ),
+        }
+
         let err = ensure_success(response, "TestProvider")
             .await
             .expect_err("expected error");
 
         match err {
             LLMError::HttpStatusError { response_body, .. } => {
+                let expected_prefix = "y".repeat(MAX_HTTP_ERROR_BODY_BYTES);
                 assert!(
-                    response_body.contains("truncated after reading")
-                        || response_body.contains("body omitted"),
+                    response_body.starts_with(&expected_prefix),
+                    "expected first {MAX_HTTP_ERROR_BODY_BYTES} bytes preserved"
+                );
+                assert!(
+                    response_body.contains("truncated after reading"),
                     "unexpected body: {response_body}"
+                );
+                assert!(
+                    !response_body.contains("body omitted"),
+                    "expected streaming truncation, not Content-Length skip"
                 );
                 assert!(response_body.len() < oversized_body.len());
             }

--- a/crates/autoagents-llm/src/http.rs
+++ b/crates/autoagents-llm/src/http.rs
@@ -280,6 +280,55 @@ mod tests {
         assert!(parsed <= Duration::from_secs(65));
     }
 
+    #[test]
+    fn parse_retry_after_accepts_rfc3339_date() {
+        let mut headers = reqwest::header::HeaderMap::new();
+        let future = (Utc::now() + chrono::Duration::seconds(90)).to_rfc3339();
+        headers.insert(
+            reqwest::header::RETRY_AFTER,
+            future.parse().expect("valid header value"),
+        );
+        let parsed = parse_retry_after(&headers).expect("retry-after should parse");
+        assert!(parsed >= Duration::from_secs(85));
+        assert!(parsed <= Duration::from_secs(95));
+    }
+
+    #[test]
+    fn parse_retry_after_past_http_date_returns_none() {
+        let mut headers = reqwest::header::HeaderMap::new();
+        let past = (Utc::now() - chrono::Duration::seconds(120))
+            .format("%a, %d %b %Y %H:%M:%S GMT")
+            .to_string();
+        headers.insert(
+            reqwest::header::RETRY_AFTER,
+            past.parse().expect("valid header value"),
+        );
+        assert_eq!(parse_retry_after(&headers), None);
+    }
+
+    #[test]
+    fn parse_provider_error_body_reads_top_level_fields() {
+        let details = parse_provider_error_body(r#"{"message":"fail","type":"provider_error"}"#);
+        assert_eq!(details.message.as_deref(), Some("fail"));
+        assert_eq!(details.provider_code.as_deref(), Some("provider_error"));
+    }
+
+    #[tokio::test]
+    async fn maps_non_standard_status_code_uses_numeric_default_message() {
+        let err = error_for_status(999, "non-standard", None).await;
+        match err {
+            LLMError::HttpStatusError {
+                message,
+                status_code,
+                ..
+            } => {
+                assert_eq!(status_code, 999);
+                assert!(message.contains("999"));
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
     #[tokio::test]
     async fn maps_401_to_auth_error() {
         let err = error_for_status(401, r#"{"error":{"message":"invalid key"}}"#, None).await;

--- a/crates/autoagents-llm/src/lib.rs
+++ b/crates/autoagents-llm/src/lib.rs
@@ -56,6 +56,13 @@ pub mod embedding;
 /// Error types and handling
 pub mod error;
 
+/// Shared configuration constants.
+pub mod config;
+
+/// Centralized HTTP response handling for provider backends.
+#[cfg(not(target_arch = "wasm32"))]
+pub mod http;
+
 /// Evaluator for LLM providers
 pub mod evaluator;
 

--- a/crates/autoagents-llm/src/optim/fallback.rs
+++ b/crates/autoagents-llm/src/optim/fallback.rs
@@ -80,10 +80,10 @@ impl Default for FallbackConfig {
 
 /// Default fallbackability predicate.
 ///
-/// Falls back on network, provider, and response-format errors as well as
-/// [`NoToolSupport`](crate::error::LLMError::NoToolSupport).
+/// Falls back on network, provider, response-format, and generic capability
+/// errors as well as typed rate-limit and retryable HTTP status failures.
 ///
-/// Does **not** fall back on auth, invalid-request, or generic errors.
+/// Does **not** fall back on auth, invalid-request, or guardrail errors.
 pub fn default_is_fallbackable(err: &LLMError) -> bool {
     crate::error::is_fallbackable(err)
 }
@@ -811,6 +811,12 @@ mod tests {
             message: "bad".into(),
             raw_response: "{}".into()
         }));
+        assert!(default_is_fallbackable(&LLMError::Generic(
+            "unsupported capability".into()
+        )));
+        assert!(default_is_fallbackable(&LLMError::HttpError(
+            "upstream unavailable".into()
+        )));
     }
 
     #[test]

--- a/crates/autoagents-llm/src/optim/fallback.rs
+++ b/crates/autoagents-llm/src/optim/fallback.rs
@@ -80,20 +80,12 @@ impl Default for FallbackConfig {
 
 /// Default fallbackability predicate.
 ///
-/// Falls back on network, provider, and structural-response errors as well as
-/// [`NoToolSupport`](crate::error::LLMError::NoToolSupport) (enables routing
-/// tool-calling tasks to a capable fallback).
+/// Falls back on network, provider, and response-format errors as well as
+/// [`NoToolSupport`](crate::error::LLMError::NoToolSupport).
 ///
-/// Does **not** fall back on auth or invalid-request errors.
+/// Does **not** fall back on auth, invalid-request, or generic errors.
 pub fn default_is_fallbackable(err: &LLMError) -> bool {
-    matches!(
-        err,
-        LLMError::HttpError(_)
-            | LLMError::ProviderError(_)
-            | LLMError::Generic(_)
-            | LLMError::ResponseFormatError { .. }
-            | LLMError::NoToolSupport(_)
-    )
+    crate::error::is_fallbackable(err)
 }
 
 // ---------------------------------------------------------------------------
@@ -461,7 +453,12 @@ mod tests {
     impl EmbeddingProvider for AlwaysFails {
         async fn embed(&self, _input: Vec<String>) -> Result<Vec<Vec<f32>>, LLMError> {
             self.calls.fetch_add(1, Ordering::Relaxed);
-            Err(LLMError::HttpError(self.err_msg.clone()))
+            Err(LLMError::HttpStatusError {
+                status_code: 503,
+                message: self.err_msg.clone(),
+                response_body: self.err_msg.clone().into_boxed_str(),
+                provider_code: None,
+            })
         }
     }
     #[async_trait]
@@ -622,7 +619,7 @@ mod tests {
 
         let msg = ChatMessage::user().content("hi").build();
         let err = provider.chat(&[msg], None).await.unwrap_err();
-        assert!(matches!(err, LLMError::AuthError(_)));
+        assert!(matches!(err, LLMError::AuthError { .. }));
         assert_eq!(
             fallback.call_count(),
             0,
@@ -700,7 +697,7 @@ mod tests {
         let fallback = AlwaysSucceeds::new("custom_fallback");
 
         let config = FallbackConfig {
-            fallbackable: |err| matches!(err, LLMError::AuthError(_)),
+            fallbackable: |err| matches!(err, LLMError::AuthError { .. }),
         };
         let provider = FallbackLayer::new(vec![fallback.clone() as Arc<dyn LLMProvider>])
             .with_config(config)
@@ -726,7 +723,7 @@ mod tests {
             _tools: Option<&[Tool]>,
             _json_schema: Option<StructuredOutputFormat>,
         ) -> Result<Box<dyn ChatResponse>, LLMError> {
-            Err(LLMError::AuthError("invalid key".into()))
+            Err(LLMError::missing_api_key("invalid key".to_string()))
         }
     }
     #[async_trait]
@@ -736,13 +733,13 @@ mod tests {
             _req: &CompletionRequest,
             _json_schema: Option<StructuredOutputFormat>,
         ) -> Result<CompletionResponse, LLMError> {
-            Err(LLMError::AuthError("invalid key".into()))
+            Err(LLMError::missing_api_key("invalid key".to_string()))
         }
     }
     #[async_trait]
     impl EmbeddingProvider for AuthFailProvider {
         async fn embed(&self, _input: Vec<String>) -> Result<Vec<Vec<f32>>, LLMError> {
-            Err(LLMError::AuthError("invalid key".into()))
+            Err(LLMError::missing_api_key("invalid key".to_string()))
         }
     }
     #[async_trait]
@@ -795,14 +792,18 @@ mod tests {
     #[test]
     fn fallbackable_errors() {
         assert!(default_is_fallbackable(&LLMError::HttpError(
-            "timeout".into()
+            "request timed out: operation timed out".into()
         )));
         assert!(default_is_fallbackable(&LLMError::ProviderError(
             "down".into()
         )));
-        assert!(default_is_fallbackable(&LLMError::Generic(
-            "network".into()
-        )));
+        assert!(default_is_fallbackable(&LLMError::RateLimitError {
+            status_code: 429,
+            message: "limit".into(),
+            response_body: "body".into(),
+            retry_after: None,
+            provider_code: None,
+        }));
         assert!(default_is_fallbackable(&LLMError::NoToolSupport(
             "unsupported".into()
         )));
@@ -814,11 +815,11 @@ mod tests {
 
     #[test]
     fn non_fallbackable_errors() {
-        assert!(!default_is_fallbackable(&LLMError::AuthError(
-            "bad key".into()
+        assert!(!default_is_fallbackable(&LLMError::missing_api_key(
+            "bad key"
         )));
-        assert!(!default_is_fallbackable(&LLMError::InvalidRequest(
-            "bad param".into()
+        assert!(!default_is_fallbackable(&LLMError::invalid_request(
+            "bad param"
         )));
         assert!(!default_is_fallbackable(&LLMError::JsonError(
             "parse".into()

--- a/crates/autoagents-llm/src/optim/fallback.rs
+++ b/crates/autoagents-llm/src/optim/fallback.rs
@@ -80,10 +80,16 @@ impl Default for FallbackConfig {
 
 /// Default fallbackability predicate.
 ///
-/// Falls back on network, provider, response-format, and generic capability
-/// errors as well as typed rate-limit and retryable HTTP status failures.
+/// Falls back on rate-limit, retryable server (5xx/408), all transport
+/// [`HttpError`] values, provider, response-format, no-tool-support, and
+/// generic capability errors.
 ///
-/// Does **not** fall back on auth, invalid-request, or guardrail errors.
+/// Does **not** fall back on auth, invalid-request, JSON/tool-config, or
+/// guardrail errors.
+///
+/// Note: [`is_retryable`] narrows [`HttpError`] to transport-failure messages only;
+/// fallback intentionally keeps every [`HttpError`] eligible so backup providers
+/// can absorb opaque transport failures.
 pub fn default_is_fallbackable(err: &LLMError) -> bool {
     crate::error::is_fallbackable(err)
 }
@@ -457,6 +463,7 @@ mod tests {
                 status_code: 503,
                 message: self.err_msg.clone(),
                 response_body: self.err_msg.clone().into_boxed_str(),
+                retry_after: None,
                 provider_code: None,
             })
         }

--- a/crates/autoagents-llm/src/optim/retry.rs
+++ b/crates/autoagents-llm/src/optim/retry.rs
@@ -10,8 +10,8 @@
 //!   default policy.
 //! - [`RateLimitError`], retryable [`HttpStatusError`], and transport
 //!   [`HttpError`] values are retried up to `max_attempts − 1` additional times
-//!   with exponential back-off, honoring provider `Retry-After` hints up to
-//!   [`RetryConfig::max_backoff`].
+//!   with exponential back-off, honoring provider `Retry-After` hints on
+//!   [`RateLimitError`] and [`HttpStatusError`] up to [`RetryConfig::max_backoff`].
 //!
 //! # Hot-path overhead
 //! On a successful first attempt the only overhead over a bare provider call
@@ -213,17 +213,19 @@ fn compute_backoff(config: &RetryConfig, attempt: u32) -> Duration {
 
 /// Resolves the sleep duration before the next retry attempt.
 ///
-/// Honors provider-supplied `Retry-After` hints on [`RateLimitError`] by taking
-/// the maximum of the configured exponential back-off and the header value,
-/// capped at [`RetryConfig::max_backoff`].
+/// Honors provider-supplied `Retry-After` hints on [`RateLimitError`] and
+/// [`HttpStatusError`] by taking the maximum of the configured exponential
+/// back-off and the header value, capped at [`RetryConfig::max_backoff`].
 fn resolve_retry_sleep(err: &LLMError, config: &RetryConfig, attempt: u32) -> Duration {
     let backoff = compute_backoff(config, attempt);
-    let sleep_for = match err {
-        LLMError::RateLimitError {
-            retry_after: Some(retry_after),
-            ..
-        } => backoff.max(*retry_after),
-        _ => backoff,
+    let retry_after = match err {
+        LLMError::RateLimitError { retry_after, .. }
+        | LLMError::HttpStatusError { retry_after, .. } => *retry_after,
+        _ => None,
+    };
+    let sleep_for = match retry_after {
+        Some(retry_after) => backoff.max(retry_after),
+        None => backoff,
     };
     sleep_for.min(config.max_backoff)
 }
@@ -497,11 +499,13 @@ mod tests {
                         status_code,
                         message,
                         response_body,
+                        retry_after,
                         provider_code,
                     } => LLMError::HttpStatusError {
                         status_code: *status_code,
                         message: message.clone(),
                         response_body: response_body.clone(),
+                        retry_after: *retry_after,
                         provider_code: provider_code.clone(),
                     },
                     LLMError::InvalidRequest {
@@ -595,6 +599,7 @@ mod tests {
             status_code,
             message: format!("status {status_code}"),
             response_body: "down".into(),
+            retry_after: None,
             provider_code: None,
         }
     }
@@ -602,6 +607,27 @@ mod tests {
     // -----------------------------------------------------------------------
     // Back-off unit tests (no I/O)
     // -----------------------------------------------------------------------
+
+    #[test]
+    fn resolve_retry_sleep_honors_retry_after_on_http_status_error() {
+        let config = RetryConfig {
+            initial_backoff: Duration::from_millis(200),
+            max_backoff: Duration::from_secs(60),
+            jitter: false,
+            ..RetryConfig::default()
+        };
+        let err = LLMError::HttpStatusError {
+            status_code: 503,
+            message: "maintenance".into(),
+            response_body: "body".into(),
+            retry_after: Some(Duration::from_secs(45)),
+            provider_code: None,
+        };
+        assert_eq!(
+            resolve_retry_sleep(&err, &config, 0),
+            Duration::from_secs(45)
+        );
+    }
 
     #[test]
     fn resolve_retry_sleep_honors_retry_after_header() {
@@ -746,6 +772,7 @@ mod tests {
             status_code: 503,
             message: "down".into(),
             response_body: "body".into(),
+            retry_after: None,
             provider_code: None,
         }));
         assert!(default_is_retryable(&LLMError::HttpError(

--- a/crates/autoagents-llm/src/optim/retry.rs
+++ b/crates/autoagents-llm/src/optim/retry.rs
@@ -6,11 +6,12 @@
 //!   before the stream starts delivering items). Mid-stream errors are not
 //!   retried — the caller must restart the stream explicitly.
 //! - [`AuthError`], [`InvalidRequest`], [`JsonError`], [`ToolConfigError`],
-//!   and [`NoToolSupport`] are **never** retried by the default policy (they
-//!   cannot succeed on a subsequent attempt without user intervention).
-//! - [`HttpError`], [`ProviderError`], and [`Generic`] errors that carry
-//!   rate-limit or server-error signals are retried up to
-//!   `max_attempts − 1` additional times with exponential back-off.
+//!   [`ResponseFormatError`], and [`NoToolSupport`] are **never** retried by the
+//!   default policy.
+//! - [`RateLimitError`], retryable [`HttpStatusError`], and transport
+//!   [`HttpError`] values are retried up to `max_attempts − 1` additional times
+//!   with exponential back-off, honoring provider `Retry-After` hints up to
+//!   [`RetryConfig::max_backoff`].
 //!
 //! # Hot-path overhead
 //! On a successful first attempt the only overhead over a bare provider call
@@ -82,34 +83,10 @@ impl Default for RetryConfig {
 
 /// Default retryability predicate.
 ///
-/// Retries when the error message contains rate-limit (429) or server-error
-/// (5xx) signals.  Never retries auth, invalid-request, or structural errors.
+/// Retries typed rate-limit and server errors plus retryable transport failures.
+/// Never retries auth, invalid-request, format/parsing, or generic errors.
 pub fn default_is_retryable(err: &LLMError) -> bool {
-    match err {
-        LLMError::HttpError(msg) | LLMError::ProviderError(msg) => {
-            let m = msg.to_lowercase();
-            m.contains("429")
-                || m.contains("500")
-                || m.contains("502")
-                || m.contains("503")
-                || m.contains("504")
-                || m.contains("529") // Anthropic overload
-                || m.contains("rate limit")
-                || m.contains("too many requests")
-                || m.contains("overloaded")
-                || m.contains("server error")
-                || m.contains("service unavailable")
-        }
-        LLMError::Generic(_) => true,
-        LLMError::AuthError(_)
-        | LLMError::InvalidRequest(_)
-        | LLMError::GuardrailBlocked { .. }
-        | LLMError::GuardrailExecutionFailed { .. }
-        | LLMError::ResponseFormatError { .. }
-        | LLMError::JsonError(_)
-        | LLMError::ToolConfigError(_)
-        | LLMError::NoToolSupport(_) => false,
-    }
+    crate::error::is_retryable(err)
 }
 
 // ---------------------------------------------------------------------------
@@ -208,15 +185,33 @@ fn compute_backoff(config: &RetryConfig, attempt: u32) -> Duration {
     }
 }
 
+/// Resolves the sleep duration before the next retry attempt.
+///
+/// Honors provider-supplied `Retry-After` hints on [`RateLimitError`] by taking
+/// the maximum of the configured exponential back-off and the header value,
+/// capped at [`RetryConfig::max_backoff`].
+fn resolve_retry_sleep(err: &LLMError, config: &RetryConfig, attempt: u32) -> Duration {
+    let backoff = compute_backoff(config, attempt);
+    let sleep_for = match err {
+        LLMError::RateLimitError {
+            retry_after: Some(retry_after),
+            ..
+        } => backoff.max(*retry_after),
+        _ => backoff,
+    };
+    sleep_for.min(config.max_backoff)
+}
+
 // ---------------------------------------------------------------------------
 // Core retry loop
 // ---------------------------------------------------------------------------
 
 /// Execute `f` up to `config.max_attempts` times.
 ///
-/// Returns immediately on the first `Ok`.  On a retryable `Err` sleeps for
-/// the computed back-off then retries.  On a non-retryable `Err` or when all
-/// attempts are exhausted, returns the error.
+/// Returns immediately on the first `Ok`.  On a retryable `Err`, sleeps for
+/// [`resolve_retry_sleep`] (exponential back-off and/or provider `Retry-After`,
+/// capped at [`RetryConfig::max_backoff`]) then retries.  On a non-retryable
+/// `Err` or when all attempts are exhausted, returns the error.
 ///
 /// # Hot path (first attempt succeeds)
 /// No allocation, no timer — just `f().await` and a match.
@@ -231,13 +226,13 @@ where
         match f().await {
             Ok(v) => return Ok(v),
             Err(e) if attempt + 1 < max && (config.retryable)(&e) => {
-                let backoff = compute_backoff(config, attempt);
+                let sleep_for = resolve_retry_sleep(&e, config, attempt);
                 log::warn!(
-                    "LLM call failed (attempt {}/{}): {e}. Retrying in {backoff:?}.",
+                    "LLM call failed (attempt {}/{}): {e}. Retrying in {sleep_for:?}.",
                     attempt + 1,
                     max,
                 );
-                tokio::time::sleep(backoff).await;
+                tokio::time::sleep(sleep_for).await;
                 attempt += 1;
             }
             Err(e) => return Err(e),
@@ -450,8 +445,48 @@ mod tests {
                     LLMError::HttpError(m) => LLMError::HttpError(m.clone()),
                     LLMError::ProviderError(m) => LLMError::ProviderError(m.clone()),
                     LLMError::Generic(m) => LLMError::Generic(m.clone()),
-                    LLMError::AuthError(m) => LLMError::AuthError(m.clone()),
-                    LLMError::InvalidRequest(m) => LLMError::InvalidRequest(m.clone()),
+                    LLMError::AuthError {
+                        message,
+                        status_code,
+                        response_body,
+                    } => LLMError::AuthError {
+                        message: message.clone(),
+                        status_code: *status_code,
+                        response_body: response_body.clone(),
+                    },
+                    LLMError::RateLimitError {
+                        status_code,
+                        message,
+                        response_body,
+                        retry_after,
+                        provider_code,
+                    } => LLMError::RateLimitError {
+                        status_code: *status_code,
+                        message: message.clone(),
+                        response_body: response_body.clone(),
+                        retry_after: *retry_after,
+                        provider_code: provider_code.clone(),
+                    },
+                    LLMError::HttpStatusError {
+                        status_code,
+                        message,
+                        response_body,
+                        provider_code,
+                    } => LLMError::HttpStatusError {
+                        status_code: *status_code,
+                        message: message.clone(),
+                        response_body: response_body.clone(),
+                        provider_code: provider_code.clone(),
+                    },
+                    LLMError::InvalidRequest {
+                        message,
+                        status_code,
+                        response_body,
+                    } => LLMError::InvalidRequest {
+                        message: message.clone(),
+                        status_code: *status_code,
+                        response_body: response_body.clone(),
+                    },
                     other => LLMError::Generic(other.to_string()),
                 })
             }
@@ -493,7 +528,7 @@ mod tests {
                     text: "done".into(),
                 })
             } else {
-                Err(LLMError::HttpError("503 service unavailable".into()))
+                Err(sample_http_status_error(503))
             }
         }
     }
@@ -505,7 +540,7 @@ mod tests {
             if n >= self.success_after {
                 Ok(vec![vec![1.0, 2.0]])
             } else {
-                Err(LLMError::HttpError("429 rate limit".into()))
+                Err(sample_rate_limit_error())
             }
         }
     }
@@ -519,9 +554,91 @@ mod tests {
         type Config = crate::NoConfig;
     }
 
+    fn sample_rate_limit_error() -> LLMError {
+        LLMError::RateLimitError {
+            status_code: 429,
+            message: "rate limited".into(),
+            response_body: "limit".into(),
+            retry_after: None,
+            provider_code: None,
+        }
+    }
+
+    fn sample_http_status_error(status_code: u16) -> LLMError {
+        LLMError::HttpStatusError {
+            status_code,
+            message: format!("status {status_code}"),
+            response_body: "down".into(),
+            provider_code: None,
+        }
+    }
+
     // -----------------------------------------------------------------------
     // Back-off unit tests (no I/O)
     // -----------------------------------------------------------------------
+
+    #[test]
+    fn resolve_retry_sleep_honors_retry_after_header() {
+        let config = RetryConfig {
+            initial_backoff: Duration::from_millis(200),
+            max_backoff: Duration::from_secs(60),
+            jitter: false,
+            ..RetryConfig::default()
+        };
+        let err = LLMError::RateLimitError {
+            status_code: 429,
+            message: "limit".into(),
+            response_body: "body".into(),
+            retry_after: Some(Duration::from_secs(45)),
+            provider_code: None,
+        };
+        assert_eq!(
+            resolve_retry_sleep(&err, &config, 0),
+            Duration::from_secs(45)
+        );
+    }
+
+    #[test]
+    fn resolve_retry_sleep_caps_at_max_backoff() {
+        let config = RetryConfig {
+            initial_backoff: Duration::from_millis(200),
+            max_backoff: Duration::from_secs(30),
+            jitter: false,
+            ..RetryConfig::default()
+        };
+        let err = LLMError::RateLimitError {
+            status_code: 429,
+            message: "limit".into(),
+            response_body: "body".into(),
+            retry_after: Some(Duration::from_secs(86_400)),
+            provider_code: None,
+        };
+        assert_eq!(
+            resolve_retry_sleep(&err, &config, 0),
+            Duration::from_secs(30)
+        );
+    }
+
+    #[test]
+    fn resolve_retry_sleep_uses_backoff_when_retry_after_is_shorter() {
+        let config = RetryConfig {
+            initial_backoff: Duration::from_secs(5),
+            max_backoff: Duration::from_secs(30),
+            jitter: false,
+            ..RetryConfig::default()
+        };
+        let err = LLMError::RateLimitError {
+            status_code: 429,
+            message: "limit".into(),
+            response_body: "body".into(),
+            retry_after: Some(Duration::from_secs(1)),
+            provider_code: None,
+        };
+        assert_eq!(
+            resolve_retry_sleep(&err, &config, 0),
+            Duration::from_secs(5)
+        );
+    }
 
     #[test]
     fn backoff_grows_exponentially() {
@@ -581,27 +698,37 @@ mod tests {
 
     #[test]
     fn retryable_errors() {
-        assert!(default_is_retryable(&LLMError::HttpError(
-            "429 rate limit exceeded".into()
-        )));
-        assert!(default_is_retryable(&LLMError::HttpError(
-            "503 service unavailable".into()
-        )));
-        assert!(default_is_retryable(&LLMError::ProviderError(
-            "overloaded".into()
-        )));
-        assert!(default_is_retryable(&LLMError::Generic(
+        assert!(!default_is_retryable(&LLMError::Generic(
             "connection reset".into()
+        )));
+        assert!(default_is_retryable(&LLMError::RateLimitError {
+            status_code: 429,
+            message: "limit".into(),
+            response_body: "body".into(),
+            retry_after: None,
+            provider_code: None,
+        }));
+        assert!(default_is_retryable(&LLMError::HttpStatusError {
+            status_code: 503,
+            message: "down".into(),
+            response_body: "body".into(),
+            provider_code: None,
+        }));
+        assert!(default_is_retryable(&LLMError::HttpError(
+            "request timed out: operation timed out".into()
+        )));
+        assert!(!default_is_retryable(&LLMError::ProviderError(
+            "overloaded".into()
         )));
     }
 
     #[test]
     fn non_retryable_errors() {
-        assert!(!default_is_retryable(&LLMError::AuthError(
-            "invalid key".into()
+        assert!(!default_is_retryable(&LLMError::missing_api_key(
+            "invalid key"
         )));
-        assert!(!default_is_retryable(&LLMError::InvalidRequest(
-            "bad param".into()
+        assert!(!default_is_retryable(&LLMError::invalid_request(
+            "bad param"
         )));
         assert!(!default_is_retryable(&LLMError::GuardrailBlocked {
             phase: crate::error::GuardrailPhase::Input,
@@ -661,7 +788,7 @@ mod tests {
     #[tokio::test]
     async fn retries_on_retryable_error_and_succeeds() {
         // Fails on attempts 1 and 2, succeeds on attempt 3.
-        let mock = CountingMock::new(3, LLMError::HttpError("429 rate limit".into()));
+        let mock = CountingMock::new(3, sample_rate_limit_error());
         let provider = build_retry(
             mock.clone(),
             RetryConfig {
@@ -679,7 +806,7 @@ mod tests {
 
     #[tokio::test]
     async fn exhausts_attempts_and_returns_last_error() {
-        let mock = CountingMock::new(99, LLMError::HttpError("503 unavailable".into()));
+        let mock = CountingMock::new(99, sample_http_status_error(503));
         let provider = build_retry(
             mock.clone(),
             RetryConfig {
@@ -697,7 +824,7 @@ mod tests {
 
     #[tokio::test]
     async fn non_retryable_error_is_not_retried() {
-        let mock = CountingMock::new(99, LLMError::AuthError("invalid key".into()));
+        let mock = CountingMock::new(99, LLMError::missing_api_key("invalid key".to_string()));
         let provider = build_retry(
             mock.clone(),
             RetryConfig {
@@ -714,7 +841,7 @@ mod tests {
 
     #[tokio::test]
     async fn max_attempts_one_means_no_retry() {
-        let mock = CountingMock::new(99, LLMError::HttpError("429".into()));
+        let mock = CountingMock::new(99, sample_rate_limit_error());
         let provider = build_retry(
             mock.clone(),
             RetryConfig {
@@ -743,7 +870,7 @@ mod tests {
 
     #[tokio::test]
     async fn completion_is_retried() {
-        let mock = CountingMock::new(2, LLMError::HttpError("503".into()));
+        let mock = CountingMock::new(2, sample_http_status_error(503));
         let provider = build_retry(
             mock.clone(),
             RetryConfig {
@@ -761,7 +888,7 @@ mod tests {
 
     #[tokio::test]
     async fn embedding_is_retried() {
-        let mock = CountingMock::new(2, LLMError::HttpError("429 rate limit".into()));
+        let mock = CountingMock::new(2, sample_rate_limit_error());
         let provider = build_retry(
             mock.clone(),
             RetryConfig {
@@ -779,14 +906,14 @@ mod tests {
     #[tokio::test]
     async fn custom_retryable_predicate() {
         // Custom predicate: only retry on auth errors (unusual, but proves override works).
-        let mock = CountingMock::new(3, LLMError::AuthError("retry me".into()));
+        let mock = CountingMock::new(3, LLMError::missing_api_key("retry me".to_string()));
         let provider = build_retry(
             mock.clone(),
             RetryConfig {
                 max_attempts: 5,
                 jitter: false,
                 initial_backoff: Duration::from_millis(1),
-                retryable: |err| matches!(err, LLMError::AuthError(_)),
+                retryable: |err| matches!(err, LLMError::AuthError { .. }),
                 ..RetryConfig::default()
             },
         );
@@ -794,6 +921,65 @@ mod tests {
         let resp = provider.chat(&[msg], None).await.unwrap();
         assert_eq!(resp.text().unwrap(), "ok");
         assert_eq!(mock.call_count(), 3);
+    }
+
+    #[tokio::test]
+    async fn retries_on_http_429_from_provider() {
+        use crate::backends::groq::Groq;
+        use httpmock::{Method::POST, MockServer};
+
+        static ATTEMPTS: AtomicU32 = AtomicU32::new(0);
+        let server = MockServer::start();
+        let _mock = server.mock(|when, then| {
+            when.method(POST).path("/openai/v1/chat/completions");
+            then.respond_with(move |_req| {
+                let attempt = ATTEMPTS.fetch_add(1, Ordering::Relaxed) + 1;
+                if attempt == 1 {
+                    httpmock::HttpMockResponse::builder()
+                        .status(429)
+                        .header("Retry-After", "0")
+                        .body(r#"{"error":{"message":"rate limited"}}"#)
+                        .build()
+                } else {
+                    httpmock::HttpMockResponse::builder()
+                        .status(200)
+                        .body(
+                            r#"{"choices":[{"message":{"role":"assistant","content":"ok"}}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}"#,
+                        )
+                        .build()
+                }
+            });
+        });
+
+        let inner = Groq::with_config(
+            "key",
+            Some(format!("{}/openai/v1", server.base_url())),
+            Some("llama3-8b-8192".to_string()),
+            None,
+            None,
+            Some(5),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        );
+        let provider = RetryLayer::new(RetryConfig {
+            max_attempts: 3,
+            jitter: false,
+            initial_backoff: Duration::from_millis(1),
+            ..RetryConfig::default()
+        })
+        .build_arc(Arc::new(inner) as Arc<dyn LLMProvider>);
+
+        let msg = ChatMessage::user().content("hi").build();
+        let resp = provider.chat(&[msg], None).await.unwrap();
+        assert_eq!(resp.text().as_deref(), Some("ok"));
+        assert_eq!(ATTEMPTS.load(Ordering::Relaxed), 2);
     }
 
     // Verify the FunctionCall import used in mock is available.

--- a/crates/autoagents-llm/src/optim/retry.rs
+++ b/crates/autoagents-llm/src/optim/retry.rs
@@ -149,24 +149,50 @@ struct RetryProvider {
 }
 
 // ---------------------------------------------------------------------------
-// Back-off helpers (no external RNG — uses subsecond system-time entropy)
+// Back-off helpers (thread-local xorshift PRNG for full jitter)
 // ---------------------------------------------------------------------------
+
+thread_local! {
+    static JITTER_RNG: std::cell::Cell<u64> = const { std::cell::Cell::new(0) };
+}
+
+fn jitter_seed() -> u64 {
+    use std::hash::{Hash, Hasher};
+
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    std::thread::current().id().hash(&mut hasher);
+    std::ptr::from_ref(&JITTER_RNG).hash(&mut hasher);
+    if let Ok(duration) = std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH) {
+        duration.as_nanos().hash(&mut hasher);
+    }
+    hasher.finish().max(1)
+}
+
+fn next_jitter_random() -> u64 {
+    JITTER_RNG.with(|rng| {
+        let mut state = rng.get();
+        if state == 0 {
+            state = jitter_seed();
+        }
+        state ^= state << 13;
+        state ^= state >> 7;
+        state ^= state << 17;
+        rng.set(state);
+        state
+    })
+}
 
 /// Full-jitter sleep duration in `[0, ceiling]`.
 ///
-/// Uses `SystemTime::subsec_nanos()` as a cheap entropy source.  Not
-/// cryptographically uniform, but sufficient for back-off anti-thundering-herd.
+/// Uses a per-thread xorshift PRNG so concurrent callers in the same
+/// millisecond still receive independent jitter samples.
 #[inline]
 fn jitter_duration(ceiling: Duration) -> Duration {
     let nanos = ceiling.as_nanos();
     if nanos == 0 {
         return Duration::ZERO;
     }
-    let seed = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .unwrap_or_default()
-        .subsec_nanos() as u128;
-    Duration::from_nanos((seed % nanos) as u64)
+    Duration::from_nanos(((next_jitter_random() as u128) % nanos) as u64)
 }
 
 /// Back-off ceiling for zero-based `attempt` index.
@@ -638,6 +664,14 @@ mod tests {
             resolve_retry_sleep(&err, &config, 0),
             Duration::from_secs(5)
         );
+    }
+
+    #[test]
+    fn jitter_duration_produces_varied_samples() {
+        let ceiling = Duration::from_secs(30);
+        let first = jitter_duration(ceiling);
+        let varied = (1..64).any(|_| jitter_duration(ceiling) != first);
+        assert!(varied, "jitter should produce multiple distinct durations");
     }
 
     #[test]

--- a/crates/autoagents-llm/src/optim/retry.rs
+++ b/crates/autoagents-llm/src/optim/retry.rs
@@ -159,7 +159,7 @@ thread_local! {
 fn jitter_seed() -> u64 {
     use std::hash::{Hash, Hasher};
 
-    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    let mut hasher = std::collections::hash_map::DefaultHasher::default();
     std::thread::current().id().hash(&mut hasher);
     std::ptr::from_ref(&JITTER_RNG).hash(&mut hasher);
     if let Ok(duration) = std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH) {

--- a/crates/autoagents-llm/src/providers/openai_compatible.rs
+++ b/crates/autoagents-llm/src/providers/openai_compatible.rs
@@ -5,7 +5,9 @@
 
 use crate::FunctionCall;
 use crate::chat::{StreamChoice, StreamChunk as ChatStreamChunk, StreamDelta};
+use crate::config::resolve_request_timeout;
 use crate::error::LLMError;
+use crate::http::ensure_success;
 use crate::{
     ToolCall,
     chat::ChatResponse,
@@ -35,7 +37,7 @@ pub struct OpenAICompatibleProvider<T: OpenAIProviderConfig> {
     pub model: String,
     pub max_tokens: Option<u32>,
     pub temperature: Option<f32>,
-    pub timeout_seconds: Option<u64>,
+    pub timeout_seconds: u64,
     pub top_p: Option<f32>,
     pub top_k: Option<u32>,
     pub tool_choice: Option<ToolChoice>,
@@ -325,10 +327,11 @@ impl<T: OpenAIProviderConfig> OpenAICompatibleProvider<T> {
         embedding_encoding_format: Option<String>,
         embedding_dimensions: Option<u32>,
     ) -> Self {
-        let mut builder = Client::builder();
-        if let Some(sec) = timeout_seconds {
-            builder = builder.timeout(std::time::Duration::from_secs(sec));
-        }
+        let timeout_seconds = resolve_request_timeout(timeout_seconds);
+        let client = Client::builder()
+            .timeout(std::time::Duration::from_secs(timeout_seconds))
+            .build()
+            .expect("Failed to build reqwest Client");
         let extra_body = match extra_body {
             Some(serde_json::Value::Object(map)) => map,
             _ => serde_json::Map::new(), // Should we panic here?
@@ -356,7 +359,7 @@ impl<T: OpenAIProviderConfig> OpenAICompatibleProvider<T> {
             normalize_response: normalize_response.unwrap_or(true),
             embedding_encoding_format,
             embedding_dimensions,
-            client: builder.build().expect("Failed to build reqwest Client"),
+            client,
             _phantom: PhantomData,
         }
     }
@@ -393,7 +396,7 @@ impl<T: OpenAIProviderConfig> ChatProvider for OpenAICompatibleProvider<T> {
         json_schema: Option<StructuredOutputFormat>,
     ) -> Result<Box<dyn ChatResponse>, LLMError> {
         if self.api_key.is_empty() {
-            return Err(LLMError::AuthError(format!(
+            return Err(LLMError::missing_api_key(format!(
                 "Missing {} API key",
                 T::PROVIDER_NAME
             )));
@@ -452,19 +455,9 @@ impl<T: OpenAIProviderConfig> ChatProvider for OpenAICompatibleProvider<T> {
         {
             log::trace!("{} request payload: {}", T::PROVIDER_NAME, json);
         }
-        if let Some(timeout) = self.timeout_seconds {
-            request = request.timeout(std::time::Duration::from_secs(timeout));
-        }
         let response = request.send().await?;
         log::debug!("{} HTTP status: {}", T::PROVIDER_NAME, response.status());
-        if !response.status().is_success() {
-            let status = response.status();
-            let error_text = response.text().await?;
-            return Err(LLMError::ResponseFormatError {
-                message: format!("{} API returned error status: {status}", T::PROVIDER_NAME),
-                raw_response: error_text,
-            });
-        }
+        let response = ensure_success(response, T::PROVIDER_NAME).await?;
         let resp_text = response.text().await?;
         let json_resp: Result<OpenAIChatResponse, serde_json::Error> =
             serde_json::from_str(&resp_text);
@@ -522,7 +515,7 @@ impl<T: OpenAIProviderConfig> ChatProvider for OpenAICompatibleProvider<T> {
         LLMError,
     > {
         if self.api_key.is_empty() {
-            return Err(LLMError::AuthError(format!(
+            return Err(LLMError::missing_api_key(format!(
                 "Missing {} API key",
                 T::PROVIDER_NAME
             )));
@@ -581,19 +574,9 @@ impl<T: OpenAIProviderConfig> ChatProvider for OpenAICompatibleProvider<T> {
         {
             log::trace!("{} request payload: {}", T::PROVIDER_NAME, json);
         }
-        if let Some(timeout) = self.timeout_seconds {
-            request = request.timeout(std::time::Duration::from_secs(timeout));
-        }
         let response = request.send().await?;
         log::debug!("{} HTTP status: {}", T::PROVIDER_NAME, response.status());
-        if !response.status().is_success() {
-            let status = response.status();
-            let error_text = response.text().await?;
-            return Err(LLMError::ResponseFormatError {
-                message: format!("{} API returned error status: {status}", T::PROVIDER_NAME),
-                raw_response: error_text,
-            });
-        }
+        let response = ensure_success(response, T::PROVIDER_NAME).await?;
         Ok(create_sse_stream(response, self.normalize_response))
     }
 
@@ -619,7 +602,7 @@ impl<T: OpenAIProviderConfig> ChatProvider for OpenAICompatibleProvider<T> {
     ) -> Result<Pin<Box<dyn Stream<Item = Result<ChatStreamChunk, LLMError>> + Send>>, LLMError>
     {
         if self.api_key.is_empty() {
-            return Err(LLMError::AuthError(format!(
+            return Err(LLMError::missing_api_key(format!(
                 "Missing {} API key",
                 T::PROVIDER_NAME
             )));
@@ -689,10 +672,6 @@ impl<T: OpenAIProviderConfig> ChatProvider for OpenAICompatibleProvider<T> {
             );
         }
 
-        if let Some(timeout) = self.timeout_seconds {
-            request = request.timeout(std::time::Duration::from_secs(timeout));
-        }
-
         log::debug!(
             "{} request: POST {} (streaming with tools)",
             T::PROVIDER_NAME,
@@ -700,15 +679,7 @@ impl<T: OpenAIProviderConfig> ChatProvider for OpenAICompatibleProvider<T> {
         );
         let response = request.send().await?;
         log::debug!("{} HTTP status: {}", T::PROVIDER_NAME, response.status());
-
-        if !response.status().is_success() {
-            let status = response.status();
-            let error_text = response.text().await?;
-            return Err(LLMError::ResponseFormatError {
-                message: format!("{} API returned error status: {status}", T::PROVIDER_NAME),
-                raw_response: error_text,
-            });
-        }
+        let response = ensure_success(response, T::PROVIDER_NAME).await?;
 
         Ok(create_openai_tool_stream(response))
     }
@@ -1009,7 +980,7 @@ pub fn chat_message_to_openai_message(
                 }]))
             }
             MessageType::Pdf(_) => {
-                return Err(LLMError::InvalidRequest(
+                return Err(LLMError::invalid_request(
                     "PDF input is not supported by OpenAI-compatible chat completions backends"
                         .to_string(),
                 ));
@@ -1842,7 +1813,7 @@ mod tests {
 
         assert!(matches!(
             err,
-            LLMError::InvalidRequest(message)
+            LLMError::InvalidRequest { message, .. }
                 if message == "PDF input is not supported by OpenAI-compatible chat completions backends"
         ));
     }
@@ -1906,7 +1877,7 @@ mod tests {
         );
         let messages = vec![ChatMessage::user().content("hello").build()];
         let err = provider.chat(&messages, None).await.unwrap_err();
-        assert!(matches!(err, LLMError::AuthError(_)));
+        assert!(matches!(err, LLMError::AuthError { .. }));
     }
 
     #[tokio::test]
@@ -1921,7 +1892,7 @@ mod tests {
             .await
             .err()
             .expect("expected auth error");
-        assert!(matches!(err, LLMError::AuthError(_)));
+        assert!(matches!(err, LLMError::AuthError { .. }));
     }
 
     #[tokio::test]
@@ -1936,7 +1907,7 @@ mod tests {
             .await
             .err()
             .expect("expected auth error");
-        assert!(matches!(err, LLMError::AuthError(_)));
+        assert!(matches!(err, LLMError::AuthError { .. }));
     }
 
     #[test]
@@ -2087,12 +2058,13 @@ mod tests {
             .expect_err("non-success status should fail");
 
         match err {
-            LLMError::ResponseFormatError {
-                message,
-                raw_response,
+            LLMError::HttpStatusError {
+                status_code,
+                response_body,
+                ..
             } => {
-                assert!(message.contains("returned error status"));
-                assert_eq!(raw_response, "provider exploded");
+                assert_eq!(status_code, 500);
+                assert_eq!(response_body.as_ref(), "provider exploded");
             }
             other => panic!("unexpected error: {other:?}"),
         }
@@ -2202,5 +2174,120 @@ mod tests {
             Ok(ChatStreamChunk::Done { stop_reason }) if stop_reason == "tool_use"
         ));
         tool_mock.assert();
+    }
+
+    #[tokio::test]
+    async fn test_429_maps_to_rate_limit_error() {
+        let server = MockServer::start();
+        let rate_mock = server.mock(|when, then| {
+            when.method(POST).path("/v1/chat/completions");
+            then.status(429)
+                .header("Retry-After", "15")
+                .body(r#"{"error":{"message":"rate limited","code":"rate_limit_exceeded"}}"#);
+        });
+
+        let provider = full_support_provider(format!("{}/v1", server.base_url()));
+        let messages = vec![ChatMessage::user().content("hello").build()];
+        let err = provider
+            .chat_with_tools(&messages, None, None)
+            .await
+            .expect_err("429 should fail");
+
+        match err {
+            LLMError::RateLimitError {
+                status_code,
+                message,
+                retry_after,
+                ..
+            } => {
+                assert_eq!(status_code, 429);
+                assert_eq!(message, "rate limited");
+                assert_eq!(retry_after, Some(std::time::Duration::from_secs(15)));
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+        rate_mock.assert();
+    }
+
+    /// Reqwest client timeout bounds the full request lifecycle, including reading
+    /// a streaming response body. A slow-to-start SSE response should fail once
+    /// the configured timeout elapses.
+    #[tokio::test]
+    async fn test_streaming_request_times_out_when_body_is_slow() {
+        let server = MockServer::start();
+        let slow_stream_mock = server.mock(|when, then| {
+            when.method(POST).path("/v1/chat/completions");
+            then.status(200)
+                .header("content-type", "text/event-stream")
+                .delay(std::time::Duration::from_secs(3))
+                .body("data: {\"choices\":[{\"delta\":{\"content\":\"late\"}}]}\n\n");
+        });
+
+        let provider = OpenAICompatibleProvider::<FullSupportConfig>::new(
+            "key",
+            Some(format!("{}/v1", server.base_url())),
+            Some("full-model".to_string()),
+            Some(128),
+            Some(0.2),
+            Some(1),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        );
+        let messages = vec![ChatMessage::user().content("stream").build()];
+        let err = match provider.chat_stream_struct(&messages, None, None).await {
+            Err(err) => err,
+            Ok(_) => panic!("slow stream should time out during setup/read"),
+        };
+
+        assert!(matches!(err, LLMError::HttpError(_)));
+        assert!(err.is_transport_retryable());
+        slow_stream_mock.assert();
+    }
+
+    #[tokio::test]
+    async fn test_chat_times_out_when_response_exceeds_limit() {
+        let server = MockServer::start();
+        let slow_mock = server.mock(|when, then| {
+            when.method(POST).path("/v1/chat/completions");
+            then.status(200).delay(std::time::Duration::from_secs(3)).body(
+                r#"{"choices":[{"message":{"role":"assistant","content":"late"}}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2}}"#,
+            );
+        });
+
+        let provider = OpenAICompatibleProvider::<FullSupportConfig>::new(
+            "key",
+            Some(format!("{}/v1", server.base_url())),
+            Some("full-model".to_string()),
+            Some(128),
+            Some(0.2),
+            Some(1),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        );
+        let messages = vec![ChatMessage::user().content("hello").build()];
+        let err = provider
+            .chat_with_tools(&messages, None, None)
+            .await
+            .expect_err("slow response should time out");
+
+        assert!(matches!(err, LLMError::HttpError(_)));
+        assert!(err.is_transport_retryable());
+        slow_mock.assert();
     }
 }

--- a/crates/autoagents-mistral-rs/src/error.rs
+++ b/crates/autoagents-mistral-rs/src/error.rs
@@ -40,7 +40,7 @@ impl From<MistralRsError> for LLMError {
                 LLMError::ProviderError(format!("Inference failed: {}", e))
             }
             MistralRsError::ConfigError(e) => {
-                LLMError::InvalidRequest(format!("Invalid configuration: {}", e))
+                LLMError::invalid_request(format!("Invalid configuration: {}", e))
             }
             MistralRsError::Other(e) => LLMError::ProviderError(format!("Mistral.rs error: {}", e)),
         }

--- a/crates/autoagents-mistral-rs/src/provider.rs
+++ b/crates/autoagents-mistral-rs/src/provider.rs
@@ -390,7 +390,7 @@ impl MistralRsProvider {
                                 break;
                             }
                             Response::ValidationError(err) => {
-                                let _ = tx.send(Err(LLMError::InvalidRequest(err.to_string())));
+                                let _ = tx.send(Err(LLMError::invalid_request(err.to_string())));
                                 break;
                             }
                             Response::ModelError(msg, _) => {

--- a/crates/autoagents-protocol/src/protocol.rs
+++ b/crates/autoagents-protocol/src/protocol.rs
@@ -163,7 +163,7 @@ pub enum Event {
 #[derive(Debug)]
 pub enum InternalEvent {
     /// Process a protocol event
-    ProtocolEvent(Event),
+    ProtocolEvent(Box<Event>),
     /// Shutdown signal
     Shutdown,
 }

--- a/crates/autoagents-protocol/src/task.rs
+++ b/crates/autoagents-protocol/src/task.rs
@@ -97,8 +97,8 @@ mod tests {
 
     #[test]
     fn with_app_meta_builder_sets_field() {
-        let task = Task::new("hi")
-            .with_app_meta(serde_json::json!({"session_id": "s1", "chat_id": "c1"}));
+        let task =
+            Task::new("hi").with_app_meta(serde_json::json!({"session_id": "s1", "chat_id": "c1"}));
         let meta = task.app_meta.expect("with_app_meta should set app_meta");
         assert_eq!(meta.get("session_id").and_then(|v| v.as_str()), Some("s1"));
         assert_eq!(meta.get("chat_id").and_then(|v| v.as_str()), Some("c1"));

--- a/docs/content/llm-providers/optimization-pipelines.md
+++ b/docs/content/llm-providers/optimization-pipelines.md
@@ -113,11 +113,11 @@ Default policy uses typed error classification:
 |-------|-------------------|---------------------|
 | `RateLimitError` (HTTP 429/529) | Yes | Yes |
 | Retryable `HttpStatusError` (408, 5xx) | Yes | Yes |
-| Transport `HttpError` (timeout/connect) | Yes | Yes |
+| Transport `HttpError` | Yes | Yes |
 | `AuthError`, `InvalidRequest`, `JsonError` | No | No |
 | `ResponseFormatError` (2xx parse failures) | No | Yes |
 | `ProviderError`, `NoToolSupport` | No | Yes |
-| `Generic` (unsupported features) | No | No |
+| `Generic` (unsupported features) | No | Yes |
 
 `Generic` programming or capability errors are not retried. HTTP status failures are mapped to typed variants (`AuthError`, `RateLimitError`, `HttpStatusError`) rather than `ResponseFormatError`, which remains reserved for malformed payloads on successful HTTP responses.
 

--- a/docs/content/llm-providers/optimization-pipelines.md
+++ b/docs/content/llm-providers/optimization-pipelines.md
@@ -107,7 +107,19 @@ Behavior notes:
 - `jitter`
 - `retryable` predicate
 
-Default policy retries transient/provider/network-style failures and avoids retrying deterministic errors (for example auth/invalid-request style failures).
+Default policy uses typed error classification:
+
+| Error | Retried by default | Fallback by default |
+|-------|-------------------|---------------------|
+| `RateLimitError` (HTTP 429/529) | Yes | Yes |
+| Retryable `HttpStatusError` (408, 5xx) | Yes | Yes |
+| Transport `HttpError` (timeout/connect) | Yes | Yes |
+| `AuthError`, `InvalidRequest`, `JsonError` | No | No |
+| `ResponseFormatError` (2xx parse failures) | No | Yes |
+| `ProviderError`, `NoToolSupport` | No | Yes |
+| `Generic` (unsupported features) | No | No |
+
+`Generic` programming or capability errors are not retried. HTTP status failures are mapped to typed variants (`AuthError`, `RateLimitError`, `HttpStatusError`) rather than `ResponseFormatError`, which remains reserved for malformed payloads on successful HTTP responses.
 
 ## FallbackLayer
 

--- a/docs/content/llm-providers/overview.md
+++ b/docs/content/llm-providers/overview.md
@@ -54,6 +54,21 @@ let llm: Arc<OpenAI> = LLMBuilder::<OpenAI>::new()
     .build()?;
 ```
 
+Unless you set `.timeout_seconds(...)`, providers apply a default HTTP timeout of **120 seconds** at the reqwest client level. This bounds the full request lifecycle, including reading a streaming response body. For long-running generations, increase the timeout explicitly:
+
+```rust
+LLMBuilder::<OpenAI>::new()
+    .model("gpt-4o")
+    .timeout_seconds(300)
+    .build()?;
+```
+
+### Streaming timeout semantics
+
+- The configured timeout applies from request start through completion of the HTTP body read.
+- `RetryLayer` retries only the initial stream-establishment call; mid-stream chunk errors are not retried automatically.
+- There is no separate idle/chunk-gap timeout in the default client configuration.
+
 Local providers like Ollama:
 
 ```rust


### PR DESCRIPTION
Centralize non-success HTTP handling in ensure_success(), introduce structured LLMError variants with bounded body reads, honor Retry-After in RetryLayer (capped at max_backoff), and default request timeouts to 120s.