### PR TITLE
[BUG]: Harden parse_document against SSRF and unbounded reads (#249)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -756,7 +756,10 @@ dependencies = [
  "base64 0.22.1",
  "calamine",
  "csv",
+ "futures",
  "html2text",
+ "httpmock",
+ "ipnet",
  "log",
  "once_cell",
  "pdf-extract",
@@ -769,6 +772,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "toml 1.1.2+spec-1.1.0",
+ "url",
  "walkdir",
  "zip 8.6.0",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,6 +128,8 @@ toml = { version = "1.0.7" }
 hf-hub = { version = "0.5.0", default-features = false }
 encoding_rs = "0.8.35"
 bytes = "1.11.1"
+url = "2.5.8"
+ipnet = "2.11.0"
 rquickjs = { version = "0.11.0", features = ["futures", "macro"] }
 deno_ast = { version = "0.53.1", features = ["transpiling", "visit"] }
 

--- a/crates/autoagents-toolkit/Cargo.toml
+++ b/crates/autoagents-toolkit/Cargo.toml
@@ -18,6 +18,9 @@ search = ["reqwest", "once_cell"]
 wolfram-alpha = ["reqwest", "once_cell"]
 document-parsing = [
   "reqwest",
+  "futures",
+  "url",
+  "ipnet",
   "pdf-extract",
   "zip",
   "quick-xml",
@@ -44,6 +47,9 @@ quick-xml = { workspace = true, optional = true }
 calamine = { workspace = true, optional = true }
 html2text = { workspace = true, optional = true }
 csv = { workspace = true, optional = true }
+url = { workspace = true, optional = true }
+ipnet = { workspace = true, optional = true }
+futures = { workspace = true, optional = true }
 rmcp = { workspace = true, optional = true, features = [
   "client",
   "transport-child-process",
@@ -55,3 +61,5 @@ tokio = { workspace = true }
 
 [dev-dependencies]
 tempfile.workspace = true
+httpmock.workspace = true
+futures.workspace = true

--- a/crates/autoagents-toolkit/src/tools/document_parsing/config.rs
+++ b/crates/autoagents-toolkit/src/tools/document_parsing/config.rs
@@ -1,0 +1,182 @@
+use std::path::PathBuf;
+use std::time::Duration;
+
+use super::source::DocumentSourceError;
+
+/// Default HTTP request timeout for document downloads.
+pub const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Default maximum document download size (50 MiB).
+pub const DEFAULT_MAX_DOWNLOAD_BYTES: usize = 52_428_800;
+
+/// Default maximum local file read size (50 MiB).
+pub const DEFAULT_MAX_LOCAL_FILE_BYTES: usize = 52_428_800;
+
+/// Default maximum number of HTTP redirects to follow.
+pub const DEFAULT_MAX_REDIRECTS: usize = 5;
+
+/// Security and resource limits for [`super::parse_document::DocumentParser`].
+#[derive(Debug, Clone)]
+pub struct DocumentParserConfig {
+    /// HTTP request timeout applied to each redirect hop.
+    pub request_timeout: Duration,
+    /// Maximum bytes read from a remote document.
+    pub max_download_bytes: usize,
+    /// Maximum bytes read from a local file.
+    pub max_local_file_bytes: usize,
+    /// Maximum redirect hops before the request is rejected.
+    pub max_redirects: usize,
+    /// Optional host allowlist. When set, only matching hosts may be fetched.
+    pub allowed_hosts: Option<Vec<String>>,
+    /// When set, only these TCP ports may be used for remote URLs.
+    pub allowed_ports: Option<Vec<u16>>,
+    /// When `false`, private, loopback, link-local, and metadata IP ranges are blocked.
+    pub allow_private_networks: bool,
+    /// Optional local filesystem roots. When set, local paths must resolve inside one of them.
+    pub allowed_roots: Option<Vec<PathBuf>>,
+}
+
+impl Default for DocumentParserConfig {
+    fn default() -> Self {
+        Self {
+            request_timeout: DEFAULT_REQUEST_TIMEOUT,
+            max_download_bytes: DEFAULT_MAX_DOWNLOAD_BYTES,
+            max_local_file_bytes: DEFAULT_MAX_LOCAL_FILE_BYTES,
+            max_redirects: DEFAULT_MAX_REDIRECTS,
+            allowed_hosts: None,
+            allowed_ports: None,
+            allow_private_networks: false,
+            allowed_roots: None,
+        }
+    }
+}
+
+impl DocumentParserConfig {
+    /// Validate security-related configuration.
+    pub fn validate(&self) -> Result<(), DocumentSourceError> {
+        if self.max_download_bytes == 0 {
+            return Err(DocumentSourceError::InvalidConfig(
+                "max_download_bytes must be greater than zero".into(),
+            ));
+        }
+
+        if self.max_local_file_bytes == 0 {
+            return Err(DocumentSourceError::InvalidConfig(
+                "max_local_file_bytes must be greater than zero".into(),
+            ));
+        }
+
+        if let Some(hosts) = &self.allowed_hosts
+            && hosts.is_empty()
+        {
+            return Err(DocumentSourceError::InvalidConfig(
+                "allowed_hosts must not be empty when set".into(),
+            ));
+        }
+
+        if let Some(ports) = &self.allowed_ports
+            && ports.is_empty()
+        {
+            return Err(DocumentSourceError::InvalidConfig(
+                "allowed_ports must not be empty when set".into(),
+            ));
+        }
+
+        if self.allow_private_networks
+            && !matches!(&self.allowed_hosts, Some(hosts) if !hosts.is_empty())
+        {
+            return Err(DocumentSourceError::InvalidConfig(
+                "allow_private_networks requires a non-empty allowed_hosts list".into(),
+            ));
+        }
+
+        Ok(())
+    }
+
+    pub fn with_allowed_roots(mut self, roots: Vec<PathBuf>) -> Self {
+        self.allowed_roots = Some(roots);
+        self
+    }
+
+    pub fn with_allowed_hosts(mut self, hosts: Vec<String>) -> Result<Self, DocumentSourceError> {
+        if hosts.is_empty() {
+            return Err(DocumentSourceError::InvalidConfig(
+                "allowed_hosts must not be empty".into(),
+            ));
+        }
+        self.allowed_hosts = Some(hosts);
+        Ok(self)
+    }
+
+    pub fn with_allowed_ports(mut self, ports: Vec<u16>) -> Result<Self, DocumentSourceError> {
+        if ports.is_empty() {
+            return Err(DocumentSourceError::InvalidConfig(
+                "allowed_ports must not be empty".into(),
+            ));
+        }
+        self.allowed_ports = Some(ports);
+        Ok(self)
+    }
+
+    pub fn with_allow_private_networks(mut self, allow: bool) -> Self {
+        self.allow_private_networks = allow;
+        self
+    }
+
+    pub fn with_max_download_bytes(mut self, max_download_bytes: usize) -> Self {
+        self.max_download_bytes = max_download_bytes;
+        self
+    }
+
+    pub fn with_max_local_file_bytes(mut self, max_local_file_bytes: usize) -> Self {
+        self.max_local_file_bytes = max_local_file_bytes;
+        self
+    }
+
+    pub fn with_max_redirects(mut self, max_redirects: usize) -> Self {
+        self.max_redirects = max_redirects;
+        self
+    }
+
+    pub fn with_request_timeout(mut self, request_timeout: Duration) -> Self {
+        self.request_timeout = request_timeout;
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_config_blocks_private_networks() {
+        let config = DocumentParserConfig::default();
+        assert!(!config.allow_private_networks);
+        assert_eq!(config.max_download_bytes, DEFAULT_MAX_DOWNLOAD_BYTES);
+        assert_eq!(config.max_local_file_bytes, DEFAULT_MAX_LOCAL_FILE_BYTES);
+        assert_eq!(config.request_timeout, DEFAULT_REQUEST_TIMEOUT);
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn rejects_empty_allowed_hosts() {
+        let result = DocumentParserConfig::default().with_allowed_hosts(vec![]);
+        assert!(matches!(result, Err(DocumentSourceError::InvalidConfig(_))));
+    }
+
+    #[test]
+    fn rejects_private_networks_without_allowlist() {
+        let config = DocumentParserConfig::default().with_allow_private_networks(true);
+        let error = config.validate().expect_err("must require allowlist");
+        assert!(matches!(error, DocumentSourceError::InvalidConfig(_)));
+    }
+
+    #[test]
+    fn allows_private_networks_with_allowlist() {
+        let config = DocumentParserConfig::default()
+            .with_allow_private_networks(true)
+            .with_allowed_hosts(vec!["localhost".to_string()])
+            .expect("hosts");
+        assert!(config.validate().is_ok());
+    }
+}

--- a/crates/autoagents-toolkit/src/tools/document_parsing/config.rs
+++ b/crates/autoagents-toolkit/src/tools/document_parsing/config.rs
@@ -30,7 +30,8 @@ pub struct DocumentParserConfig {
     pub allowed_hosts: Option<Vec<String>>,
     /// When set, only these TCP ports may be used for remote URLs.
     pub allowed_ports: Option<Vec<u16>>,
-    /// When `false`, private, loopback, link-local, and metadata IP ranges are blocked.
+    /// When `false`, private, loopback, link-local, metadata IP ranges, and blocked
+    /// hostnames are rejected unless the host is explicitly allowlisted.
     pub allow_private_networks: bool,
     /// Optional local filesystem roots. When set, local paths must resolve inside one of them.
     pub allowed_roots: Option<Vec<PathBuf>>,

--- a/crates/autoagents-toolkit/src/tools/document_parsing/mod.rs
+++ b/crates/autoagents-toolkit/src/tools/document_parsing/mod.rs
@@ -1,6 +1,22 @@
+//! Document parsing tools with hardened remote and local source loading.
+//!
+//! # Security defaults
+//!
+//! - URL fetching blocks private, loopback, link-local, and metadata destinations unless
+//!   [`DocumentParserConfig::allow_private_networks`] is enabled together with a non-empty
+//!   [`DocumentParserConfig::allowed_hosts`] list.
+//! - Remote downloads and local reads are size-bounded via
+//!   [`DocumentParserConfig::max_download_bytes`] and
+//!   [`DocumentParserConfig::max_local_file_bytes`].
+//! - Local file paths are unrestricted unless
+//!   [`DocumentParserConfig::allowed_roots`] is configured. Agent deployments should always
+//!   set allowed roots explicitly.
+mod config;
 mod parse_document;
 pub(crate) mod parsers;
+mod source;
 
+pub use config::DocumentParserConfig;
 pub use parse_document::DocumentParser;
 
 use std::path::Path;

--- a/crates/autoagents-toolkit/src/tools/document_parsing/mod.rs
+++ b/crates/autoagents-toolkit/src/tools/document_parsing/mod.rs
@@ -4,7 +4,8 @@
 //!
 //! - URL fetching blocks private, loopback, link-local, and metadata destinations unless
 //!   [`DocumentParserConfig::allow_private_networks`] is enabled together with a non-empty
-//!   [`DocumentParserConfig::allowed_hosts`] list.
+//!   [`DocumentParserConfig::allowed_hosts`] list. When private networks are allowed,
+//!   hostname-based blocks (for example `localhost` and `.internal`) are bypassed as well.
 //! - Remote downloads and local reads are size-bounded via
 //!   [`DocumentParserConfig::max_download_bytes`] and
 //!   [`DocumentParserConfig::max_local_file_bytes`].

--- a/crates/autoagents-toolkit/src/tools/document_parsing/parse_document.rs
+++ b/crates/autoagents-toolkit/src/tools/document_parsing/parse_document.rs
@@ -1,13 +1,20 @@
+use std::path::PathBuf;
+use std::sync::Once;
+
 use autoagents::core::{
     ractor::async_trait,
     tool::{ToolCallError, ToolRuntime, ToolT},
 };
 use autoagents_derive::{ToolInput, tool};
-use log::debug;
+use log::{debug, warn};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 
+use super::config::DocumentParserConfig;
+use super::source::{DocumentSourceError, fetch_url, load_local_file};
 use super::{DocumentFormat, parsers};
+
+static WARN_UNRESTRICTED_LOCAL: Once = Once::new();
 
 #[derive(Serialize, Deserialize, ToolInput, Debug)]
 pub struct DocumentParserArgs {
@@ -27,15 +34,37 @@ pub struct DocumentParserArgs {
     input = DocumentParserArgs,
 )]
 #[derive(Default)]
-pub struct DocumentParser;
+pub struct DocumentParser {
+    config: DocumentParserConfig,
+}
 
 impl DocumentParser {
     pub fn new() -> Self {
-        Self
+        Self::default()
+    }
+
+    pub fn try_with_config(config: DocumentParserConfig) -> Result<Self, DocumentSourceError> {
+        config.validate()?;
+        Ok(Self { config })
+    }
+
+    pub fn with_config(config: DocumentParserConfig) -> Result<Self, DocumentSourceError> {
+        Self::try_with_config(config)
+    }
+
+    pub fn with_allowed_roots(roots: Vec<PathBuf>) -> Self {
+        Self {
+            config: DocumentParserConfig::default().with_allowed_roots(roots),
+        }
+    }
+
+    pub fn with_allowed_hosts(hosts: Vec<String>) -> Result<Self, DocumentSourceError> {
+        Self::try_with_config(DocumentParserConfig::default().with_allowed_hosts(hosts)?)
     }
 
     fn is_url(source: &str) -> bool {
-        source.starts_with("http://") || source.starts_with("https://")
+        starts_with_ignore_ascii_case(source, "https://")
+            || starts_with_ignore_ascii_case(source, "http://")
     }
 
     fn resolve_format(
@@ -59,31 +88,26 @@ impl DocumentParser {
         }
     }
 
-    async fn load_file(path: &str) -> Result<Vec<u8>, ToolCallError> {
-        tokio::fs::read(path)
-            .await
-            .map_err(|e| ToolCallError::RuntimeError(Box::new(e)))
+    fn map_source_error(error: DocumentSourceError) -> ToolCallError {
+        ToolCallError::RuntimeError(Box::new(error))
     }
 
-    async fn fetch_url(url: &str) -> Result<(Vec<u8>, Option<String>), ToolCallError> {
-        let response = reqwest::get(url)
-            .await
-            .map_err(|e| ToolCallError::RuntimeError(Box::new(e)))?;
-
-        let filename = response
-            .url()
-            .path_segments()
-            .and_then(|mut segments| segments.next_back())
-            .map(|s| s.to_string());
-
-        let bytes = response
-            .bytes()
-            .await
-            .map_err(|e| ToolCallError::RuntimeError(Box::new(e)))?
-            .to_vec();
-
-        Ok((bytes, filename))
+    fn warn_if_local_paths_unrestricted(&self) {
+        if self.config.allowed_roots.is_none() {
+            WARN_UNRESTRICTED_LOCAL.call_once(|| {
+                warn!(
+                    "DocumentParser local file paths are unrestricted; configure allowed_roots for agent deployments"
+                );
+            });
+        }
     }
+}
+
+fn starts_with_ignore_ascii_case(value: &str, prefix: &str) -> bool {
+    value
+        .as_bytes()
+        .get(..prefix.len())
+        .is_some_and(|candidate| candidate.eq_ignore_ascii_case(prefix.as_bytes()))
 }
 
 #[async_trait]
@@ -94,11 +118,16 @@ impl ToolRuntime for DocumentParser {
         debug!("DocumentParser executing: source={}", source);
 
         let (bytes, effective_source) = if Self::is_url(&source) {
-            let (bytes, filename) = Self::fetch_url(&source).await?;
+            let (bytes, filename) = fetch_url(&source, &self.config)
+                .await
+                .map_err(Self::map_source_error)?;
             let effective = filename.unwrap_or_else(|| source.clone());
             (bytes, effective)
         } else {
-            let bytes = Self::load_file(&source).await?;
+            self.warn_if_local_paths_unrestricted();
+            let bytes = load_local_file(&source, &self.config)
+                .await
+                .map_err(Self::map_source_error)?;
             (bytes, source.clone())
         };
 
@@ -169,7 +198,7 @@ mod tests {
         file.write_all(b"Hello World").expect("Failed to write");
         drop(file);
 
-        let parser = DocumentParser;
+        let parser = DocumentParser::default();
         let args = json!({
             "source": file_path.display().to_string()
         });
@@ -197,7 +226,7 @@ mod tests {
             .expect("Failed to write");
         drop(file);
 
-        let parser = DocumentParser;
+        let parser = DocumentParser::default();
         let args = json!({
             "source": file_path.display().to_string()
         });
@@ -216,7 +245,7 @@ mod tests {
             .expect("Failed to write");
         drop(file);
 
-        let parser = DocumentParser;
+        let parser = DocumentParser::default();
         let args = json!({
             "source": file_path.display().to_string()
         });
@@ -243,7 +272,7 @@ mod tests {
             .expect("Failed to write");
         drop(file);
 
-        let parser = DocumentParser;
+        let parser = DocumentParser::default();
         let args = json!({
             "source": file_path.display().to_string(),
             "format": "csv"
@@ -262,7 +291,52 @@ mod tests {
         file.write_all(b"content").expect("Failed to write");
         drop(file);
 
-        let parser = DocumentParser;
+        let parser = DocumentParser::default();
+        let args = json!({
+            "source": file_path.display().to_string()
+        });
+
+        let result = parser.execute(args).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_parse_blocks_private_url() {
+        let parser = DocumentParser::new();
+        let args = json!({
+            "source": "http://169.254.169.254/latest/meta-data/"
+        });
+
+        let result = parser.execute(args).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_parse_blocks_local_file_outside_allowed_roots() {
+        let allowed_dir = tempdir().expect("allowed dir");
+        let outside_dir = tempdir().expect("outside dir");
+        let outside_file = outside_dir.path().join("secret.txt");
+        std::fs::write(&outside_file, b"secret").expect("write");
+
+        let parser = DocumentParser::with_allowed_roots(vec![allowed_dir.path().to_path_buf()]);
+        let args = json!({
+            "source": outside_file.display().to_string()
+        });
+
+        let result = parser.execute(args).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_parse_rejects_oversized_local_file() {
+        let dir = tempdir().expect("tempdir");
+        let file_path = dir.path().join("large.txt");
+        std::fs::write(&file_path, vec![b'a'; 2048]).expect("write");
+
+        let parser = DocumentParser::try_with_config(
+            DocumentParserConfig::default().with_max_local_file_bytes(1024),
+        )
+        .expect("config");
         let args = json!({
             "source": file_path.display().to_string()
         });
@@ -275,6 +349,8 @@ mod tests {
     fn test_is_url() {
         assert!(DocumentParser::is_url("https://example.com/file.pdf"));
         assert!(DocumentParser::is_url("http://example.com/file.pdf"));
+        assert!(DocumentParser::is_url("HTTPS://example.com/file.pdf"));
+        assert!(DocumentParser::is_url("HTTP://example.com/file.pdf"));
         assert!(!DocumentParser::is_url("/path/to/file.pdf"));
         assert!(!DocumentParser::is_url("file.pdf"));
     }

--- a/crates/autoagents-toolkit/src/tools/document_parsing/parse_document.rs
+++ b/crates/autoagents-toolkit/src/tools/document_parsing/parse_document.rs
@@ -48,10 +48,6 @@ impl DocumentParser {
         Ok(Self { config })
     }
 
-    pub fn with_config(config: DocumentParserConfig) -> Result<Self, DocumentSourceError> {
-        Self::try_with_config(config)
-    }
-
     pub fn with_allowed_roots(roots: Vec<PathBuf>) -> Self {
         Self {
             config: DocumentParserConfig::default().with_allowed_roots(roots),
@@ -302,7 +298,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_parse_blocks_private_url() {
-        let parser = DocumentParser::new();
+        let parser = DocumentParser::default();
         let args = json!({
             "source": "http://169.254.169.254/latest/meta-data/"
         });

--- a/crates/autoagents-toolkit/src/tools/document_parsing/source/error.rs
+++ b/crates/autoagents-toolkit/src/tools/document_parsing/source/error.rs
@@ -1,0 +1,72 @@
+use std::net::IpAddr;
+use std::path::PathBuf;
+
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum DocumentSourceError {
+    #[error("unsupported URL scheme: {0}")]
+    UrlSchemeNotAllowed(String),
+
+    #[error("credentials are not allowed in document URLs")]
+    CredentialsInUrl,
+
+    #[error("host is not allowed: {0}")]
+    HostNotAllowed(String),
+
+    #[error("port {port} is not allowed")]
+    PortNotAllowed { port: u16 },
+
+    #[error("blocked hostname: {0}")]
+    BlockedHostname(String),
+
+    #[error("invalid document parser configuration: {0}")]
+    InvalidConfig(String),
+
+    #[error(
+        "local file exceeds maximum size of {limit} bytes (observed at least {observed} bytes)"
+    )]
+    LocalFileTooLarge { limit: usize, observed: usize },
+
+    #[error("invalid URL host: {0}")]
+    InvalidHost(String),
+
+    #[error("private or restricted network address blocked for host {host}: {addr}")]
+    PrivateNetworkBlocked { host: String, addr: IpAddr },
+
+    #[error("failed to resolve host {host}: {source}")]
+    DnsResolutionFailed {
+        host: String,
+        #[source]
+        source: std::io::Error,
+    },
+
+    #[error("no addresses resolved for host: {0}")]
+    NoResolvedAddresses(String),
+
+    #[error("too many redirects while fetching document (limit: {limit})")]
+    TooManyRedirects { limit: usize },
+
+    #[error("redirect response missing Location header")]
+    MissingRedirectLocation,
+
+    #[error("invalid redirect Location header: {0}")]
+    InvalidRedirectLocation(String),
+
+    #[error(
+        "document download exceeds maximum size of {limit} bytes (observed at least {observed} bytes)"
+    )]
+    DownloadTooLarge { limit: usize, observed: usize },
+
+    #[error("HTTP request failed with status {status}")]
+    HttpStatus { status: u16 },
+
+    #[error("path {path} is outside of allowed roots")]
+    PathOutsideRoot { path: PathBuf },
+
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+
+    #[error(transparent)]
+    Http(#[from] reqwest::Error),
+}

--- a/crates/autoagents-toolkit/src/tools/document_parsing/source/http_fetch.rs
+++ b/crates/autoagents-toolkit/src/tools/document_parsing/source/http_fetch.rs
@@ -1,0 +1,298 @@
+use futures::StreamExt;
+use reqwest::{Client, Response, redirect::Policy};
+use url::Url;
+
+use super::error::DocumentSourceError;
+use super::url_policy::{resolve_host, validate_url, validate_url_str};
+use crate::tools::document_parsing::config::DocumentParserConfig;
+
+fn build_pinned_client(
+    host: &str,
+    addresses: &[std::net::SocketAddr],
+    config: &DocumentParserConfig,
+) -> Result<Client, DocumentSourceError> {
+    // A fresh client is built per hop so DNS pinning via `resolve_to_addrs` stays accurate.
+    // Document parsing is low-QPS; connection reuse is less important than SSRF resistance.
+    Client::builder()
+        .timeout(config.request_timeout)
+        .redirect(Policy::none())
+        .resolve_to_addrs(host, addresses)
+        .build()
+        .map_err(DocumentSourceError::from)
+}
+
+pub async fn fetch_url(
+    url: &str,
+    config: &DocumentParserConfig,
+) -> Result<(Vec<u8>, Option<String>), DocumentSourceError> {
+    let mut current = validate_url_str(url, config)?;
+    let mut redirects = 0usize;
+
+    loop {
+        let response = send_request(&current, config).await?;
+
+        if response.status().is_redirection() {
+            if redirects >= config.max_redirects {
+                return Err(DocumentSourceError::TooManyRedirects {
+                    limit: config.max_redirects,
+                });
+            }
+
+            let location = response
+                .headers()
+                .get(reqwest::header::LOCATION)
+                .ok_or(DocumentSourceError::MissingRedirectLocation)?
+                .to_str()
+                .map_err(|_| {
+                    DocumentSourceError::InvalidRedirectLocation("non-UTF-8 Location".to_string())
+                })?;
+
+            current = current.join(location).map_err(|error| {
+                DocumentSourceError::InvalidRedirectLocation(format!("{location}: {error}"))
+            })?;
+            validate_url(&current, config)?;
+            redirects += 1;
+            continue;
+        }
+
+        let checked = response.error_for_status().map_err(map_status_error)?;
+
+        let bytes = read_bounded_body(checked, config.max_download_bytes).await?;
+        let filename = current
+            .path_segments()
+            .and_then(|mut segments| segments.next_back())
+            .filter(|segment| !segment.is_empty())
+            .map(|segment| segment.to_string());
+
+        return Ok((bytes, filename));
+    }
+}
+
+async fn send_request(
+    url: &Url,
+    config: &DocumentParserConfig,
+) -> Result<Response, DocumentSourceError> {
+    let host = url
+        .host_str()
+        .ok_or_else(|| DocumentSourceError::InvalidHost(url.to_string()))?;
+    let port = url.port_or_known_default().unwrap_or(80);
+    let addresses = resolve_host(host, port, config).await?;
+    let client = build_pinned_client(host, &addresses, config)?;
+
+    client
+        .get(url.clone())
+        .send()
+        .await
+        .map_err(DocumentSourceError::from)
+}
+
+fn map_status_error(error: reqwest::Error) -> DocumentSourceError {
+    if let Some(status) = error.status() {
+        DocumentSourceError::HttpStatus {
+            status: status.as_u16(),
+        }
+    } else {
+        DocumentSourceError::Http(error)
+    }
+}
+
+async fn read_bounded_body(
+    response: Response,
+    max_download_bytes: usize,
+) -> Result<Vec<u8>, DocumentSourceError> {
+    if let Some(content_length) = response.content_length()
+        && content_length > max_download_bytes as u64
+    {
+        return Err(DocumentSourceError::DownloadTooLarge {
+            limit: max_download_bytes,
+            observed: content_length as usize,
+        });
+    }
+
+    let mut stream = response.bytes_stream();
+    let mut collected = Vec::with_capacity(max_download_bytes.min(8192));
+
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.map_err(DocumentSourceError::from)?;
+        let remaining = max_download_bytes.saturating_sub(collected.len());
+
+        if chunk.len() > remaining {
+            return Err(DocumentSourceError::DownloadTooLarge {
+                limit: max_download_bytes,
+                observed: collected.len() + chunk.len(),
+            });
+        }
+
+        collected.extend_from_slice(&chunk);
+    }
+
+    Ok(collected)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use httpmock::{Method::GET, MockServer};
+    use std::time::Duration;
+
+    fn test_config(max_download_bytes: usize) -> DocumentParserConfig {
+        DocumentParserConfig::default()
+            .with_allow_private_networks(true)
+            .with_allowed_hosts(vec!["127.0.0.1".to_string()])
+            .expect("hosts")
+            .with_max_download_bytes(max_download_bytes)
+            .with_request_timeout(Duration::from_secs(5))
+    }
+
+    #[tokio::test]
+    async fn fetch_returns_body_on_success() {
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(GET).path("/doc.txt");
+            then.status(200).body("hello document");
+        });
+
+        let (bytes, filename) = fetch_url(
+            &format!("{}/doc.txt", server.base_url()),
+            &test_config(1024),
+        )
+        .await
+        .expect("fetch succeeds");
+
+        mock.assert();
+        assert_eq!(bytes, b"hello document");
+        assert_eq!(filename.as_deref(), Some("doc.txt"));
+    }
+
+    #[tokio::test]
+    async fn fetch_rejects_http_error_status() {
+        let server = MockServer::start();
+        let _mock = server.mock(|when, then| {
+            when.method(GET).path("/missing");
+            then.status(404).body("not found");
+        });
+
+        let error = fetch_url(
+            &format!("{}/missing", server.base_url()),
+            &test_config(1024),
+        )
+        .await
+        .expect_err("404 should fail");
+
+        assert!(matches!(
+            error,
+            DocumentSourceError::HttpStatus { status: 404 }
+        ));
+    }
+
+    #[tokio::test]
+    async fn fetch_rejects_oversized_content_length() {
+        let server = MockServer::start();
+        let _mock = server.mock(|when, then| {
+            when.method(GET).path("/huge");
+            then.status(200)
+                .header("Content-Length", "2048")
+                .body(&"x".repeat(2048));
+        });
+
+        let error = fetch_url(&format!("{}/huge", server.base_url()), &test_config(1024))
+            .await
+            .expect_err("oversized body");
+
+        assert!(matches!(
+            error,
+            DocumentSourceError::DownloadTooLarge { .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn fetch_rejects_oversized_chunked_body() {
+        let server = MockServer::start();
+        let body = "y".repeat(2048);
+        let _mock = server.mock(|when, then| {
+            when.method(GET).path("/chunked");
+            then.status(200)
+                .header("Transfer-Encoding", "chunked")
+                .body(&body);
+        });
+
+        let error = fetch_url(
+            &format!("{}/chunked", server.base_url()),
+            &test_config(1024),
+        )
+        .await
+        .expect_err("chunked oversized body");
+
+        assert!(matches!(
+            error,
+            DocumentSourceError::DownloadTooLarge { .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn fetch_blocks_redirect_to_private_host() {
+        let server = MockServer::start();
+        let _mock = server.mock(|when, then| {
+            when.method(GET).path("/redirect");
+            then.status(302)
+                .header("Location", "http://127.0.0.1/private")
+                .body("");
+        });
+
+        let config = DocumentParserConfig::default().with_request_timeout(Duration::from_secs(5));
+        let error = fetch_url(&format!("{}/redirect", server.base_url()), &config)
+            .await
+            .expect_err("redirect to private host");
+
+        assert!(matches!(
+            error,
+            DocumentSourceError::PrivateNetworkBlocked { .. }
+                | DocumentSourceError::BlockedHostname(_)
+        ));
+    }
+
+    #[tokio::test]
+    async fn fetch_follows_redirect_to_allowed_destination() {
+        let server = MockServer::start();
+        let redirect_mock = server.mock(|when, then| {
+            when.method(GET).path("/redirect");
+            then.status(302).header("Location", "/final.txt").body("");
+        });
+        let final_mock = server.mock(|when, then| {
+            when.method(GET).path("/final.txt");
+            then.status(200).body("redirected");
+        });
+
+        let config = test_config(1024);
+        let (bytes, _) = fetch_url(&format!("{}/redirect", server.base_url()), &config)
+            .await
+            .expect("redirect succeeds");
+
+        redirect_mock.assert();
+        final_mock.assert();
+        assert_eq!(bytes, b"redirected");
+    }
+
+    #[tokio::test]
+    async fn fetch_rejects_too_many_redirects() {
+        let server = MockServer::start();
+        for index in 0..6 {
+            let path = format!("/redirect-{index}");
+            let next = format!("/redirect-{}", index + 1);
+            let _mock = server.mock(move |when, then| {
+                when.method(GET).path(&path);
+                then.status(302).header("Location", &next).body("");
+            });
+        }
+
+        let config = test_config(1024).with_max_redirects(5);
+        let error = fetch_url(&format!("{}/redirect-0", server.base_url()), &config)
+            .await
+            .expect_err("redirect limit");
+
+        assert!(matches!(
+            error,
+            DocumentSourceError::TooManyRedirects { limit: 5 }
+        ));
+    }
+}

--- a/crates/autoagents-toolkit/src/tools/document_parsing/source/http_fetch.rs
+++ b/crates/autoagents-toolkit/src/tools/document_parsing/source/http_fetch.rs
@@ -230,25 +230,21 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn fetch_blocks_redirect_to_private_host() {
+    async fn fetch_blocks_redirect_to_disallowed_host() {
         let server = MockServer::start();
         let _mock = server.mock(|when, then| {
             when.method(GET).path("/redirect");
             then.status(302)
-                .header("Location", "http://127.0.0.1/private")
+                .header("Location", "http://example.com/private")
                 .body("");
         });
 
-        let config = DocumentParserConfig::default().with_request_timeout(Duration::from_secs(5));
+        let config = test_config(1024);
         let error = fetch_url(&format!("{}/redirect", server.base_url()), &config)
             .await
-            .expect_err("redirect to private host");
+            .expect_err("redirect to disallowed host");
 
-        assert!(matches!(
-            error,
-            DocumentSourceError::PrivateNetworkBlocked { .. }
-                | DocumentSourceError::BlockedHostname(_)
-        ));
+        assert!(matches!(error, DocumentSourceError::HostNotAllowed(_)));
     }
 
     #[tokio::test]

--- a/crates/autoagents-toolkit/src/tools/document_parsing/source/local_file.rs
+++ b/crates/autoagents-toolkit/src/tools/document_parsing/source/local_file.rs
@@ -1,0 +1,164 @@
+use std::path::Path;
+
+use tokio::fs::File;
+use tokio::io::AsyncReadExt;
+
+use super::error::DocumentSourceError;
+use crate::tools::document_parsing::config::DocumentParserConfig;
+use crate::utils::path_sandbox;
+
+pub async fn load_local_file(
+    path: &str,
+    config: &DocumentParserConfig,
+) -> Result<Vec<u8>, DocumentSourceError> {
+    let path = Path::new(path);
+
+    let canonical = match config.allowed_roots.as_deref() {
+        Some(roots) => path_sandbox::ensure_within_any_root(path, roots).map_err(|error| {
+            if error.kind() == std::io::ErrorKind::PermissionDenied {
+                DocumentSourceError::PathOutsideRoot {
+                    path: path.to_path_buf(),
+                }
+            } else {
+                DocumentSourceError::Io(error)
+            }
+        })?,
+        None => path_sandbox::canonicalize_or_normalize(path),
+    };
+
+    read_bounded_file(&canonical, config.max_local_file_bytes).await
+}
+
+async fn read_bounded_file(path: &Path, max_bytes: usize) -> Result<Vec<u8>, DocumentSourceError> {
+    let metadata = tokio::fs::metadata(path)
+        .await
+        .map_err(DocumentSourceError::from)?;
+    if metadata.len() > max_bytes as u64 {
+        return Err(DocumentSourceError::LocalFileTooLarge {
+            limit: max_bytes,
+            observed: metadata.len() as usize,
+        });
+    }
+
+    let mut file = File::open(path).await.map_err(DocumentSourceError::from)?;
+    let mut collected = Vec::with_capacity(metadata.len().min(max_bytes as u64) as usize);
+    let mut chunk = [0u8; 8_192];
+
+    loop {
+        let read = file
+            .read(&mut chunk)
+            .await
+            .map_err(DocumentSourceError::from)?;
+        if read == 0 {
+            break;
+        }
+
+        if collected.len() + read > max_bytes {
+            return Err(DocumentSourceError::LocalFileTooLarge {
+                limit: max_bytes,
+                observed: collected.len() + read,
+            });
+        }
+
+        collected.extend_from_slice(&chunk[..read]);
+    }
+
+    Ok(collected)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use std::path::PathBuf;
+    use tempfile::tempdir;
+
+    use crate::tools::document_parsing::config::DEFAULT_MAX_LOCAL_FILE_BYTES;
+
+    fn test_config(
+        max_local_file_bytes: usize,
+        roots: Option<Vec<PathBuf>>,
+    ) -> DocumentParserConfig {
+        let mut config =
+            DocumentParserConfig::default().with_max_local_file_bytes(max_local_file_bytes);
+        if let Some(roots) = roots {
+            config = config.with_allowed_roots(roots);
+        }
+        config
+    }
+
+    #[tokio::test]
+    async fn load_without_roots_allows_readable_file() {
+        let dir = tempdir().expect("tempdir");
+        let file_path = dir.path().join("doc.txt");
+        std::fs::File::create(&file_path)
+            .expect("create")
+            .write_all(b"hello")
+            .expect("write");
+
+        let bytes = load_local_file(
+            &file_path.display().to_string(),
+            &test_config(DEFAULT_MAX_LOCAL_FILE_BYTES, None),
+        )
+        .await
+        .expect("read file");
+        assert_eq!(bytes, b"hello");
+    }
+
+    #[tokio::test]
+    async fn load_with_roots_blocks_outside_path() {
+        let dir = tempdir().expect("tempdir");
+        let outside =
+            std::env::temp_dir().join(format!("outside-autoagents-{}", std::process::id()));
+        std::fs::write(&outside, b"secret").expect("write outside file");
+
+        let error = load_local_file(
+            &outside.display().to_string(),
+            &test_config(
+                DEFAULT_MAX_LOCAL_FILE_BYTES,
+                Some(vec![dir.path().to_path_buf()]),
+            ),
+        )
+        .await
+        .expect_err("outside path should be blocked");
+
+        assert!(matches!(error, DocumentSourceError::PathOutsideRoot { .. }));
+
+        std::fs::remove_file(outside).ok();
+    }
+
+    #[tokio::test]
+    async fn load_with_roots_allows_inside_path() {
+        let dir = tempdir().expect("tempdir");
+        let file_path = dir.path().join("doc.txt");
+        std::fs::write(&file_path, b"inside").expect("write");
+
+        let bytes = load_local_file(
+            &file_path.display().to_string(),
+            &test_config(
+                DEFAULT_MAX_LOCAL_FILE_BYTES,
+                Some(vec![dir.path().to_path_buf()]),
+            ),
+        )
+        .await
+        .expect("inside path allowed");
+
+        assert_eq!(bytes, b"inside");
+    }
+
+    #[tokio::test]
+    async fn load_rejects_oversized_local_file() {
+        let dir = tempdir().expect("tempdir");
+        let file_path = dir.path().join("large.txt");
+        std::fs::write(&file_path, vec![b'a'; 2048]).expect("write");
+
+        let error = load_local_file(&file_path.display().to_string(), &test_config(1024, None))
+            .await
+            .expect_err("oversized local file");
+
+        assert!(matches!(
+            error,
+            DocumentSourceError::LocalFileTooLarge { .. }
+        ));
+    }
+}

--- a/crates/autoagents-toolkit/src/tools/document_parsing/source/mod.rs
+++ b/crates/autoagents-toolkit/src/tools/document_parsing/source/mod.rs
@@ -1,0 +1,8 @@
+mod error;
+mod http_fetch;
+mod local_file;
+mod url_policy;
+
+pub use error::DocumentSourceError;
+pub use http_fetch::fetch_url;
+pub use local_file::load_local_file;

--- a/crates/autoagents-toolkit/src/tools/document_parsing/source/url_policy.rs
+++ b/crates/autoagents-toolkit/src/tools/document_parsing/source/url_policy.rs
@@ -1,0 +1,451 @@
+use std::net::{IpAddr, SocketAddr};
+use std::str::FromStr;
+use std::sync::LazyLock;
+
+use ipnet::{Ipv4Net, Ipv6Net};
+use url::{Host, Url};
+
+use super::error::DocumentSourceError;
+use crate::tools::document_parsing::config::DocumentParserConfig;
+
+const BLOCKED_IPV4_NETS_RAW: &[&str] = &[
+    "0.0.0.0/8",
+    "10.0.0.0/8",
+    "100.64.0.0/10",
+    "127.0.0.0/8",
+    "169.254.0.0/16",
+    "172.16.0.0/12",
+    "192.0.0.0/24",
+    "192.0.2.0/24",
+    "192.168.0.0/16",
+    "198.18.0.0/15",
+    "198.51.100.0/24",
+    "203.0.113.0/24",
+    "224.0.0.0/4",
+    "240.0.0.0/4",
+    "255.255.255.255/32",
+];
+
+const BLOCKED_IPV6_NETS_RAW: &[&str] = &[
+    "::/128",
+    "::1/128",
+    "100::/64",
+    "2001:db8::/32",
+    "fc00::/7",
+    "fe80::/10",
+    "ff00::/8",
+];
+
+const BLOCKED_HOSTNAMES: &[&str] = &["localhost", "metadata.google.internal", "metadata.google"];
+
+const BLOCKED_HOSTNAME_SUFFIXES: &[&str] = &[".localhost", ".local", ".internal", ".corp"];
+
+static BLOCKED_IPV4_NETS: LazyLock<Vec<Ipv4Net>> = LazyLock::new(|| {
+    BLOCKED_IPV4_NETS_RAW
+        .iter()
+        .map(|net| Ipv4Net::from_str(net).expect("valid IPv4 net"))
+        .collect()
+});
+
+static BLOCKED_IPV6_NETS: LazyLock<Vec<Ipv6Net>> = LazyLock::new(|| {
+    BLOCKED_IPV6_NETS_RAW
+        .iter()
+        .map(|net| Ipv6Net::from_str(net).expect("valid IPv6 net"))
+        .collect()
+});
+
+fn is_blocked_ip(addr: IpAddr, allow_private_networks: bool) -> bool {
+    if allow_private_networks {
+        return false;
+    }
+
+    match addr {
+        IpAddr::V4(ipv4) => BLOCKED_IPV4_NETS.iter().any(|net| net.contains(&ipv4)),
+        IpAddr::V6(ipv6) => {
+            if ipv4_from_ipv6_mapped(ipv6)
+                .is_some_and(|ipv4| BLOCKED_IPV4_NETS.iter().any(|net| net.contains(&ipv4)))
+            {
+                return true;
+            }
+
+            BLOCKED_IPV6_NETS.iter().any(|net| net.contains(&ipv6))
+        }
+    }
+}
+
+fn ipv4_from_ipv6_mapped(addr: std::net::Ipv6Addr) -> Option<std::net::Ipv4Addr> {
+    let octets = addr.octets();
+    if octets[0..10] == [0, 0, 0, 0, 0, 0, 0, 0, 0, 0] && octets[10] == 0xff && octets[11] == 0xff {
+        Some(std::net::Ipv4Addr::new(
+            octets[12], octets[13], octets[14], octets[15],
+        ))
+    } else {
+        None
+    }
+}
+
+fn host_matches_allowlist(host: &str, allowed_hosts: &[String]) -> bool {
+    let host = host.trim_end_matches('.').to_ascii_lowercase();
+
+    allowed_hosts.iter().any(|allowed| {
+        let allowed = allowed.trim().trim_end_matches('.').to_ascii_lowercase();
+        if allowed.is_empty() {
+            return false;
+        }
+
+        host == allowed
+            || host.ends_with(&format!(".{allowed}"))
+            || (allowed.starts_with('.') && host.ends_with(&allowed))
+    })
+}
+
+fn is_blocked_hostname(host: &str) -> bool {
+    let host = host.trim_end_matches('.').to_ascii_lowercase();
+
+    if BLOCKED_HOSTNAMES.iter().any(|blocked| *blocked == host) {
+        return true;
+    }
+
+    BLOCKED_HOSTNAME_SUFFIXES
+        .iter()
+        .any(|suffix| host.ends_with(suffix))
+}
+
+fn parse_ip_octet(part: &str) -> Option<u8> {
+    let part = part.trim();
+    if part.is_empty() {
+        return None;
+    }
+
+    if let Some(hex) = part.strip_prefix("0x").or_else(|| part.strip_prefix("0X")) {
+        return u8::from_str_radix(hex, 16).ok();
+    }
+
+    if part.len() > 1 && part.starts_with('0') && part.chars().all(|ch| ch.is_ascii_digit()) {
+        return u8::from_str_radix(part, 8).ok();
+    }
+
+    part.parse().ok()
+}
+
+fn parse_dotted_ipv4(host: &str) -> Option<IpAddr> {
+    let parts: Vec<&str> = host.split('.').collect();
+    if parts.len() != 4 {
+        return None;
+    }
+
+    let mut octets = [0u8; 4];
+    for (index, part) in parts.iter().enumerate() {
+        octets[index] = parse_ip_octet(part)?;
+    }
+
+    Some(IpAddr::V4(std::net::Ipv4Addr::from(octets)))
+}
+
+fn host_to_ip(host: &str) -> Option<IpAddr> {
+    if let Ok(addr) = host.parse::<IpAddr>() {
+        return Some(addr);
+    }
+
+    let host = host.trim();
+
+    if host.chars().all(|ch| ch.is_ascii_digit()) {
+        let value: u32 = host.parse().ok()?;
+        return Some(IpAddr::V4(std::net::Ipv4Addr::from(value.to_be_bytes())));
+    }
+
+    if let Some(hex) = host.strip_prefix("0x").or_else(|| host.strip_prefix("0X")) {
+        let value = u32::from_str_radix(hex, 16).ok()?;
+        return Some(IpAddr::V4(std::net::Ipv4Addr::from(value.to_be_bytes())));
+    }
+
+    parse_dotted_ipv4(host)
+}
+
+fn validate_port(url: &Url, config: &DocumentParserConfig) -> Result<(), DocumentSourceError> {
+    let Some(allowed_ports) = &config.allowed_ports else {
+        return Ok(());
+    };
+
+    let port = url.port_or_known_default().unwrap_or(80);
+    if allowed_ports.contains(&port) {
+        Ok(())
+    } else {
+        Err(DocumentSourceError::PortNotAllowed { port })
+    }
+}
+
+fn validate_host_name(
+    host: &str,
+    config: &DocumentParserConfig,
+) -> Result<(), DocumentSourceError> {
+    if is_blocked_hostname(host) {
+        return Err(DocumentSourceError::BlockedHostname(host.to_string()));
+    }
+
+    if let Some(allowed_hosts) = &config.allowed_hosts
+        && !host_matches_allowlist(host, allowed_hosts)
+    {
+        return Err(DocumentSourceError::HostNotAllowed(host.to_string()));
+    }
+
+    if let Some(addr) = host_to_ip(host)
+        && is_blocked_ip(addr, config.allow_private_networks)
+    {
+        return Err(DocumentSourceError::PrivateNetworkBlocked {
+            host: host.to_string(),
+            addr,
+        });
+    }
+
+    Ok(())
+}
+
+pub fn validate_url_str(
+    url: &str,
+    config: &DocumentParserConfig,
+) -> Result<Url, DocumentSourceError> {
+    let parsed = Url::parse(url)
+        .map_err(|error| DocumentSourceError::InvalidHost(format!("{url}: {error}")))?;
+
+    validate_url(&parsed, config)?;
+    Ok(parsed)
+}
+
+pub fn validate_url(url: &Url, config: &DocumentParserConfig) -> Result<(), DocumentSourceError> {
+    match url.scheme() {
+        "http" | "https" => {}
+        other => {
+            return Err(DocumentSourceError::UrlSchemeNotAllowed(other.to_string()));
+        }
+    }
+
+    if !url.username().is_empty() || url.password().is_some() {
+        return Err(DocumentSourceError::CredentialsInUrl);
+    }
+
+    validate_port(url, config)?;
+
+    let host = url
+        .host()
+        .ok_or_else(|| DocumentSourceError::InvalidHost(url.to_string()))?;
+
+    match host {
+        Host::Domain(domain) => validate_host_name(domain, config)?,
+        Host::Ipv4(addr) => {
+            if is_blocked_ip(IpAddr::V4(addr), config.allow_private_networks) {
+                return Err(DocumentSourceError::PrivateNetworkBlocked {
+                    host: addr.to_string(),
+                    addr: IpAddr::V4(addr),
+                });
+            }
+            validate_host_name(&addr.to_string(), config)?;
+        }
+        Host::Ipv6(addr) => {
+            if is_blocked_ip(IpAddr::V6(addr), config.allow_private_networks) {
+                return Err(DocumentSourceError::PrivateNetworkBlocked {
+                    host: addr.to_string(),
+                    addr: IpAddr::V6(addr),
+                });
+            }
+            validate_host_name(&addr.to_string(), config)?;
+        }
+    }
+
+    Ok(())
+}
+
+pub fn validate_resolved_addresses(
+    host: &str,
+    addresses: &[SocketAddr],
+    config: &DocumentParserConfig,
+) -> Result<(), DocumentSourceError> {
+    if addresses.is_empty() {
+        return Err(DocumentSourceError::NoResolvedAddresses(host.to_string()));
+    }
+
+    for address in addresses {
+        if is_blocked_ip(address.ip(), config.allow_private_networks) {
+            return Err(DocumentSourceError::PrivateNetworkBlocked {
+                host: host.to_string(),
+                addr: address.ip(),
+            });
+        }
+    }
+
+    Ok(())
+}
+
+pub async fn resolve_host(
+    host: &str,
+    port: u16,
+    config: &DocumentParserConfig,
+) -> Result<Vec<SocketAddr>, DocumentSourceError> {
+    validate_host_name(host, config)?;
+
+    if let Some(addr) = host_to_ip(host) {
+        let socket = SocketAddr::new(addr, port);
+        validate_resolved_addresses(host, std::slice::from_ref(&socket), config)?;
+        return Ok(vec![socket]);
+    }
+
+    let lookup_target = format!("{host}:{port}");
+    let mut addresses = tokio::net::lookup_host(&lookup_target)
+        .await
+        .map_err(|source| DocumentSourceError::DnsResolutionFailed {
+            host: host.to_string(),
+            source,
+        })?
+        .collect::<Vec<_>>();
+
+    if addresses.is_empty() {
+        return Err(DocumentSourceError::NoResolvedAddresses(host.to_string()));
+    }
+
+    addresses.sort();
+    addresses.dedup();
+
+    validate_resolved_addresses(host, &addresses, config)?;
+    Ok(addresses)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn default_config() -> DocumentParserConfig {
+        DocumentParserConfig::default()
+    }
+
+    #[test]
+    fn blocks_metadata_ip_literal() {
+        let config = default_config();
+        let error = validate_url_str("http://169.254.169.254/latest/meta-data/", &config)
+            .expect_err("metadata IP should be blocked");
+        assert!(matches!(
+            error,
+            DocumentSourceError::PrivateNetworkBlocked { .. }
+        ));
+    }
+
+    #[test]
+    fn blocks_loopback_ip() {
+        let config = default_config();
+        let error = validate_url_str("http://127.0.0.1/secret", &config).expect_err("loopback");
+        assert!(matches!(
+            error,
+            DocumentSourceError::PrivateNetworkBlocked { .. }
+        ));
+    }
+
+    #[test]
+    fn blocks_decimal_ip_notation() {
+        let config = default_config();
+        let error = validate_url_str("http://2130706433/", &config).expect_err("decimal IP");
+        assert!(matches!(
+            error,
+            DocumentSourceError::PrivateNetworkBlocked { .. }
+        ));
+    }
+
+    #[test]
+    fn blocks_octal_dotted_ip_notation() {
+        let config = default_config();
+        let error = validate_url_str("http://0177.0.0.1/secret", &config).expect_err("octal IP");
+        assert!(matches!(
+            error,
+            DocumentSourceError::PrivateNetworkBlocked { .. }
+        ));
+    }
+
+    #[test]
+    fn blocks_localhost_hostname() {
+        let config = default_config();
+        let error = validate_url_str("http://localhost/secret", &config).expect_err("localhost");
+        assert!(matches!(error, DocumentSourceError::BlockedHostname(_)));
+    }
+
+    #[test]
+    fn blocks_internal_hostname_suffix() {
+        let config = default_config();
+        let error = validate_url_str("http://service.internal/doc", &config).expect_err("internal");
+        assert!(matches!(error, DocumentSourceError::BlockedHostname(_)));
+    }
+
+    #[test]
+    fn blocks_credentials_in_url() {
+        let config = default_config();
+        let error = validate_url_str("http://user:pass@example.com/doc.pdf", &config)
+            .expect_err("credentials");
+        assert!(matches!(error, DocumentSourceError::CredentialsInUrl));
+    }
+
+    #[test]
+    fn blocks_non_http_scheme() {
+        let config = default_config();
+        let error = validate_url_str("file:///etc/passwd", &config).expect_err("file scheme");
+        assert!(matches!(error, DocumentSourceError::UrlSchemeNotAllowed(_)));
+    }
+
+    #[test]
+    fn blocks_disallowed_port() {
+        let config = DocumentParserConfig::default()
+            .with_allowed_ports(vec![80, 443])
+            .expect("ports");
+        let error =
+            validate_url_str("http://example.com:8080/doc.pdf", &config).expect_err("port blocked");
+        assert!(matches!(
+            error,
+            DocumentSourceError::PortNotAllowed { port: 8080 }
+        ));
+    }
+
+    #[test]
+    fn allows_public_url() {
+        let config = default_config();
+        validate_url_str("https://example.com/file.pdf", &config).expect("public URL allowed");
+    }
+
+    #[test]
+    fn host_allowlist_rejects_unlisted_host() {
+        let config = DocumentParserConfig::default()
+            .with_allowed_hosts(vec!["example.com".to_string()])
+            .expect("hosts");
+        let error = validate_url_str("https://evil.com/file.pdf", &config).expect_err("allowlist");
+        assert!(matches!(error, DocumentSourceError::HostNotAllowed(_)));
+    }
+
+    #[test]
+    fn host_allowlist_accepts_subdomain() {
+        let config = DocumentParserConfig::default()
+            .with_allowed_hosts(vec!["example.com".to_string()])
+            .expect("hosts");
+        validate_url_str("https://cdn.example.com/file.pdf", &config)
+            .expect("subdomain should match");
+    }
+
+    #[test]
+    fn resolved_addresses_must_all_be_public() {
+        let config = default_config();
+        let addresses = vec![
+            SocketAddr::new(IpAddr::V4(std::net::Ipv4Addr::new(8, 8, 8, 8)), 443),
+            SocketAddr::new(IpAddr::V4(std::net::Ipv4Addr::new(10, 0, 0, 1)), 443),
+        ];
+
+        let error = validate_resolved_addresses("example.com", &addresses, &config)
+            .expect_err("mixed DNS answers");
+        assert!(matches!(
+            error,
+            DocumentSourceError::PrivateNetworkBlocked { .. }
+        ));
+    }
+
+    #[test]
+    fn private_networks_allowed_when_configured() {
+        let config = DocumentParserConfig::default()
+            .with_allow_private_networks(true)
+            .with_allowed_hosts(vec!["127.0.0.1".to_string()])
+            .expect("hosts");
+        validate_url_str("http://127.0.0.1/secret", &config).expect("private allowed");
+    }
+}

--- a/crates/autoagents-toolkit/src/tools/document_parsing/source/url_policy.rs
+++ b/crates/autoagents-toolkit/src/tools/document_parsing/source/url_policy.rs
@@ -85,6 +85,10 @@ fn ipv4_from_ipv6_mapped(addr: std::net::Ipv6Addr) -> Option<std::net::Ipv4Addr>
 }
 
 fn host_matches_allowlist(host: &str, allowed_hosts: &[String]) -> bool {
+    if host_to_ip(host).is_some() {
+        return host_matches_allowlist_exact(host, allowed_hosts);
+    }
+
     let host = host.trim_end_matches('.').to_ascii_lowercase();
 
     allowed_hosts.iter().any(|allowed| {
@@ -99,7 +103,19 @@ fn host_matches_allowlist(host: &str, allowed_hosts: &[String]) -> bool {
     })
 }
 
-fn is_blocked_hostname(host: &str) -> bool {
+fn host_matches_allowlist_exact(host: &str, allowed_hosts: &[String]) -> bool {
+    let host = host.trim_end_matches('.').to_ascii_lowercase();
+    allowed_hosts.iter().any(|allowed| {
+        let allowed = allowed.trim().trim_end_matches('.').to_ascii_lowercase();
+        !allowed.is_empty() && host == allowed
+    })
+}
+
+fn is_blocked_hostname(host: &str, allow_private_networks: bool) -> bool {
+    if allow_private_networks {
+        return false;
+    }
+
     let host = host.trim_end_matches('.').to_ascii_lowercase();
 
     if BLOCKED_HOSTNAMES.iter().any(|blocked| *blocked == host) {
@@ -179,7 +195,7 @@ fn validate_host_name(
     host: &str,
     config: &DocumentParserConfig,
 ) -> Result<(), DocumentSourceError> {
-    if is_blocked_hostname(host) {
+    if is_blocked_hostname(host, config.allow_private_networks) {
         return Err(DocumentSourceError::BlockedHostname(host.to_string()));
     }
 
@@ -196,6 +212,29 @@ fn validate_host_name(
             host: host.to_string(),
             addr,
         });
+    }
+
+    Ok(())
+}
+
+fn validate_ip_literal(
+    addr: IpAddr,
+    display_host: &str,
+    config: &DocumentParserConfig,
+) -> Result<(), DocumentSourceError> {
+    if is_blocked_ip(addr, config.allow_private_networks) {
+        return Err(DocumentSourceError::PrivateNetworkBlocked {
+            host: display_host.to_string(),
+            addr,
+        });
+    }
+
+    if let Some(allowed_hosts) = &config.allowed_hosts
+        && !host_matches_allowlist_exact(display_host, allowed_hosts)
+    {
+        return Err(DocumentSourceError::HostNotAllowed(
+            display_host.to_string(),
+        ));
     }
 
     Ok(())
@@ -232,24 +271,8 @@ pub fn validate_url(url: &Url, config: &DocumentParserConfig) -> Result<(), Docu
 
     match host {
         Host::Domain(domain) => validate_host_name(domain, config)?,
-        Host::Ipv4(addr) => {
-            if is_blocked_ip(IpAddr::V4(addr), config.allow_private_networks) {
-                return Err(DocumentSourceError::PrivateNetworkBlocked {
-                    host: addr.to_string(),
-                    addr: IpAddr::V4(addr),
-                });
-            }
-            validate_host_name(&addr.to_string(), config)?;
-        }
-        Host::Ipv6(addr) => {
-            if is_blocked_ip(IpAddr::V6(addr), config.allow_private_networks) {
-                return Err(DocumentSourceError::PrivateNetworkBlocked {
-                    host: addr.to_string(),
-                    addr: IpAddr::V6(addr),
-                });
-            }
-            validate_host_name(&addr.to_string(), config)?;
-        }
+        Host::Ipv4(addr) => validate_ip_literal(IpAddr::V4(addr), &addr.to_string(), config)?,
+        Host::Ipv6(addr) => validate_ip_literal(IpAddr::V6(addr), &addr.to_string(), config)?,
     }
 
     Ok(())
@@ -441,11 +464,21 @@ mod tests {
     }
 
     #[test]
+    fn host_allowlist_requires_exact_match_for_ip_literals() {
+        let config = DocumentParserConfig::default()
+            .with_allowed_hosts(vec!["8.8".to_string()])
+            .expect("hosts");
+        let error = validate_url_str("http://8.8.8.8/doc.pdf", &config).expect_err("suffix match");
+        assert!(matches!(error, DocumentSourceError::HostNotAllowed(_)));
+    }
+
+    #[test]
     fn private_networks_allowed_when_configured() {
         let config = DocumentParserConfig::default()
             .with_allow_private_networks(true)
-            .with_allowed_hosts(vec!["127.0.0.1".to_string()])
+            .with_allowed_hosts(vec!["127.0.0.1".to_string(), "localhost".to_string()])
             .expect("hosts");
-        validate_url_str("http://127.0.0.1/secret", &config).expect("private allowed");
+        validate_url_str("http://127.0.0.1/secret", &config).expect("loopback IP allowed");
+        validate_url_str("http://localhost/secret", &config).expect("localhost allowed");
     }
 }

--- a/crates/autoagents-toolkit/src/tools/filesystem/mod.rs
+++ b/crates/autoagents-toolkit/src/tools/filesystem/mod.rs
@@ -18,6 +18,8 @@ pub use write_file::WriteFile;
 
 use std::path::{Path, PathBuf};
 
+use crate::utils::path_sandbox;
+
 pub trait BaseFileTool {
     fn root_dir(&self) -> Option<String>;
 
@@ -38,37 +40,11 @@ pub trait BaseFileTool {
     }
 
     fn ensure_within_root(&self, path: &Path) -> Result<PathBuf, std::io::Error> {
-        fn normalize_path(path: &Path) -> PathBuf {
-            use std::path::Component;
-
-            let mut normalized = PathBuf::default();
-
-            for component in path.components() {
-                match component {
-                    Component::CurDir => {}
-                    Component::ParentDir => {
-                        normalized.pop();
-                    }
-                    _ => normalized.push(component.as_os_str()),
-                }
-            }
-
-            normalized
-        }
-
-        let canonical = path.canonicalize().unwrap_or_else(|_| normalize_path(path));
-
         if let Some(root) = self.root_dir() {
-            let root_canonical = Path::new(&root).canonicalize()?;
-            if !canonical.starts_with(&root_canonical) {
-                return Err(std::io::Error::new(
-                    std::io::ErrorKind::PermissionDenied,
-                    format!("Path {} is outside of root directory", path.display()),
-                ));
-            }
+            path_sandbox::ensure_within_root(path, Path::new(&root))
+        } else {
+            Ok(path_sandbox::canonicalize_or_normalize(path))
         }
-
-        Ok(canonical)
     }
 }
 

--- a/crates/autoagents-toolkit/src/utils/mod.rs
+++ b/crates/autoagents-toolkit/src/utils/mod.rs
@@ -1,1 +1,2 @@
 pub(crate) mod constant;
+pub(crate) mod path_sandbox;

--- a/crates/autoagents-toolkit/src/utils/path_sandbox.rs
+++ b/crates/autoagents-toolkit/src/utils/path_sandbox.rs
@@ -74,8 +74,8 @@ mod tests {
 
     #[test]
     fn normalize_path_resolves_parent_dirs() {
-        let path = Path::new("/tmp/a/../b/./file.txt");
-        assert_eq!(normalize_path(path), PathBuf::from("/tmp/b/file.txt"));
+        let path = Path::new("workspace/a/../b/./file.txt");
+        assert_eq!(normalize_path(path), PathBuf::from("workspace/b/file.txt"));
     }
 
     #[test]

--- a/crates/autoagents-toolkit/src/utils/path_sandbox.rs
+++ b/crates/autoagents-toolkit/src/utils/path_sandbox.rs
@@ -1,0 +1,121 @@
+use std::path::{Component, Path, PathBuf};
+
+/// Normalize a path by resolving `.` and `..` components without touching the filesystem.
+pub fn normalize_path(path: &Path) -> PathBuf {
+    let mut normalized = PathBuf::default();
+
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                normalized.pop();
+            }
+            _ => normalized.push(component.as_os_str()),
+        }
+    }
+
+    normalized
+}
+
+/// Canonicalize `path`, falling back to logical normalization when the target does not exist yet.
+pub fn canonicalize_or_normalize(path: &Path) -> PathBuf {
+    path.canonicalize().unwrap_or_else(|_| normalize_path(path))
+}
+
+/// Ensure `path` resolves inside `root`.
+pub fn ensure_within_root(path: &Path, root: &Path) -> Result<PathBuf, std::io::Error> {
+    let canonical = canonicalize_or_normalize(path);
+    let root_canonical = root.canonicalize()?;
+
+    if !canonical.starts_with(&root_canonical) {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            format!(
+                "Path {} is outside of root directory {}",
+                path.display(),
+                root.display()
+            ),
+        ));
+    }
+
+    Ok(canonical)
+}
+
+/// Ensure `path` resolves inside at least one of the provided roots.
+#[cfg(feature = "document-parsing")]
+pub fn ensure_within_any_root(path: &Path, roots: &[PathBuf]) -> Result<PathBuf, std::io::Error> {
+    if roots.is_empty() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "no allowed roots configured",
+        ));
+    }
+
+    let mut last_error = None;
+
+    for root in roots {
+        match ensure_within_root(path, root) {
+            Ok(canonical) => return Ok(canonical),
+            Err(error) => last_error = Some(error),
+        }
+    }
+
+    Err(last_error.unwrap_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::PermissionDenied,
+            format!("Path {} is outside of allowed roots", path.display()),
+        )
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_path_resolves_parent_dirs() {
+        let path = Path::new("/tmp/a/../b/./file.txt");
+        assert_eq!(normalize_path(path), PathBuf::from("/tmp/b/file.txt"));
+    }
+
+    #[test]
+    fn ensure_within_root_safe_path() {
+        let dir = std::env::temp_dir();
+        let safe = dir.join("path_sandbox_safe.txt");
+        std::fs::write(&safe, "").expect("write temp file");
+
+        let result = ensure_within_root(&safe, &dir);
+        assert!(result.is_ok());
+
+        std::fs::remove_file(safe).ok();
+    }
+
+    #[test]
+    fn ensure_within_root_traversal_blocked() {
+        let dir = std::env::temp_dir().join("path_sandbox_root");
+        std::fs::create_dir_all(&dir).expect("create temp dir");
+
+        let traversal = dir.join("../../etc/passwd");
+        let result = ensure_within_root(&traversal, &dir);
+        assert!(result.is_err());
+
+        std::fs::remove_dir_all(dir).ok();
+    }
+
+    #[test]
+    #[cfg(feature = "document-parsing")]
+    fn ensure_within_any_root_accepts_matching_root() {
+        let dir = std::env::temp_dir().join("path_sandbox_any_root");
+        std::fs::create_dir_all(&dir).expect("create temp dir");
+
+        let file = dir.join("doc.txt");
+        std::fs::write(&file, "ok").expect("write temp file");
+
+        let roots = vec![std::env::temp_dir(), dir.clone()];
+        let result = ensure_within_any_root(&file, &roots);
+        assert!(result.is_ok());
+
+        std::fs::remove_file(file).ok();
+        std::fs::remove_dir_all(dir).ok();
+    }
+}


### PR DESCRIPTION
## Summary
- Hardens `parse_document` against SSRF, unbounded HTTP/local reads, and path traversal by introducing a dedicated source-loading layer with URL policy validation, DNS-pinned fetches, redirect re-validation, and bounded streaming reads.
- Adds `DocumentParserConfig` for timeouts, size limits, host/port allowlists, optional local filesystem roots, and secure defaults for agent deployments.
- Extracts shared path sandboxing into `utils/path_sandbox.rs` and reuses it from filesystem tools.

## Security changes
- Blocks private/loopback/link-local/metadata IP ranges, obfuscated IP literals, credentials in URLs, and dangerous hostnames (including `.internal` / `.corp`).
- Validates every redirect hop and pins DNS resolution before connecting.
- Enforces HTTP status checks and download byte caps (default 50 MiB).
- Enforces local file byte caps and optional `allowed_roots` sandboxing.

## Test plan
- [x] `cargo test -p autoagents-toolkit --features document-parsing`
- [x] `cargo test -p autoagents-toolkit --features filesystem`
- [x] `cargo clippy -p autoagents-toolkit --features document-parsing,filesystem -- -D warnings`
- [x] Pre-commit hooks (fmt, clippy, test --features full)

Closes #249


Made with [Cursor](https://cursor.com)