### PR TITLE
[SECURITY]: Sandbox filesystem tools and coding_agent for v0.4.0 (#248)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,32 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [0.4.0] - Unreleased
+
+### Security
+
+- Filesystem toolkit tools now require an explicit workspace root via `Tool::new(&root)?`.
+- Removed unscoped filesystem constructors (`ReadFile::new()`, `Default`, `new_with_root_dir`).
+- Reject absolute paths, `..` traversal, and symlink escapes within the sandbox.
+- `delete_file` deletes directories non-recursively by default; pass `"recursive": true` for trees.
+- Mutating tools re-validate paths after parent directory creation to close TOCTOU gaps.
+
+### Migration
+
+| Before (pre-0.4.0) | After (0.4.0) |
+| ------------------ | ------------- |
+| `ReadFile::new()` | `ReadFile::new(&workspace_root)?` |
+| `ReadFile::new_with_root_dir(path)` | `ReadFile::new(&path)?` |
+| `SearchFile::new(100)` | `SearchFile::new(&workspace_root, 100)?` |
+| `DeleteFile` on non-empty directory | Add `"recursive": true` to args |
+
+Share one `FilesystemSandbox` across tools when wiring agents dynamically:
+
+```rust
+let sandbox = FilesystemSandbox::new(&workspace)?;
+let read = ReadFile::with_sandbox(sandbox.clone());
+let write = WriteFile::with_sandbox(sandbox);
+```
+
+See `examples/coding_agent` for the reference integration.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -756,6 +756,7 @@ dependencies = [
  "base64 0.22.1",
  "calamine",
  "csv",
+ "glob",
  "html2text",
  "log",
  "once_cell",

--- a/crates/autoagents-toolkit/Cargo.toml
+++ b/crates/autoagents-toolkit/Cargo.toml
@@ -36,6 +36,7 @@ log = { workspace = true }
 once_cell = { workspace = true, optional = true }
 base64 = { workspace = true }
 walkdir = { workspace = true }
+glob = { workspace = true }
 toml = { workspace = true, optional = true }
 thiserror = { workspace = true }
 pdf-extract = { workspace = true, optional = true }

--- a/crates/autoagents-toolkit/src/tools/filesystem/copy_file.rs
+++ b/crates/autoagents-toolkit/src/tools/filesystem/copy_file.rs
@@ -1,3 +1,5 @@
+use std::path::Path;
+
 use autoagents::core::{
     ractor::async_trait,
     tool::{ToolCallError, ToolRuntime, ToolT},
@@ -8,7 +10,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use tokio::fs;
 
-use super::BaseFileTool;
+use super::{BaseFileTool, FilesystemSandbox, prepare_mutation_path, sandbox_error};
 
 #[derive(Serialize, Deserialize, ToolInput, Debug)]
 pub struct CopyFileArgs {
@@ -23,26 +25,25 @@ pub struct CopyFileArgs {
     description = "Copy a file from source path to destination path",
     input = CopyFileArgs,
 )]
-#[derive(Default)]
 pub struct CopyFile {
-    root_dir: Option<String>,
+    sandbox: FilesystemSandbox,
 }
 
 impl CopyFile {
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(root: impl AsRef<Path>) -> std::io::Result<Self> {
+        Ok(Self {
+            sandbox: FilesystemSandbox::new(root)?,
+        })
     }
 
-    pub fn new_with_root_dir(root_dir: String) -> Self {
-        Self {
-            root_dir: Some(root_dir),
-        }
+    pub fn with_sandbox(sandbox: FilesystemSandbox) -> Self {
+        Self { sandbox }
     }
 }
 
 impl BaseFileTool for CopyFile {
-    fn root_dir(&self) -> Option<String> {
-        self.root_dir.clone()
+    fn sandbox(&self) -> &FilesystemSandbox {
+        &self.sandbox
     }
 }
 
@@ -62,32 +63,23 @@ where
             source_path, destination_path
         );
 
-        let src_path = self.get_relative_path(&source_path);
-        let dest_path = self.get_relative_path(&destination_path);
+        let src_path = self
+            .sandbox()
+            .resolve_relative(&source_path)
+            .map_err(sandbox_error)?;
 
-        // Validate source exists
         if !src_path.exists() {
             return Err(ToolCallError::RuntimeError(
                 format!("Source file does not exist: {}", src_path.display()).into(),
             ));
         }
 
-        // Ensure paths are within root if root is set
-        if self.root_dir().is_some() {
-            self.ensure_within_root(&src_path)
-                .map_err(|e| ToolCallError::RuntimeError(Box::new(e)))?;
-            self.ensure_within_root(&dest_path)
-                .map_err(|e| ToolCallError::RuntimeError(Box::new(e)))?;
-        }
+        let src_path = self
+            .sandbox()
+            .ensure_resolved(&src_path)
+            .map_err(sandbox_error)?;
+        let dest_path = prepare_mutation_path(self.sandbox(), &destination_path).await?;
 
-        // Create parent directory if it doesn't exist
-        if let Some(parent) = dest_path.parent() {
-            fs::create_dir_all(parent)
-                .await
-                .map_err(|e| ToolCallError::RuntimeError(Box::new(e)))?;
-        }
-
-        // Perform the copy
         let bytes_copied = fs::copy(&src_path, &dest_path)
             .await
             .map_err(|e| ToolCallError::RuntimeError(Box::new(e)))?;
@@ -113,23 +105,21 @@ mod tests {
         let src_path = temp_dir.path().join("source.txt");
         let dest_path = temp_dir.path().join("destination.txt");
 
-        // Create source file
         let mut src_file = std::fs::File::create(&src_path).expect("Failed to create source file");
         src_file
             .write_all(b"Hello, World!")
             .expect("Failed to write to source file");
         drop(src_file);
 
-        let copy_file = CopyFile::default();
+        let copy_file = CopyFile::new(temp_dir.path()).expect("sandbox");
         let args = json!({
-            "source_path": src_path.display().to_string(),
-            "destination_path": dest_path.display().to_string()
+            "source_path": "source.txt",
+            "destination_path": "destination.txt"
         });
 
         let result = copy_file.execute(args).await;
         assert!(result.is_ok());
 
-        // Verify destination file exists and has correct content
         let content = std::fs::read_to_string(&dest_path).expect("Failed to read destination file");
         assert_eq!(content, "Hello, World!");
     }
@@ -137,13 +127,11 @@ mod tests {
     #[tokio::test]
     async fn test_copy_file_source_not_exists() {
         let temp_dir = tempdir().expect("Failed to create temp dir");
-        let src_path = temp_dir.path().join("nonexistent.txt");
-        let dest_path = temp_dir.path().join("destination.txt");
 
-        let copy_file = CopyFile::default();
+        let copy_file = CopyFile::new(temp_dir.path()).expect("sandbox");
         let args = json!({
-            "source_path": src_path.display().to_string(),
-            "destination_path": dest_path.display().to_string()
+            "source_path": "nonexistent.txt",
+            "destination_path": "destination.txt"
         });
 
         let result = copy_file.execute(args).await;
@@ -153,7 +141,6 @@ mod tests {
     #[tokio::test]
     async fn test_copy_file_with_root_dir() {
         let temp_dir = tempdir().expect("Failed to create temp dir");
-        let root_dir = temp_dir.path().to_str().unwrap().to_string();
 
         let src_file = temp_dir.path().join("source.txt");
         let mut file = std::fs::File::create(&src_file).expect("Failed to create source file");
@@ -161,7 +148,7 @@ mod tests {
             .expect("Failed to write to source file");
         drop(file);
 
-        let copy_file = CopyFile::new_with_root_dir(root_dir);
+        let copy_file = CopyFile::new(temp_dir.path()).expect("sandbox");
         let args = json!({
             "source_path": "source.txt",
             "destination_path": "dest.txt"

--- a/crates/autoagents-toolkit/src/tools/filesystem/copy_file.rs
+++ b/crates/autoagents-toolkit/src/tools/filesystem/copy_file.rs
@@ -86,8 +86,8 @@ where
 
         Ok(json!({
             "success": true,
-            "source": src_path.display().to_string(),
-            "destination": dest_path.display().to_string(),
+            "source": self.sandbox().relative_path_display(&src_path),
+            "destination": self.sandbox().relative_path_display(&dest_path),
             "bytes_copied": bytes_copied
         }))
     }

--- a/crates/autoagents-toolkit/src/tools/filesystem/create_dir.rs
+++ b/crates/autoagents-toolkit/src/tools/filesystem/create_dir.rs
@@ -1,9 +1,10 @@
+use std::path::Path;
+
 use autoagents::core::{
     ractor::async_trait,
     tool::{ToolCallError, ToolRuntime},
 };
 use autoagents_derive::{ToolInput, tool};
-
 use log::debug;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
@@ -11,7 +12,7 @@ use tokio::fs;
 
 use autoagents::prelude::ToolT;
 
-use super::BaseFileTool;
+use super::{BaseFileTool, FilesystemSandbox, sandbox_error};
 
 #[derive(Serialize, Deserialize, ToolInput, Debug)]
 pub struct CreateDirArgs {
@@ -27,26 +28,24 @@ pub struct CreateDirArgs {
     description = "Create a directory in the filesystem. Idempotent: succeeds if the directory already exists.",
     input = CreateDirArgs,
 )]
-#[derive(Default)]
 pub struct CreateDir {
-    root_dir: Option<String>,
+    sandbox: FilesystemSandbox,
 }
 
 impl CreateDir {
-    pub fn new() -> Self {
-        Self { root_dir: None }
+    pub fn new(root: impl AsRef<Path>) -> std::io::Result<Self> {
+        Ok(Self {
+            sandbox: FilesystemSandbox::new(root)?,
+        })
     }
-
-    pub fn new_with_root_dir(root_dir: String) -> Self {
-        Self {
-            root_dir: Some(root_dir),
-        }
+    pub fn with_sandbox(sandbox: FilesystemSandbox) -> Self {
+        Self { sandbox }
     }
 }
 
 impl BaseFileTool for CreateDir {
-    fn root_dir(&self) -> Option<String> {
-        self.root_dir.clone()
+    fn sandbox(&self) -> &FilesystemSandbox {
+        &self.sandbox
     }
 }
 
@@ -63,17 +62,17 @@ where
 
         debug!("CreateDir Executing: directory_path={}", directory_path);
 
-        let path = self.get_relative_path(&directory_path);
-
-        // Ensure path is within root if root is set
-        if self.root_dir().is_some() {
-            self.ensure_within_root(&path)
-                .map_err(|e| ToolCallError::RuntimeError(Box::new(e)))?;
-        }
+        let path = self
+            .sandbox()
+            .resolve_relative(&directory_path)
+            .map_err(sandbox_error)?;
+        let path = self
+            .sandbox()
+            .ensure_resolved(&path)
+            .map_err(sandbox_error)?;
 
         use std::io::ErrorKind;
 
-        // For recursive mode, determine created/existed via existence check before mkdir -p.
         let existed_before = fs::metadata(&path).await.is_ok();
 
         let (mut already_existed, mut created) = (false, false);
@@ -97,12 +96,16 @@ where
             }
         }
 
+        let path = self
+            .sandbox()
+            .ensure_resolved(&path)
+            .map_err(sandbox_error)?;
+
         let message = if already_existed {
             "Directory already existed"
         } else if created {
             "Directory created successfully"
         } else {
-            // Extremely rare fallback
             "Directory ensured"
         };
 
@@ -126,9 +129,8 @@ mod tests {
     #[tokio::test]
     async fn test_create_dir_creates_new_directory() {
         let tmp = tempdir().expect("tempdir");
-        let root = tmp.path().to_str().unwrap().to_string();
 
-        let tool = CreateDir::new_with_root_dir(root.clone());
+        let tool = CreateDir::new(tmp.path()).expect("sandbox");
 
         let args = json!({
             "directory_path": "test",
@@ -151,13 +153,11 @@ mod tests {
     #[tokio::test]
     async fn test_create_dir_idempotent_when_already_exists() {
         let tmp = tempdir().expect("tempdir");
-        let root = tmp.path().to_str().unwrap().to_string();
 
-        // Create initial directory using std (outside tool)
         let initial = tmp.path().join("test");
         std::fs::create_dir_all(&initial).expect("create initial dir");
 
-        let tool = CreateDir::new_with_root_dir(root.clone());
+        let tool = CreateDir::new(tmp.path()).expect("sandbox");
 
         let args = json!({
             "directory_path": "test",
@@ -178,11 +178,9 @@ mod tests {
     #[tokio::test]
     async fn test_create_dir_recursive_creates_nested_directories() {
         let tmp = tempdir().expect("tempdir");
-        let root = tmp.path().to_str().unwrap().to_string();
 
-        let tool = CreateDir::new_with_root_dir(root);
+        let tool = CreateDir::new(tmp.path()).expect("sandbox");
 
-        // Note: omit "recursive" to test serde default = false? Here we set true explicitly.
         let args = json!({
             "directory_path": "a/b/c",
             "recursive": true
@@ -204,11 +202,9 @@ mod tests {
     #[tokio::test]
     async fn test_create_dir_recursive_default_field_is_false_when_omitted() {
         let tmp = tempdir().expect("tempdir");
-        let root = tmp.path().to_str().unwrap().to_string();
 
-        let tool = CreateDir::new_with_root_dir(root);
+        let tool = CreateDir::new(tmp.path()).expect("sandbox");
 
-        // Omit "recursive" to ensure serde default kicks in (recursive=false).
         let args = json!({
             "directory_path": "test"
         });
@@ -224,19 +220,15 @@ mod tests {
     #[tokio::test]
     async fn test_create_dir_rejects_path_outside_root() {
         let tmp = tempdir().expect("tempdir");
-        let root = tmp.path().to_str().unwrap().to_string();
 
-        let tool = CreateDir::new_with_root_dir(root);
+        let tool = CreateDir::new(tmp.path()).expect("sandbox");
 
-        // Try to escape root
         let args = json!({
             "directory_path": "../outside",
             "recursive": true
         });
 
         let err = tool.execute(args).await.expect_err("should fail");
-        // We don't assert exact error string because ensure_within_root may format differently,
-        // but we ensure it's a runtime error, not a serde error.
         match err {
             ToolCallError::RuntimeError(_) => {}
             other => panic!("expected RuntimeError, got: {other:?}"),

--- a/crates/autoagents-toolkit/src/tools/filesystem/create_dir.rs
+++ b/crates/autoagents-toolkit/src/tools/filesystem/create_dir.rs
@@ -111,7 +111,7 @@ where
 
         Ok(json!({
             "success": true,
-            "path": path.display().to_string(),
+            "path": self.sandbox().relative_path_display(&path),
             "already_existed": already_existed,
             "created": created,
             "recursive": recursive,

--- a/crates/autoagents-toolkit/src/tools/filesystem/delete_file.rs
+++ b/crates/autoagents-toolkit/src/tools/filesystem/delete_file.rs
@@ -1,3 +1,5 @@
+use std::path::Path;
+
 use autoagents::core::{
     ractor::async_trait,
     tool::{ToolCallError, ToolRuntime, ToolT},
@@ -8,12 +10,15 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use tokio::fs;
 
-use super::BaseFileTool;
+use super::{BaseFileTool, FilesystemSandbox, sandbox_error};
 
 #[derive(Serialize, Deserialize, ToolInput, Debug)]
 pub struct DeleteFileArgs {
     #[input(description = "Path of the file or directory to delete")]
     path: String,
+    #[serde(default)]
+    #[input(description = "When deleting a directory, recursively delete its contents")]
+    recursive: bool,
 }
 
 #[tool(
@@ -21,26 +26,24 @@ pub struct DeleteFileArgs {
     description = "Delete a file or directory from the filesystem",
     input = DeleteFileArgs,
 )]
-#[derive(Default)]
 pub struct DeleteFile {
-    root_dir: Option<String>,
+    sandbox: FilesystemSandbox,
 }
 
 impl DeleteFile {
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(root: impl AsRef<Path>) -> std::io::Result<Self> {
+        Ok(Self {
+            sandbox: FilesystemSandbox::new(root)?,
+        })
     }
-
-    pub fn new_with_root_dir(root_dir: String) -> Self {
-        Self {
-            root_dir: Some(root_dir),
-        }
+    pub fn with_sandbox(sandbox: FilesystemSandbox) -> Self {
+        Self { sandbox }
     }
 }
 
 impl BaseFileTool for DeleteFile {
-    fn root_dir(&self) -> Option<String> {
-        self.root_dir.clone()
+    fn sandbox(&self) -> &FilesystemSandbox {
+        &self.sandbox
     }
 }
 
@@ -50,29 +53,28 @@ where
     Self: BaseFileTool,
 {
     async fn execute(&self, args: Value) -> Result<Value, ToolCallError> {
-        let DeleteFileArgs { path } = serde_json::from_value(args)?;
+        let DeleteFileArgs { path, recursive } = serde_json::from_value(args)?;
 
         debug!("Delete File Executing: Source: {}", path);
 
-        let file_path = self.get_relative_path(&path);
-        let recursive = true; // Always allow recursive deletion for safety
+        let file_path = self
+            .sandbox()
+            .resolve_relative(&path)
+            .map_err(sandbox_error)?;
 
-        // Validate path exists
         if !file_path.exists() {
             return Err(ToolCallError::RuntimeError(
                 format!("Path does not exist: {}", file_path.display()).into(),
             ));
         }
 
-        // Ensure path is within root if root is set
-        if self.root_dir().is_some() {
-            self.ensure_within_root(&file_path)
-                .map_err(|e| ToolCallError::RuntimeError(Box::new(e)))?;
-        }
+        let file_path = self
+            .sandbox()
+            .ensure_resolved(&file_path)
+            .map_err(sandbox_error)?;
 
         let is_dir = file_path.is_dir();
 
-        // Delete file or directory
         if is_dir {
             if recursive {
                 fs::remove_dir_all(&file_path)
@@ -92,7 +94,8 @@ where
         Ok(json!({
             "success": true,
             "path": file_path.display().to_string(),
-            "type": if is_dir { "directory" } else { "file" }
+            "type": if is_dir { "directory" } else { "file" },
+            "recursive": recursive
         }))
     }
 }
@@ -108,7 +111,6 @@ mod tests {
         let temp_dir = tempdir().expect("Failed to create temp dir");
         let file_path = temp_dir.path().join("test.txt");
 
-        // Create test file
         let mut file = std::fs::File::create(&file_path).expect("Failed to create test file");
         file.write_all(b"Test content")
             .expect("Failed to write to test file");
@@ -116,9 +118,9 @@ mod tests {
 
         assert!(file_path.exists());
 
-        let delete_file = DeleteFile::default();
+        let delete_file = DeleteFile::new(temp_dir.path()).expect("sandbox");
         let args = json!({
-            "path": file_path.display().to_string()
+            "path": "test.txt"
         });
 
         let result = delete_file
@@ -137,9 +139,9 @@ mod tests {
         std::fs::create_dir_all(&dir_path).expect("Failed to create test directory");
         assert!(dir_path.exists());
 
-        let delete_file = DeleteFile::default();
+        let delete_file = DeleteFile::new(temp_dir.path()).expect("sandbox");
         let args = json!({
-            "path": dir_path.display().to_string()
+            "path": "test_dir"
         });
 
         let result = delete_file
@@ -163,9 +165,9 @@ mod tests {
         assert!(dir_path.exists());
         assert!(file_in_nested.exists());
 
-        let delete_file = DeleteFile::default();
+        let delete_file = DeleteFile::new(temp_dir.path()).expect("sandbox");
         let args = json!({
-            "path": dir_path.display().to_string(),
+            "path": "test_dir",
             "recursive": true
         });
 
@@ -178,13 +180,30 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_delete_non_empty_directory_without_recursive_fails() {
+        let temp_dir = tempdir().expect("Failed to create temp dir");
+        let dir_path = temp_dir.path().join("test_dir");
+        let nested_dir = dir_path.join("nested");
+
+        std::fs::create_dir_all(&nested_dir).expect("Failed to create nested directories");
+
+        let delete_file = DeleteFile::new(temp_dir.path()).expect("sandbox");
+        let args = json!({
+            "path": "test_dir"
+        });
+
+        let result = delete_file.execute(args).await;
+        assert!(result.is_err());
+        assert!(dir_path.exists());
+    }
+
+    #[tokio::test]
     async fn test_delete_nonexistent_file() {
         let temp_dir = tempdir().expect("Failed to create temp dir");
-        let file_path = temp_dir.path().join("nonexistent.txt");
 
-        let delete_file = DeleteFile::default();
+        let delete_file = DeleteFile::new(temp_dir.path()).expect("sandbox");
         let args = json!({
-            "path": file_path.display().to_string()
+            "path": "nonexistent.txt"
         });
 
         let result = delete_file.execute(args).await;
@@ -194,12 +213,11 @@ mod tests {
     #[tokio::test]
     async fn test_delete_with_root_dir() {
         let temp_dir = tempdir().expect("Failed to create temp dir");
-        let root_dir = temp_dir.path().to_str().unwrap().to_string();
 
         let file_path = temp_dir.path().join("test.txt");
         std::fs::write(&file_path, "content").expect("Failed to create test file");
 
-        let delete_file = DeleteFile::new_with_root_dir(root_dir);
+        let delete_file = DeleteFile::new(temp_dir.path()).expect("sandbox");
         let args = json!({
             "path": "test.txt"
         });

--- a/crates/autoagents-toolkit/src/tools/filesystem/delete_file.rs
+++ b/crates/autoagents-toolkit/src/tools/filesystem/delete_file.rs
@@ -93,7 +93,7 @@ where
 
         Ok(json!({
             "success": true,
-            "path": file_path.display().to_string(),
+            "path": self.sandbox().relative_path_display(&file_path),
             "type": if is_dir { "directory" } else { "file" },
             "recursive": recursive
         }))

--- a/crates/autoagents-toolkit/src/tools/filesystem/list_dir.rs
+++ b/crates/autoagents-toolkit/src/tools/filesystem/list_dir.rs
@@ -1,3 +1,5 @@
+use std::path::Path;
+
 use autoagents::core::{
     ractor::async_trait,
     tool::{ToolCallError, ToolRuntime, ToolT},
@@ -8,7 +10,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use tokio::fs;
 
-use super::BaseFileTool;
+use super::{BaseFileTool, FilesystemSandbox, sandbox_error};
 
 #[derive(Serialize, Deserialize, ToolInput, Debug)]
 pub struct ListDirArgs {
@@ -21,26 +23,24 @@ pub struct ListDirArgs {
     description = "List contents of a directory",
     input = ListDirArgs,
 )]
-#[derive(Default)]
 pub struct ListDir {
-    root_dir: Option<String>,
+    sandbox: FilesystemSandbox,
 }
 
 impl ListDir {
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(root: impl AsRef<Path>) -> std::io::Result<Self> {
+        Ok(Self {
+            sandbox: FilesystemSandbox::new(root)?,
+        })
     }
-
-    pub fn new_with_root_dir(root_dir: String) -> Self {
-        Self {
-            root_dir: Some(root_dir),
-        }
+    pub fn with_sandbox(sandbox: FilesystemSandbox) -> Self {
+        Self { sandbox }
     }
 }
 
 impl BaseFileTool for ListDir {
-    fn root_dir(&self) -> Option<String> {
-        self.root_dir.clone()
+    fn sandbox(&self) -> &FilesystemSandbox {
+        &self.sandbox
     }
 }
 
@@ -54,12 +54,11 @@ where
 
         debug!("List Directory Executing: Directory: {}", directory_path);
 
-        let dir_path = self.get_relative_path(&directory_path);
-        let _recursive = false; // Simplified to non-recursive
-        let include_hidden = false;
-        let filter_extension: Option<String> = None;
+        let dir_path = self
+            .sandbox()
+            .resolve_relative(&directory_path)
+            .map_err(sandbox_error)?;
 
-        // Validate directory exists
         if !dir_path.exists() {
             return Err(ToolCallError::RuntimeError(
                 format!("Directory does not exist: {}", dir_path.display()).into(),
@@ -72,60 +71,62 @@ where
             ));
         }
 
-        // Ensure path is within root if root is set
-        if self.root_dir().is_some() {
-            self.ensure_within_root(&dir_path)
-                .map_err(|e| ToolCallError::RuntimeError(Box::new(e)))?;
-        }
+        let dir_path = self
+            .sandbox()
+            .ensure_resolved(&dir_path)
+            .map_err(sandbox_error)?;
+
+        let include_hidden = false;
+        let filter_extension: Option<String> = None;
 
         let mut entries = Vec::new();
 
-        // Simplified to non-recursive listing only
+        let mut read_dir = fs::read_dir(&dir_path)
+            .await
+            .map_err(|e| ToolCallError::RuntimeError(Box::new(e)))?;
+
+        while let Some(entry) = read_dir
+            .next_entry()
+            .await
+            .map_err(|e| ToolCallError::RuntimeError(Box::new(e)))?
         {
-            let mut read_dir = fs::read_dir(&dir_path)
+            let path = entry.path();
+            let validated_path = self
+                .sandbox()
+                .validate_walk_entry(&path)
+                .map_err(sandbox_error)?;
+
+            let file_name = entry.file_name().to_string_lossy().to_string();
+
+            if !include_hidden && file_name.starts_with('.') {
+                continue;
+            }
+
+            let metadata = entry
+                .metadata()
                 .await
                 .map_err(|e| ToolCallError::RuntimeError(Box::new(e)))?;
 
-            while let Some(entry) = read_dir
-                .next_entry()
-                .await
-                .map_err(|e| ToolCallError::RuntimeError(Box::new(e)))?
+            let is_dir = metadata.is_dir();
+
+            if let Some(ref ext_filter) = filter_extension
+                && !is_dir
             {
-                let path = entry.path();
-                let file_name = entry.file_name().to_string_lossy().to_string();
-
-                // Skip hidden files if requested
-                if !include_hidden && file_name.starts_with('.') {
-                    continue;
-                }
-
-                let metadata = entry
-                    .metadata()
-                    .await
-                    .map_err(|e| ToolCallError::RuntimeError(Box::new(e)))?;
-
-                let is_dir = metadata.is_dir();
-
-                // Apply extension filter if provided
-                if let Some(ref ext_filter) = filter_extension
-                    && !is_dir
-                {
-                    if let Some(ext) = path.extension() {
-                        if ext.to_string_lossy() != *ext_filter {
-                            continue;
-                        }
-                    } else {
+                if let Some(ext) = validated_path.extension() {
+                    if ext.to_string_lossy() != *ext_filter {
                         continue;
                     }
+                } else {
+                    continue;
                 }
-
-                entries.push(json!({
-                    "name": file_name,
-                    "path": path.display().to_string(),
-                    "is_dir": is_dir,
-                    "size": if !is_dir { metadata.len() } else { 0 },
-                }));
             }
+
+            entries.push(json!({
+                "name": file_name,
+                "path": validated_path.display().to_string(),
+                "is_dir": is_dir,
+                "size": if !is_dir { metadata.len() } else { 0 },
+            }));
         }
 
         Ok(json!({
@@ -140,23 +141,21 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    // std::io::Write import removed - not used in simplified tests
     use tempfile::tempdir;
 
     #[tokio::test]
     async fn test_list_dir_simple() {
         let temp_dir = tempdir().expect("Failed to create temp dir");
 
-        // Create some test files and directories
         std::fs::write(temp_dir.path().join("file1.txt"), "content1")
             .expect("Failed to create file1");
         std::fs::write(temp_dir.path().join("file2.rs"), "content2")
             .expect("Failed to create file2");
         std::fs::create_dir_all(temp_dir.path().join("subdir")).expect("Failed to create subdir");
 
-        let list_dir = ListDir::default();
+        let list_dir = ListDir::new(temp_dir.path()).expect("sandbox");
         let args = json!({
-            "directory_path": temp_dir.path().display().to_string()
+            "directory_path": "."
         });
 
         let result = list_dir
@@ -169,20 +168,13 @@ mod tests {
         assert_eq!(entries.len(), 3);
     }
 
-    // Filter test removed - feature not implemented in simplified version
-
-    // Recursive test removed - feature not implemented in simplified version
-
-    // Hidden files test removed - feature not implemented in simplified version
-
     #[tokio::test]
     async fn test_list_nonexistent_dir() {
         let temp_dir = tempdir().expect("Failed to create temp dir");
-        let nonexistent = temp_dir.path().join("nonexistent");
 
-        let list_dir = ListDir::default();
+        let list_dir = ListDir::new(temp_dir.path()).expect("sandbox");
         let args = json!({
-            "directory_path": nonexistent.display().to_string()
+            "directory_path": "nonexistent"
         });
 
         let result = list_dir.execute(args).await;
@@ -192,12 +184,11 @@ mod tests {
     #[tokio::test]
     async fn test_list_dir_with_root_dir() {
         let temp_dir = tempdir().expect("Failed to create temp dir");
-        let root_dir = temp_dir.path().to_str().unwrap().to_string();
 
         std::fs::write(temp_dir.path().join("test.txt"), "content")
             .expect("Failed to create test file");
 
-        let list_dir = ListDir::new_with_root_dir(root_dir);
+        let list_dir = ListDir::new(temp_dir.path()).expect("sandbox");
         let args = json!({
             "directory_path": "."
         });

--- a/crates/autoagents-toolkit/src/tools/filesystem/list_dir.rs
+++ b/crates/autoagents-toolkit/src/tools/filesystem/list_dir.rs
@@ -116,7 +116,7 @@ where
 
             entries.push(json!({
                 "name": file_name,
-                "path": validated_path.display().to_string(),
+                "path": self.sandbox().relative_path_display(&validated_path),
                 "is_dir": is_dir,
                 "size": if !is_dir { metadata.len() } else { 0 },
             }));
@@ -124,7 +124,7 @@ where
 
         Ok(json!({
             "success": true,
-            "directory": dir_path.display().to_string(),
+            "directory": self.sandbox().relative_path_display(&dir_path),
             "count": entries.len(),
             "entries": entries
         }))

--- a/crates/autoagents-toolkit/src/tools/filesystem/list_dir.rs
+++ b/crates/autoagents-toolkit/src/tools/filesystem/list_dir.rs
@@ -16,6 +16,11 @@ use super::{BaseFileTool, FilesystemSandbox, sandbox_error};
 pub struct ListDirArgs {
     #[input(description = "Path of the directory to list")]
     directory_path: String,
+    #[serde(default)]
+    #[input(
+        description = "Whether to include hidden files and directories (names starting with '.')"
+    )]
+    include_hidden: bool,
 }
 
 #[tool(
@@ -50,7 +55,10 @@ where
     Self: BaseFileTool,
 {
     async fn execute(&self, args: Value) -> Result<Value, ToolCallError> {
-        let ListDirArgs { directory_path } = serde_json::from_value(args)?;
+        let ListDirArgs {
+            directory_path,
+            include_hidden,
+        } = serde_json::from_value(args)?;
 
         debug!("List Directory Executing: Directory: {}", directory_path);
 
@@ -75,9 +83,6 @@ where
             .sandbox()
             .ensure_resolved(&dir_path)
             .map_err(sandbox_error)?;
-
-        let include_hidden = false;
-        let filter_extension: Option<String> = None;
 
         let mut entries = Vec::new();
 
@@ -108,18 +113,6 @@ where
                 .map_err(|e| ToolCallError::RuntimeError(Box::new(e)))?;
 
             let is_dir = metadata.is_dir();
-
-            if let Some(ref ext_filter) = filter_extension
-                && !is_dir
-            {
-                if let Some(ext) = validated_path.extension() {
-                    if ext.to_string_lossy() != *ext_filter {
-                        continue;
-                    }
-                } else {
-                    continue;
-                }
-            }
 
             entries.push(json!({
                 "name": file_name,
@@ -201,5 +194,41 @@ mod tests {
 
         let entries = result.get("entries").and_then(|v| v.as_array()).unwrap();
         assert_eq!(entries.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_list_dir_include_hidden() {
+        let temp_dir = tempdir().expect("Failed to create temp dir");
+
+        std::fs::write(temp_dir.path().join("visible.txt"), "content")
+            .expect("Failed to create visible file");
+        std::fs::write(temp_dir.path().join(".hidden"), "secret")
+            .expect("Failed to create hidden file");
+
+        let list_dir = ListDir::new(temp_dir.path()).expect("sandbox");
+
+        let hidden_excluded = list_dir
+            .execute(json!({ "directory_path": "." }))
+            .await
+            .expect("list should succeed");
+        let excluded = hidden_excluded
+            .get("entries")
+            .and_then(|v| v.as_array())
+            .unwrap();
+        assert_eq!(excluded.len(), 1);
+        assert_eq!(
+            excluded[0].get("name").and_then(|v| v.as_str()),
+            Some("visible.txt")
+        );
+
+        let hidden_included = list_dir
+            .execute(json!({ "directory_path": ".", "include_hidden": true }))
+            .await
+            .expect("list with hidden should succeed");
+        let included = hidden_included
+            .get("entries")
+            .and_then(|v| v.as_array())
+            .unwrap();
+        assert_eq!(included.len(), 2);
     }
 }

--- a/crates/autoagents-toolkit/src/tools/filesystem/mod.rs
+++ b/crates/autoagents-toolkit/src/tools/filesystem/mod.rs
@@ -4,6 +4,7 @@ mod delete_file;
 mod list_dir;
 mod move_file;
 mod read_file;
+mod sandbox;
 mod search_file;
 mod write_file;
 
@@ -13,138 +14,37 @@ pub use delete_file::DeleteFile;
 pub use list_dir::ListDir;
 pub use move_file::MoveFile;
 pub use read_file::ReadFile;
+pub use sandbox::FilesystemSandbox;
 pub use search_file::SearchFile;
 pub use write_file::WriteFile;
 
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 
-pub trait BaseFileTool {
-    fn root_dir(&self) -> Option<String>;
+use autoagents::core::tool::ToolCallError;
 
-    fn get_relative_path(&self, file_path: &str) -> PathBuf {
-        match self.root_dir() {
-            Some(root) => {
-                let root_path = Path::new(&root);
-                let file_path = Path::new(file_path);
-
-                if file_path.is_absolute() {
-                    file_path.to_path_buf()
-                } else {
-                    root_path.join(file_path)
-                }
-            }
-            None => Path::new(file_path).to_path_buf(),
-        }
-    }
-
-    fn ensure_within_root(&self, path: &Path) -> Result<PathBuf, std::io::Error> {
-        fn normalize_path(path: &Path) -> PathBuf {
-            use std::path::Component;
-
-            let mut normalized = PathBuf::default();
-
-            for component in path.components() {
-                match component {
-                    Component::CurDir => {}
-                    Component::ParentDir => {
-                        normalized.pop();
-                    }
-                    _ => normalized.push(component.as_os_str()),
-                }
-            }
-
-            normalized
-        }
-
-        let canonical = path.canonicalize().unwrap_or_else(|_| normalize_path(path));
-
-        if let Some(root) = self.root_dir() {
-            let root_canonical = Path::new(&root).canonicalize()?;
-            if !canonical.starts_with(&root_canonical) {
-                return Err(std::io::Error::new(
-                    std::io::ErrorKind::PermissionDenied,
-                    format!("Path {} is outside of root directory", path.display()),
-                ));
-            }
-        }
-
-        Ok(canonical)
-    }
+pub(crate) trait BaseFileTool {
+    fn sandbox(&self) -> &FilesystemSandbox;
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
+pub(crate) fn sandbox_error(error: std::io::Error) -> ToolCallError {
+    ToolCallError::RuntimeError(Box::new(error))
+}
 
-    struct TestFileTool {
-        root: Option<String>,
+/// Resolve a relative path, create parent directories when needed, then re-validate
+/// the full path to close TOCTOU gaps from symlink races in parent chains.
+pub(crate) async fn prepare_mutation_path(
+    sandbox: &FilesystemSandbox,
+    user_path: &str,
+) -> Result<PathBuf, ToolCallError> {
+    let path = sandbox.resolve_relative(user_path).map_err(sandbox_error)?;
+
+    if let Some(parent) = path.parent()
+        && parent != sandbox.root()
+    {
+        tokio::fs::create_dir_all(parent)
+            .await
+            .map_err(|e| ToolCallError::RuntimeError(Box::new(e)))?;
     }
 
-    impl BaseFileTool for TestFileTool {
-        fn root_dir(&self) -> Option<String> {
-            self.root.clone()
-        }
-    }
-
-    #[test]
-    fn test_get_relative_path_no_root() {
-        let tool = TestFileTool { root: None };
-        let path = tool.get_relative_path("some/file.txt");
-        assert_eq!(path, PathBuf::from("some/file.txt"));
-    }
-
-    #[test]
-    fn test_get_relative_path_with_root_relative() {
-        let tool = TestFileTool {
-            root: Some("/home/user".to_string()),
-        };
-        let path = tool.get_relative_path("docs/file.txt");
-        assert_eq!(path, PathBuf::from("/home/user/docs/file.txt"));
-    }
-
-    #[test]
-    fn test_get_relative_path_with_root_absolute() {
-        let tool = TestFileTool {
-            root: Some("/home/user".to_string()),
-        };
-        let path = tool.get_relative_path("/absolute/path.txt");
-        assert_eq!(path, PathBuf::from("/absolute/path.txt"));
-    }
-
-    #[test]
-    fn test_ensure_within_root_safe_path() {
-        let dir = std::env::temp_dir();
-        let tool = TestFileTool {
-            root: Some(dir.to_string_lossy().to_string()),
-        };
-        let safe = dir.join("test.txt");
-        // Create file so canonicalize works
-        std::fs::write(&safe, "").ok();
-        let result = tool.ensure_within_root(&safe);
-        assert!(result.is_ok());
-        std::fs::remove_file(&safe).ok();
-    }
-
-    #[test]
-    fn test_ensure_within_root_traversal_blocked() {
-        let dir = std::env::temp_dir().join("test_root_autoagents");
-        std::fs::create_dir_all(&dir).ok();
-        let tool = TestFileTool {
-            root: Some(dir.to_string_lossy().to_string()),
-        };
-        let traversal = dir.join("../../etc/passwd");
-        let result = tool.ensure_within_root(&traversal);
-        assert!(result.is_err());
-        std::fs::remove_dir_all(&dir).ok();
-    }
-
-    #[test]
-    fn test_ensure_within_root_no_root() {
-        let tool = TestFileTool { root: None };
-        let path = std::env::temp_dir().join("any_file.txt");
-        std::fs::write(&path, "").ok();
-        let result = tool.ensure_within_root(&path);
-        assert!(result.is_ok());
-        std::fs::remove_file(&path).ok();
-    }
+    sandbox.ensure_resolved(&path).map_err(sandbox_error)
 }

--- a/crates/autoagents-toolkit/src/tools/filesystem/mod.rs
+++ b/crates/autoagents-toolkit/src/tools/filesystem/mod.rs
@@ -41,9 +41,13 @@ pub(crate) async fn prepare_mutation_path(
     if let Some(parent) = path.parent()
         && parent != sandbox.root()
     {
-        tokio::fs::create_dir_all(parent)
-            .await
-            .map_err(|e| ToolCallError::RuntimeError(Box::new(e)))?;
+        sandbox.ensure_resolved(parent).map_err(sandbox_error)?;
+
+        if !parent.exists() {
+            tokio::fs::create_dir_all(parent)
+                .await
+                .map_err(|e| ToolCallError::RuntimeError(Box::new(e)))?;
+        }
     }
 
     sandbox.ensure_resolved(&path).map_err(sandbox_error)

--- a/crates/autoagents-toolkit/src/tools/filesystem/move_file.rs
+++ b/crates/autoagents-toolkit/src/tools/filesystem/move_file.rs
@@ -1,3 +1,5 @@
+use std::path::Path;
+
 use autoagents::core::{
     ractor::async_trait,
     tool::{ToolCallError, ToolRuntime, ToolT},
@@ -8,7 +10,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use tokio::fs;
 
-use super::BaseFileTool;
+use super::{BaseFileTool, FilesystemSandbox, prepare_mutation_path, sandbox_error};
 
 #[derive(Serialize, Deserialize, ToolInput, Debug)]
 pub struct MoveFileArgs {
@@ -23,26 +25,25 @@ pub struct MoveFileArgs {
     description = "Move or rename a file or directory",
     input = MoveFileArgs,
 )]
-#[derive(Default)]
 pub struct MoveFile {
-    root_dir: Option<String>,
+    sandbox: FilesystemSandbox,
 }
 
 impl MoveFile {
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(root: impl AsRef<Path>) -> std::io::Result<Self> {
+        Ok(Self {
+            sandbox: FilesystemSandbox::new(root)?,
+        })
     }
 
-    pub fn new_with_root_dir(root_dir: String) -> Self {
-        Self {
-            root_dir: Some(root_dir),
-        }
+    pub fn with_sandbox(sandbox: FilesystemSandbox) -> Self {
+        Self { sandbox }
     }
 }
 
 impl BaseFileTool for MoveFile {
-    fn root_dir(&self) -> Option<String> {
-        self.root_dir.clone()
+    fn sandbox(&self) -> &FilesystemSandbox {
+        &self.sandbox
     }
 }
 
@@ -62,39 +63,34 @@ where
             source_path, destination_path
         );
 
-        let src_path = self.get_relative_path(&source_path);
-        let dest_path = self.get_relative_path(&destination_path);
+        let src_path = self
+            .sandbox()
+            .resolve_relative(&source_path)
+            .map_err(sandbox_error)?;
+        let dest_path = self
+            .sandbox()
+            .resolve_relative(&destination_path)
+            .map_err(sandbox_error)?;
 
-        // Validate source exists
         if !src_path.exists() {
             return Err(ToolCallError::RuntimeError(
                 format!("Source path does not exist: {}", src_path.display()).into(),
             ));
         }
 
-        // Ensure paths are within root if root is set
-        if self.root_dir().is_some() {
-            self.ensure_within_root(&src_path)
-                .map_err(|e| ToolCallError::RuntimeError(Box::new(e)))?;
-            self.ensure_within_root(&dest_path)
-                .map_err(|e| ToolCallError::RuntimeError(Box::new(e)))?;
-        }
+        let src_path = self
+            .sandbox()
+            .ensure_resolved(&src_path)
+            .map_err(sandbox_error)?;
 
-        // Check if destination exists
         if dest_path.exists() {
             return Err(ToolCallError::RuntimeError(
                 format!("Destination already exists: {}", dest_path.display()).into(),
             ));
         }
 
-        // Create parent directory if it doesn't exist
-        if let Some(parent) = dest_path.parent() {
-            fs::create_dir_all(parent)
-                .await
-                .map_err(|e| ToolCallError::RuntimeError(Box::new(e)))?;
-        }
+        let dest_path = prepare_mutation_path(self.sandbox(), &destination_path).await?;
 
-        // Perform the move/rename
         fs::rename(&src_path, &dest_path)
             .await
             .map_err(|e| ToolCallError::RuntimeError(Box::new(e)))?;
@@ -120,7 +116,6 @@ mod tests {
         let src_path = temp_dir.path().join("source.txt");
         let dest_path = temp_dir.path().join("destination.txt");
 
-        // Create source file
         let mut file = std::fs::File::create(&src_path).expect("Failed to create source file");
         file.write_all(b"Test content")
             .expect("Failed to write to source file");
@@ -128,16 +123,15 @@ mod tests {
 
         assert!(src_path.exists());
 
-        let move_file = MoveFile::default();
+        let move_file = MoveFile::new(temp_dir.path()).expect("sandbox");
         let args = json!({
-            "source_path": src_path.display().to_string(),
-            "destination_path": dest_path.display().to_string()
+            "source_path": "source.txt",
+            "destination_path": "destination.txt"
         });
 
         let result = move_file.execute(args).await.expect("Failed to move file");
         assert!(result.get("success").and_then(|v| v.as_bool()).unwrap());
 
-        // Verify source no longer exists and destination exists with correct content
         assert!(!src_path.exists());
         assert!(dest_path.exists());
 
@@ -151,13 +145,12 @@ mod tests {
         let old_name = temp_dir.path().join("old_name.txt");
         let new_name = temp_dir.path().join("new_name.txt");
 
-        // Create file with old name
         std::fs::write(&old_name, "Content").expect("Failed to create file");
 
-        let move_file = MoveFile::default();
+        let move_file = MoveFile::new(temp_dir.path()).expect("sandbox");
         let args = json!({
-            "source_path": old_name.display().to_string(),
-            "destination_path": new_name.display().to_string()
+            "source_path": "old_name.txt",
+            "destination_path": "new_name.txt"
         });
 
         let result = move_file
@@ -177,14 +170,13 @@ mod tests {
         let file_in_dir = src_dir.join("file.txt");
         let dest_dir = temp_dir.path().join("dest_dir");
 
-        // Create source directory with a file
         std::fs::create_dir_all(&src_dir).expect("Failed to create source directory");
         std::fs::write(&file_in_dir, "content").expect("Failed to create file in directory");
 
-        let move_file = MoveFile::default();
+        let move_file = MoveFile::new(temp_dir.path()).expect("sandbox");
         let args = json!({
-            "source_path": src_dir.display().to_string(),
-            "destination_path": dest_dir.display().to_string()
+            "source_path": "source_dir",
+            "destination_path": "dest_dir"
         });
 
         let result = move_file
@@ -201,13 +193,11 @@ mod tests {
     #[tokio::test]
     async fn test_move_nonexistent_file() {
         let temp_dir = tempdir().expect("Failed to create temp dir");
-        let src_path = temp_dir.path().join("nonexistent.txt");
-        let dest_path = temp_dir.path().join("destination.txt");
 
-        let move_file = MoveFile::default();
+        let move_file = MoveFile::new(temp_dir.path()).expect("sandbox");
         let args = json!({
-            "source_path": src_path.display().to_string(),
-            "destination_path": dest_path.display().to_string()
+            "source_path": "nonexistent.txt",
+            "destination_path": "destination.txt"
         });
 
         let result = move_file.execute(args).await;
@@ -220,14 +210,13 @@ mod tests {
         let src_path = temp_dir.path().join("source.txt");
         let dest_path = temp_dir.path().join("destination.txt");
 
-        // Create both files
         std::fs::write(&src_path, "source").expect("Failed to create source file");
         std::fs::write(&dest_path, "destination").expect("Failed to create destination file");
 
-        let move_file = MoveFile::default();
+        let move_file = MoveFile::new(temp_dir.path()).expect("sandbox");
         let args = json!({
-            "source_path": src_path.display().to_string(),
-            "destination_path": dest_path.display().to_string()
+            "source_path": "source.txt",
+            "destination_path": "destination.txt"
         });
 
         let result = move_file.execute(args).await;
@@ -237,12 +226,11 @@ mod tests {
     #[tokio::test]
     async fn test_move_with_root_dir() {
         let temp_dir = tempdir().expect("Failed to create temp dir");
-        let root_dir = temp_dir.path().to_str().unwrap().to_string();
 
         let src_file = temp_dir.path().join("source.txt");
         std::fs::write(&src_file, "content").expect("Failed to create source file");
 
-        let move_file = MoveFile::new_with_root_dir(root_dir);
+        let move_file = MoveFile::new(temp_dir.path()).expect("sandbox");
         let args = json!({
             "source_path": "source.txt",
             "destination_path": "moved.txt"

--- a/crates/autoagents-toolkit/src/tools/filesystem/move_file.rs
+++ b/crates/autoagents-toolkit/src/tools/filesystem/move_file.rs
@@ -91,6 +91,8 @@ where
 
         let dest_path = prepare_mutation_path(self.sandbox(), &destination_path).await?;
 
+        let is_directory = src_path.is_dir();
+
         fs::rename(&src_path, &dest_path)
             .await
             .map_err(|e| ToolCallError::RuntimeError(Box::new(e)))?;
@@ -99,7 +101,7 @@ where
             "success": true,
             "source": src_path.display().to_string(),
             "destination": dest_path.display().to_string(),
-            "type": if src_path.is_dir() { "directory" } else { "file" }
+            "type": if is_directory { "directory" } else { "file" }
         }))
     }
 }
@@ -184,6 +186,10 @@ mod tests {
             .await
             .expect("Failed to move directory");
         assert!(result.get("success").and_then(|v| v.as_bool()).unwrap());
+        assert_eq!(
+            result.get("type").and_then(|v| v.as_str()),
+            Some("directory")
+        );
 
         assert!(!src_dir.exists());
         assert!(dest_dir.exists());

--- a/crates/autoagents-toolkit/src/tools/filesystem/move_file.rs
+++ b/crates/autoagents-toolkit/src/tools/filesystem/move_file.rs
@@ -99,8 +99,8 @@ where
 
         Ok(json!({
             "success": true,
-            "source": src_path.display().to_string(),
-            "destination": dest_path.display().to_string(),
+            "source": self.sandbox().relative_path_display(&src_path),
+            "destination": self.sandbox().relative_path_display(&dest_path),
             "type": if is_directory { "directory" } else { "file" }
         }))
     }

--- a/crates/autoagents-toolkit/src/tools/filesystem/read_file.rs
+++ b/crates/autoagents-toolkit/src/tools/filesystem/read_file.rs
@@ -76,52 +76,16 @@ where
             .ensure_resolved(&path)
             .map_err(sandbox_error)?;
 
-        let encoding = "utf8".to_string();
+        let content = fs::read_to_string(&path)
+            .await
+            .map_err(|e| ToolCallError::RuntimeError(Box::new(e)))?;
 
-        match encoding.as_str() {
-            "utf8" | "utf-8" => {
-                let content = fs::read_to_string(&path)
-                    .await
-                    .map_err(|e| ToolCallError::RuntimeError(Box::new(e)))?;
-
-                Ok(json!({
-                    "success": true,
-                    "path": path.display().to_string(),
-                    "content": content,
-                    "encoding": encoding
-                }))
-            }
-            "base64" => {
-                let bytes = fs::read(&path)
-                    .await
-                    .map_err(|e| ToolCallError::RuntimeError(Box::new(e)))?;
-
-                use base64::{Engine as _, engine::general_purpose::STANDARD};
-                let encoded = STANDARD.encode(bytes);
-
-                Ok(json!({
-                    "success": true,
-                    "path": path.display().to_string(),
-                    "content": encoded,
-                    "encoding": encoding
-                }))
-            }
-            "bytes" => {
-                let bytes = fs::read(&path)
-                    .await
-                    .map_err(|e| ToolCallError::RuntimeError(Box::new(e)))?;
-
-                Ok(json!({
-                    "success": true,
-                    "path": path.display().to_string(),
-                    "content": bytes,
-                    "encoding": encoding
-                }))
-            }
-            _ => Err(ToolCallError::RuntimeError(
-                format!("Unsupported encoding: {}", encoding).into(),
-            )),
-        }
+        Ok(json!({
+            "success": true,
+            "path": path.display().to_string(),
+            "content": content,
+            "encoding": "utf8"
+        }))
     }
 }
 

--- a/crates/autoagents-toolkit/src/tools/filesystem/read_file.rs
+++ b/crates/autoagents-toolkit/src/tools/filesystem/read_file.rs
@@ -1,3 +1,5 @@
+use std::path::Path;
+
 use autoagents::core::{
     ractor::async_trait,
     tool::{ToolCallError, ToolRuntime, ToolT},
@@ -8,7 +10,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use tokio::fs;
 
-use super::BaseFileTool;
+use super::{BaseFileTool, FilesystemSandbox, sandbox_error};
 
 #[derive(Serialize, Deserialize, ToolInput, Debug)]
 pub struct ReadFileArgs {
@@ -21,26 +23,24 @@ pub struct ReadFileArgs {
     description = "Read the contents of a file from the filesystem",
     input = ReadFileArgs,
 )]
-#[derive(Default)]
 pub struct ReadFile {
-    root_dir: Option<String>,
+    sandbox: FilesystemSandbox,
 }
 
 impl ReadFile {
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(root: impl AsRef<Path>) -> std::io::Result<Self> {
+        Ok(Self {
+            sandbox: FilesystemSandbox::new(root)?,
+        })
     }
-
-    pub fn new_with_root_dir(root_dir: String) -> Self {
-        Self {
-            root_dir: Some(root_dir),
-        }
+    pub fn with_sandbox(sandbox: FilesystemSandbox) -> Self {
+        Self { sandbox }
     }
 }
 
 impl BaseFileTool for ReadFile {
-    fn root_dir(&self) -> Option<String> {
-        self.root_dir.clone()
+    fn sandbox(&self) -> &FilesystemSandbox {
+        &self.sandbox
     }
 }
 
@@ -54,9 +54,11 @@ where
 
         debug!("Read File Executing: Source: {}", file_path);
 
-        let path = self.get_relative_path(&file_path);
+        let path = self
+            .sandbox()
+            .resolve_relative(&file_path)
+            .map_err(sandbox_error)?;
 
-        // Validate file exists
         if !path.exists() {
             return Err(ToolCallError::RuntimeError(
                 format!("File does not exist: {}", path.display()).into(),
@@ -69,11 +71,10 @@ where
             ));
         }
 
-        // Ensure path is within root if root is set
-        if self.root_dir().is_some() {
-            self.ensure_within_root(&path)
-                .map_err(|e| ToolCallError::RuntimeError(Box::new(e)))?;
-        }
+        let path = self
+            .sandbox()
+            .ensure_resolved(&path)
+            .map_err(sandbox_error)?;
 
         let encoding = "utf8".to_string();
 
@@ -135,15 +136,14 @@ mod tests {
         let temp_dir = tempdir().expect("Failed to create temp dir");
         let file_path = temp_dir.path().join("test.txt");
 
-        // Create test file
         let mut file = std::fs::File::create(&file_path).expect("Failed to create test file");
         file.write_all(b"Hello, World!")
             .expect("Failed to write to test file");
         drop(file);
 
-        let read_file = ReadFile::default();
+        let read_file = ReadFile::new(temp_dir.path()).expect("sandbox");
         let args = json!({
-            "file_path": file_path.display().to_string()
+            "file_path": "test.txt"
         });
 
         let result = read_file.execute(args).await.expect("Failed to read file");
@@ -151,16 +151,13 @@ mod tests {
         assert_eq!(content, "Hello, World!");
     }
 
-    // Base64 test removed - feature not implemented in simplified version
-
     #[tokio::test]
     async fn test_read_file_not_exists() {
         let temp_dir = tempdir().expect("Failed to create temp dir");
-        let file_path = temp_dir.path().join("nonexistent.txt");
 
-        let read_file = ReadFile::default();
+        let read_file = ReadFile::new(temp_dir.path()).expect("sandbox");
         let args = json!({
-            "file_path": file_path.display().to_string()
+            "file_path": "nonexistent.txt"
         });
 
         let result = read_file.execute(args).await;
@@ -170,7 +167,6 @@ mod tests {
     #[tokio::test]
     async fn test_read_file_with_root_dir() {
         let temp_dir = tempdir().expect("Failed to create temp dir");
-        let root_dir = temp_dir.path().to_str().unwrap().to_string();
 
         let file_path = temp_dir.path().join("test.txt");
         let mut file = std::fs::File::create(&file_path).expect("Failed to create test file");
@@ -178,7 +174,7 @@ mod tests {
             .expect("Failed to write to test file");
         drop(file);
 
-        let read_file = ReadFile::new_with_root_dir(root_dir);
+        let read_file = ReadFile::new(temp_dir.path()).expect("sandbox");
         let args = json!({
             "file_path": "test.txt"
         });

--- a/crates/autoagents-toolkit/src/tools/filesystem/read_file.rs
+++ b/crates/autoagents-toolkit/src/tools/filesystem/read_file.rs
@@ -82,7 +82,7 @@ where
 
         Ok(json!({
             "success": true,
-            "path": path.display().to_string(),
+            "path": self.sandbox().relative_path_display(&path),
             "content": content,
             "encoding": "utf8"
         }))

--- a/crates/autoagents-toolkit/src/tools/filesystem/sandbox.rs
+++ b/crates/autoagents-toolkit/src/tools/filesystem/sandbox.rs
@@ -82,7 +82,7 @@ impl FilesystemSandbox {
             return Ok(canonical);
         }
 
-        let mut suffix = PathBuf::new();
+        let mut suffix = PathBuf::default();
         let mut ancestor = path.to_path_buf();
 
         while !ancestor.exists() {
@@ -158,7 +158,7 @@ impl FilesystemSandbox {
 }
 
 fn normalize_joined_path(path: &Path) -> io::Result<PathBuf> {
-    let mut normalized = PathBuf::new();
+    let mut normalized = PathBuf::default();
 
     for component in path.components() {
         match component {

--- a/crates/autoagents-toolkit/src/tools/filesystem/sandbox.rs
+++ b/crates/autoagents-toolkit/src/tools/filesystem/sandbox.rs
@@ -41,6 +41,19 @@ impl FilesystemSandbox {
         &self.root
     }
 
+    /// Format a resolved path as a sandbox-relative path for tool output.
+    pub fn relative_path_display(&self, path: &Path) -> String {
+        path.strip_prefix(&self.root)
+            .map(|relative| {
+                if relative.as_os_str().is_empty() {
+                    ".".to_string()
+                } else {
+                    relative.display().to_string()
+                }
+            })
+            .unwrap_or_else(|_| path.display().to_string())
+    }
+
     /// Resolve a user-supplied relative path under the sandbox root.
     pub fn resolve_relative(&self, user_path: &str) -> io::Result<PathBuf> {
         let user_path = user_path.trim();
@@ -277,6 +290,19 @@ mod tests {
         assert_eq!(err.kind(), io::ErrorKind::PermissionDenied);
 
         let _ = fs::remove_file(outside);
+    }
+
+    #[test]
+    fn relative_path_display_strips_sandbox_root() {
+        let tmp = tempdir().expect("tempdir");
+        let nested = tmp.path().join("nested/file.txt");
+        fs::create_dir_all(nested.parent().unwrap()).expect("mkdir");
+        fs::write(&nested, "data").expect("write");
+
+        let sandbox = FilesystemSandbox::new(tmp.path()).expect("sandbox");
+        let resolved = sandbox.ensure_resolved(&nested).expect("resolve");
+        assert_eq!(sandbox.relative_path_display(&resolved), "nested/file.txt");
+        assert_eq!(sandbox.relative_path_display(sandbox.root()), ".");
     }
 
     #[test]

--- a/crates/autoagents-toolkit/src/tools/filesystem/sandbox.rs
+++ b/crates/autoagents-toolkit/src/tools/filesystem/sandbox.rs
@@ -1,0 +1,298 @@
+//! Canonical filesystem sandbox for toolkit file tools.
+//!
+//! Symlink-escape regression tests run on Unix platforms. On Windows, junctions and
+//! directory symlinks are validated when present, but CI does not yet include
+//! Windows-specific escape fixtures.
+
+use std::io;
+use std::path::{Component, Path, PathBuf};
+
+use walkdir::WalkDir;
+
+/// Canonical filesystem root for sandboxed file tool operations.
+#[derive(Debug, Clone)]
+pub struct FilesystemSandbox {
+    root: PathBuf,
+}
+
+impl FilesystemSandbox {
+    /// Create a sandbox rooted at `root`. The path must exist and be a directory.
+    pub fn new(root: impl AsRef<Path>) -> io::Result<Self> {
+        let root_ref = root.as_ref();
+        if !root_ref.exists() {
+            return Err(io::Error::new(
+                io::ErrorKind::NotFound,
+                format!("Sandbox root does not exist: {}", root_ref.display()),
+            ));
+        }
+        if !root_ref.is_dir() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("Sandbox root is not a directory: {}", root_ref.display()),
+            ));
+        }
+
+        let canonical = root_ref.canonicalize()?;
+        Ok(Self { root: canonical })
+    }
+
+    /// Canonical sandbox root path.
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    /// Resolve a user-supplied relative path under the sandbox root.
+    pub fn resolve_relative(&self, user_path: &str) -> io::Result<PathBuf> {
+        let user_path = user_path.trim();
+        if user_path.is_empty() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "Path must not be empty",
+            ));
+        }
+
+        let user = Path::new(user_path);
+        if user.is_absolute() {
+            return Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                format!("Absolute paths are not allowed: {user_path}"),
+            ));
+        }
+
+        if user
+            .components()
+            .any(|component| matches!(component, Component::ParentDir))
+        {
+            return Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                format!("Path traversal is not allowed: {user_path}"),
+            ));
+        }
+
+        let joined = normalize_joined_path(&self.root.join(user))?;
+        self.verify_within_root(&joined)?;
+        Ok(joined)
+    }
+
+    /// Verify that `path` resolves within the sandbox, returning the canonical or logical path.
+    pub fn ensure_resolved(&self, path: &Path) -> io::Result<PathBuf> {
+        if path.exists() {
+            let canonical = path.canonicalize()?;
+            self.verify_within_root(&canonical)?;
+            return Ok(canonical);
+        }
+
+        let mut suffix = PathBuf::new();
+        let mut ancestor = path.to_path_buf();
+
+        while !ancestor.exists() {
+            match ancestor.file_name() {
+                Some(name) => {
+                    suffix = PathBuf::from(name).join(suffix);
+                }
+                None => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::PermissionDenied,
+                        format!("Unable to resolve path within sandbox: {}", path.display()),
+                    ));
+                }
+            }
+            if !ancestor.pop() {
+                return Err(io::Error::new(
+                    io::ErrorKind::PermissionDenied,
+                    format!("Unable to resolve path within sandbox: {}", path.display()),
+                ));
+            }
+        }
+
+        let canonical_ancestor = ancestor.canonicalize()?;
+        self.verify_within_root(&canonical_ancestor)?;
+
+        let mut resolved = canonical_ancestor;
+        for component in suffix.components() {
+            match component {
+                Component::Normal(name) => resolved.push(name),
+                Component::CurDir => {}
+                Component::ParentDir => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::PermissionDenied,
+                        format!("Path traversal is not allowed: {}", path.display()),
+                    ));
+                }
+                _ => {
+                    return Err(io::Error::new(
+                        io::ErrorKind::PermissionDenied,
+                        format!("Invalid path component in {}", path.display()),
+                    ));
+                }
+            }
+        }
+
+        self.verify_within_root(&resolved)?;
+        Ok(resolved)
+    }
+
+    /// Validate a directory-walk entry stays within the sandbox.
+    pub fn validate_walk_entry(&self, entry_path: &Path) -> io::Result<PathBuf> {
+        self.ensure_resolved(entry_path)
+    }
+
+    /// Create a `WalkDir` iterator that does not follow symlinks.
+    pub fn walk_dir(&self, dir: &Path) -> WalkDir {
+        WalkDir::new(dir).follow_links(false)
+    }
+
+    fn verify_within_root(&self, path: &Path) -> io::Result<()> {
+        if !path.starts_with(&self.root) {
+            return Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                format!(
+                    "Path {} is outside of sandbox root {}",
+                    path.display(),
+                    self.root.display()
+                ),
+            ));
+        }
+        Ok(())
+    }
+}
+
+fn normalize_joined_path(path: &Path) -> io::Result<PathBuf> {
+    let mut normalized = PathBuf::new();
+
+    for component in path.components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                return Err(io::Error::new(
+                    io::ErrorKind::PermissionDenied,
+                    "Path traversal is not allowed",
+                ));
+            }
+            Component::RootDir | Component::Prefix(_) => normalized.push(component.as_os_str()),
+            Component::Normal(name) => normalized.push(name),
+        }
+    }
+
+    Ok(normalized)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    #[test]
+    fn rejects_absolute_paths() {
+        let tmp = tempdir().expect("tempdir");
+        let sandbox = FilesystemSandbox::new(tmp.path()).expect("sandbox");
+
+        let err = sandbox
+            .resolve_relative("/etc/passwd")
+            .expect_err("absolute path");
+        assert_eq!(err.kind(), io::ErrorKind::PermissionDenied);
+    }
+
+    #[test]
+    fn rejects_whitespace_only_paths() {
+        let tmp = tempdir().expect("tempdir");
+        let sandbox = FilesystemSandbox::new(tmp.path()).expect("sandbox");
+
+        let err = sandbox.resolve_relative("   ").expect_err("whitespace");
+        assert_eq!(err.kind(), io::ErrorKind::InvalidInput);
+    }
+
+    #[test]
+    fn rejects_parent_dir_traversal() {
+        let tmp = tempdir().expect("tempdir");
+        let sandbox = FilesystemSandbox::new(tmp.path()).expect("sandbox");
+
+        let err = sandbox
+            .resolve_relative("../outside")
+            .expect_err("traversal");
+        assert_eq!(err.kind(), io::ErrorKind::PermissionDenied);
+    }
+
+    #[test]
+    fn resolves_relative_path_under_root() {
+        let tmp = tempdir().expect("tempdir");
+        let sandbox = FilesystemSandbox::new(tmp.path()).expect("sandbox");
+
+        let resolved = sandbox.resolve_relative("src/main.rs").expect("resolve");
+        assert_eq!(resolved, tmp.path().join("src/main.rs"));
+    }
+
+    #[test]
+    fn ensure_resolved_existing_file() {
+        let tmp = tempdir().expect("tempdir");
+        let file = tmp.path().join("test.txt");
+        fs::write(&file, "data").expect("write");
+
+        let sandbox = FilesystemSandbox::new(tmp.path()).expect("sandbox");
+        let resolved = sandbox.ensure_resolved(&file).expect("ensure");
+        assert!(resolved.starts_with(sandbox.root()));
+    }
+
+    #[test]
+    fn ensure_resolved_nonexistent_path_within_root() {
+        let tmp = tempdir().expect("tempdir");
+        fs::create_dir_all(tmp.path().join("nested")).expect("mkdir");
+
+        let sandbox = FilesystemSandbox::new(tmp.path()).expect("sandbox");
+        let target = tmp.path().join("nested/new.txt");
+        let resolved = sandbox.ensure_resolved(&target).expect("ensure");
+        assert!(resolved.starts_with(sandbox.root()));
+    }
+
+    #[test]
+    fn ensure_resolved_rejects_outside_root() {
+        let tmp = tempdir().expect("tempdir");
+        let outside =
+            std::env::temp_dir().join(format!("autoagents-outside-{}", std::process::id()));
+        fs::write(&outside, "secret").expect("write");
+
+        let sandbox = FilesystemSandbox::new(tmp.path()).expect("sandbox");
+        let err = sandbox.ensure_resolved(&outside).expect_err("outside root");
+        assert_eq!(err.kind(), io::ErrorKind::PermissionDenied);
+
+        let _ = fs::remove_file(outside);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn ensure_resolved_rejects_symlink_escape() {
+        use std::os::unix::fs::symlink;
+
+        let tmp = tempdir().expect("tempdir");
+        let outside =
+            std::env::temp_dir().join(format!("autoagents-outside-symlink-{}", std::process::id()));
+        fs::write(&outside, "secret").expect("write");
+
+        let link = tmp.path().join("escape.txt");
+        symlink(&outside, &link).expect("symlink");
+
+        let sandbox = FilesystemSandbox::new(tmp.path()).expect("sandbox");
+        let err = sandbox.ensure_resolved(&link).expect_err("symlink escape");
+        assert_eq!(err.kind(), io::ErrorKind::PermissionDenied);
+
+        let _ = fs::remove_file(outside);
+    }
+
+    #[test]
+    fn prefix_boundary_sibling_root_rejected() {
+        let parent = tempdir().expect("tempdir");
+        let root = parent.path().join("workspace");
+        let sibling = parent.path().join("workspace_extra");
+        fs::create_dir_all(&root).expect("mkdir root");
+        fs::create_dir_all(&sibling).expect("mkdir sibling");
+        let outside_file = sibling.join("secret.txt");
+        fs::write(&outside_file, "secret").expect("write");
+
+        let sandbox = FilesystemSandbox::new(&root).expect("sandbox");
+        let err = sandbox
+            .ensure_resolved(&outside_file)
+            .expect_err("sibling root");
+        assert_eq!(err.kind(), io::ErrorKind::PermissionDenied);
+    }
+}

--- a/crates/autoagents-toolkit/src/tools/filesystem/search_file.rs
+++ b/crates/autoagents-toolkit/src/tools/filesystem/search_file.rs
@@ -5,10 +5,10 @@ use autoagents::core::{
     tool::{ToolCallError, ToolRuntime, ToolT},
 };
 use autoagents_derive::{ToolInput, tool};
+use glob::{MatchOptions, Pattern};
 use log::debug;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
-use tokio::fs;
 
 use super::{BaseFileTool, FilesystemSandbox, sandbox_error};
 
@@ -16,13 +16,20 @@ use super::{BaseFileTool, FilesystemSandbox, sandbox_error};
 pub struct SearchFileArgs {
     #[input(description = "Directory path to search in")]
     directory: String,
-    #[input(description = "Pattern to search for (supports wildcards: * and ?)")]
+    #[input(description = "Filename pattern to search for (supports wildcards: * and ?)")]
     pattern: String,
+    #[serde(default = "default_case_sensitive")]
+    #[input(description = "Whether filename matching is case-sensitive")]
+    case_sensitive: bool,
+}
+
+fn default_case_sensitive() -> bool {
+    true
 }
 
 #[tool(
     name = "search_file",
-    description = "Search for files by name pattern or content in a directory",
+    description = "Search for files by filename pattern in a directory",
     input = SearchFileArgs,
 )]
 pub struct SearchFile {
@@ -46,62 +53,16 @@ impl SearchFile {
     }
 
     fn matches_pattern(filename: &str, pattern: &str, case_sensitive: bool) -> bool {
-        let filename = if case_sensitive {
-            filename.to_string()
-        } else {
-            filename.to_lowercase()
+        let Ok(glob_pattern) = Pattern::new(pattern) else {
+            return false;
         };
 
-        let pattern = if case_sensitive {
-            pattern.to_string()
-        } else {
-            pattern.to_lowercase()
+        let options = MatchOptions {
+            case_sensitive,
+            ..MatchOptions::new()
         };
 
-        let pattern_parts: Vec<&str> = pattern.split('*').collect();
-
-        if pattern_parts.len() == 1 {
-            return filename.contains(&pattern);
-        }
-
-        let mut pos = 0;
-        for (i, part) in pattern_parts.iter().enumerate() {
-            if part.is_empty() {
-                continue;
-            }
-
-            if i == 0 && !pattern.starts_with('*') {
-                if !filename.starts_with(part) {
-                    return false;
-                }
-                pos = part.len();
-            } else if i == pattern_parts.len() - 1 && !pattern.ends_with('*') {
-                return filename.ends_with(part);
-            } else if let Some(found_pos) = filename[pos..].find(part) {
-                pos += found_pos + part.len();
-            } else {
-                return false;
-            }
-        }
-
-        true
-    }
-
-    async fn search_content_in_file(
-        file_path: &Path,
-        pattern: &str,
-        case_sensitive: bool,
-    ) -> Result<bool, ToolCallError> {
-        let content = match fs::read_to_string(file_path).await {
-            Ok(content) => content,
-            Err(_) => return Ok(false),
-        };
-
-        if case_sensitive {
-            Ok(content.contains(pattern))
-        } else {
-            Ok(content.to_lowercase().contains(&pattern.to_lowercase()))
-        }
+        glob_pattern.matches_with(filename, options)
     }
 }
 
@@ -117,7 +78,11 @@ where
     Self: BaseFileTool,
 {
     async fn execute(&self, args: Value) -> Result<Value, ToolCallError> {
-        let SearchFileArgs { directory, pattern } = serde_json::from_value(args)?;
+        let SearchFileArgs {
+            directory,
+            pattern,
+            case_sensitive,
+        } = serde_json::from_value(args)?;
 
         debug!(
             "Search File Executing: Directory: {} - Pattern: {}",
@@ -128,8 +93,6 @@ where
             .sandbox()
             .resolve_relative(&directory)
             .map_err(sandbox_error)?;
-        let search_content = false;
-        let case_sensitive = true;
 
         if !dir_path.exists() {
             return Err(ToolCallError::RuntimeError(
@@ -182,16 +145,7 @@ where
                 .metadata()
                 .map_err(|e| ToolCallError::RuntimeError(Box::new(e)))?;
 
-            if search_content {
-                if Self::search_content_in_file(&validated_path, &pattern, case_sensitive).await? {
-                    results.push(json!({
-                        "path": validated_path.display().to_string(),
-                        "name": file_name,
-                        "size": metadata.len(),
-                        "match_type": "content"
-                    }));
-                }
-            } else if Self::matches_pattern(&file_name, &pattern, case_sensitive) {
+            if Self::matches_pattern(&file_name, &pattern, case_sensitive) {
                 results.push(json!({
                     "path": validated_path.display().to_string(),
                     "name": file_name,
@@ -208,7 +162,8 @@ where
             "max_iterations": self.max_iterations,
             "iterations": iterations,
             "iteration_limit_reached": iteration_limit_reached,
-            "search_type": if search_content { "content" } else { "filename" },
+            "search_type": "filename",
+            "case_sensitive": case_sensitive,
             "count": results.len(),
             "results": results
         }))
@@ -284,6 +239,8 @@ mod tests {
         assert!(SearchFile::matches_pattern("test.txt", "test.txt", true));
         assert!(SearchFile::matches_pattern("test_file.txt", "*file*", true));
         assert!(!SearchFile::matches_pattern("test.txt", "data*", true));
+        assert!(!SearchFile::matches_pattern("stdlib.rs", "lib.rs", true));
+        assert!(SearchFile::matches_pattern("main1.rs", "main?.rs", true));
 
         assert!(SearchFile::matches_pattern("TEST.txt", "test*", false));
         assert!(!SearchFile::matches_pattern("TEST.txt", "test*", true));

--- a/crates/autoagents-toolkit/src/tools/filesystem/search_file.rs
+++ b/crates/autoagents-toolkit/src/tools/filesystem/search_file.rs
@@ -1,3 +1,5 @@
+use std::path::Path;
+
 use autoagents::core::{
     ractor::async_trait,
     tool::{ToolCallError, ToolRuntime, ToolT},
@@ -6,11 +8,9 @@ use autoagents_derive::{ToolInput, tool};
 use log::debug;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
-use std::path::Path;
 use tokio::fs;
-use walkdir::WalkDir;
 
-use super::BaseFileTool;
+use super::{BaseFileTool, FilesystemSandbox, sandbox_error};
 
 #[derive(Serialize, Deserialize, ToolInput, Debug)]
 pub struct SearchFileArgs {
@@ -26,37 +26,21 @@ pub struct SearchFileArgs {
     input = SearchFileArgs,
 )]
 pub struct SearchFile {
-    root_dir: Option<String>,
+    sandbox: FilesystemSandbox,
     max_iterations: usize,
 }
 
-impl Default for SearchFile {
-    fn default() -> Self {
-        Self {
-            root_dir: None,
-            max_iterations: 100,
-        }
-    }
-}
-
 impl SearchFile {
-    pub fn new(max_iterations: usize) -> Self {
-        Self {
+    pub fn new(root: impl AsRef<Path>, max_iterations: usize) -> std::io::Result<Self> {
+        Ok(Self {
+            sandbox: FilesystemSandbox::new(root)?,
             max_iterations,
-            ..Self::default()
-        }
+        })
     }
 
-    pub fn new_with_root_dir(root_dir: String) -> Self {
+    pub fn with_sandbox(sandbox: FilesystemSandbox, max_iterations: usize) -> Self {
         Self {
-            root_dir: Some(root_dir),
-            ..Self::default()
-        }
-    }
-
-    pub fn new_with_root_dir_and_max_iterations(root_dir: String, max_iterations: usize) -> Self {
-        Self {
-            root_dir: Some(root_dir),
+            sandbox,
             max_iterations,
         }
     }
@@ -74,11 +58,9 @@ impl SearchFile {
             pattern.to_lowercase()
         };
 
-        // Simple wildcard matching
         let pattern_parts: Vec<&str> = pattern.split('*').collect();
 
         if pattern_parts.len() == 1 {
-            // No wildcards, exact match or contains
             return filename.contains(&pattern);
         }
 
@@ -89,21 +71,16 @@ impl SearchFile {
             }
 
             if i == 0 && !pattern.starts_with('*') {
-                // Pattern doesn't start with *, must match at beginning
                 if !filename.starts_with(part) {
                     return false;
                 }
                 pos = part.len();
             } else if i == pattern_parts.len() - 1 && !pattern.ends_with('*') {
-                // Pattern doesn't end with *, must match at end
                 return filename.ends_with(part);
+            } else if let Some(found_pos) = filename[pos..].find(part) {
+                pos += found_pos + part.len();
             } else {
-                // Find the part in the remaining string
-                if let Some(found_pos) = filename[pos..].find(part) {
-                    pos += found_pos + part.len();
-                } else {
-                    return false;
-                }
+                return false;
             }
         }
 
@@ -115,10 +92,9 @@ impl SearchFile {
         pattern: &str,
         case_sensitive: bool,
     ) -> Result<bool, ToolCallError> {
-        // Only search in text files
         let content = match fs::read_to_string(file_path).await {
             Ok(content) => content,
-            Err(_) => return Ok(false), // Skip binary files
+            Err(_) => return Ok(false),
         };
 
         if case_sensitive {
@@ -130,8 +106,8 @@ impl SearchFile {
 }
 
 impl BaseFileTool for SearchFile {
-    fn root_dir(&self) -> Option<String> {
-        self.root_dir.clone()
+    fn sandbox(&self) -> &FilesystemSandbox {
+        &self.sandbox
     }
 }
 
@@ -148,12 +124,13 @@ where
             directory, pattern
         );
 
-        let dir_path = self.get_relative_path(&directory);
-        let recursive = true;
-        let search_content = false; // Search by filename only
+        let dir_path = self
+            .sandbox()
+            .resolve_relative(&directory)
+            .map_err(sandbox_error)?;
+        let search_content = false;
         let case_sensitive = true;
 
-        // Validate directory exists
         if !dir_path.exists() {
             return Err(ToolCallError::RuntimeError(
                 format!("Directory does not exist: {}", dir_path.display()).into(),
@@ -166,20 +143,16 @@ where
             ));
         }
 
-        // Ensure path is within root if root is set
-        if self.root_dir().is_some() {
-            self.ensure_within_root(&dir_path)
-                .map_err(|e| ToolCallError::RuntimeError(Box::new(e)))?;
-        }
+        let dir_path = self
+            .sandbox()
+            .ensure_resolved(&dir_path)
+            .map_err(sandbox_error)?;
 
         let mut results = Vec::new();
         let mut iterations = 0usize;
         let mut iteration_limit_reached = false;
 
-        let mut walker = WalkDir::new(&dir_path);
-        if !recursive {
-            walker = walker.max_depth(1);
-        }
+        let walker = self.sandbox().walk_dir(&dir_path);
 
         for entry in walker.into_iter() {
             if iterations >= self.max_iterations {
@@ -199,15 +172,20 @@ where
                 continue;
             }
 
+            let validated_path = self
+                .sandbox()
+                .validate_walk_entry(path)
+                .map_err(sandbox_error)?;
+
             let file_name = entry.file_name().to_string_lossy().to_string();
             let metadata = entry
                 .metadata()
                 .map_err(|e| ToolCallError::RuntimeError(Box::new(e)))?;
 
             if search_content {
-                if Self::search_content_in_file(path, &pattern, case_sensitive).await? {
+                if Self::search_content_in_file(&validated_path, &pattern, case_sensitive).await? {
                     results.push(json!({
-                        "path": path.display().to_string(),
+                        "path": validated_path.display().to_string(),
                         "name": file_name,
                         "size": metadata.len(),
                         "match_type": "content"
@@ -215,7 +193,7 @@ where
                 }
             } else if Self::matches_pattern(&file_name, &pattern, case_sensitive) {
                 results.push(json!({
-                    "path": path.display().to_string(),
+                    "path": validated_path.display().to_string(),
                     "name": file_name,
                     "size": metadata.len(),
                     "match_type": "filename"
@@ -246,7 +224,6 @@ mod tests {
     async fn test_search_by_filename() {
         let temp_dir = tempdir().expect("Failed to create temp dir");
 
-        // Create test files
         std::fs::write(temp_dir.path().join("test.txt"), "content")
             .expect("Failed to create test.txt");
         std::fs::write(temp_dir.path().join("data.json"), "{}")
@@ -254,11 +231,10 @@ mod tests {
         std::fs::write(temp_dir.path().join("test.rs"), "fn main()")
             .expect("Failed to create test.rs");
 
-        let search_file = SearchFile::default();
+        let search_file = SearchFile::new(temp_dir.path(), 100).expect("sandbox");
         let args = json!({
-            "directory": temp_dir.path().display().to_string(),
-            "pattern": "test*",
-            "recursive": false
+            "directory": ".",
+            "pattern": "test*"
         });
 
         let result = search_file
@@ -266,7 +242,7 @@ mod tests {
             .await
             .expect("Failed to search files");
         let results = result.get("results").and_then(|v| v.as_array()).unwrap();
-        assert_eq!(results.len(), 2); // test.txt and test.rs
+        assert_eq!(results.len(), 2);
     }
 
     #[tokio::test]
@@ -278,9 +254,9 @@ mod tests {
             std::fs::write(path, "content").expect("Failed to create test file");
         }
 
-        let search_file = SearchFile::new(3);
+        let search_file = SearchFile::new(temp_dir.path(), 3).expect("sandbox");
         let args = json!({
-            "directory": temp_dir.path().display().to_string(),
+            "directory": ".",
             "pattern": "test*"
         });
 
@@ -301,14 +277,6 @@ mod tests {
         );
     }
 
-    // Content search test removed - feature not implemented in simplified version
-
-    // Case insensitive test removed - feature not implemented in simplified version
-
-    // Recursive search test removed - feature not implemented in simplified version
-
-    // Max results test removed - feature not fully implemented in simplified version
-
     #[tokio::test]
     async fn test_pattern_matching() {
         assert!(SearchFile::matches_pattern("test.txt", "test*", true));
@@ -317,7 +285,6 @@ mod tests {
         assert!(SearchFile::matches_pattern("test_file.txt", "*file*", true));
         assert!(!SearchFile::matches_pattern("test.txt", "data*", true));
 
-        // Case insensitive
         assert!(SearchFile::matches_pattern("TEST.txt", "test*", false));
         assert!(!SearchFile::matches_pattern("TEST.txt", "test*", true));
     }

--- a/crates/autoagents-toolkit/src/tools/filesystem/search_file.rs
+++ b/crates/autoagents-toolkit/src/tools/filesystem/search_file.rs
@@ -147,7 +147,7 @@ where
 
             if Self::matches_pattern(&file_name, &pattern, case_sensitive) {
                 results.push(json!({
-                    "path": validated_path.display().to_string(),
+                    "path": self.sandbox().relative_path_display(&validated_path),
                     "name": file_name,
                     "size": metadata.len(),
                     "match_type": "filename"
@@ -157,7 +157,7 @@ where
 
         Ok(json!({
             "success": true,
-            "directory": dir_path.display().to_string(),
+            "directory": self.sandbox().relative_path_display(&dir_path),
             "pattern": pattern,
             "max_iterations": self.max_iterations,
             "iterations": iterations,

--- a/crates/autoagents-toolkit/src/tools/filesystem/write_file.rs
+++ b/crates/autoagents-toolkit/src/tools/filesystem/write_file.rs
@@ -89,7 +89,7 @@ where
 
         Ok(json!({
             "success": true,
-            "path": path.display().to_string(),
+            "path": self.sandbox().relative_path_display(&path),
             "bytes_written": bytes.len(),
             "mode": if append { "append" } else { "overwrite" }
         }))

--- a/crates/autoagents-toolkit/src/tools/filesystem/write_file.rs
+++ b/crates/autoagents-toolkit/src/tools/filesystem/write_file.rs
@@ -65,22 +65,7 @@ where
 
         let path = prepare_mutation_path(self.sandbox(), &file_path).await?;
 
-        let encoding = "utf8".to_string();
-
-        let bytes = match encoding.as_str() {
-            "utf8" | "utf-8" => content.into_bytes(),
-            "base64" => {
-                use base64::{Engine as _, engine::general_purpose::STANDARD};
-                STANDARD
-                    .decode(content)
-                    .map_err(|e| ToolCallError::RuntimeError(Box::new(e)))?
-            }
-            _ => {
-                return Err(ToolCallError::RuntimeError(
-                    format!("Unsupported encoding: {}", encoding).into(),
-                ));
-            }
-        };
+        let bytes = content.into_bytes();
 
         if append {
             use tokio::fs::OpenOptions;

--- a/crates/autoagents-toolkit/src/tools/filesystem/write_file.rs
+++ b/crates/autoagents-toolkit/src/tools/filesystem/write_file.rs
@@ -1,3 +1,5 @@
+use std::path::Path;
+
 use autoagents::core::{
     ractor::async_trait,
     tool::{ToolCallError, ToolRuntime, ToolT},
@@ -8,7 +10,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use tokio::fs;
 
-use super::BaseFileTool;
+use super::{BaseFileTool, FilesystemSandbox, prepare_mutation_path};
 
 #[derive(Serialize, Deserialize, ToolInput, Debug)]
 pub struct WriteFileArgs {
@@ -25,26 +27,25 @@ pub struct WriteFileArgs {
     description = "Write content to a file in the filesystem",
     input = WriteFileArgs,
 )]
-#[derive(Default)]
 pub struct WriteFile {
-    root_dir: Option<String>,
+    sandbox: FilesystemSandbox,
 }
 
 impl WriteFile {
-    pub fn new() -> Self {
-        Self::default()
+    pub fn new(root: impl AsRef<Path>) -> std::io::Result<Self> {
+        Ok(Self {
+            sandbox: FilesystemSandbox::new(root)?,
+        })
     }
 
-    pub fn new_with_root_dir(root_dir: String) -> Self {
-        Self {
-            root_dir: Some(root_dir),
-        }
+    pub fn with_sandbox(sandbox: FilesystemSandbox) -> Self {
+        Self { sandbox }
     }
 }
 
 impl BaseFileTool for WriteFile {
-    fn root_dir(&self) -> Option<String> {
-        self.root_dir.clone()
+    fn sandbox(&self) -> &FilesystemSandbox {
+        &self.sandbox
     }
 }
 
@@ -62,24 +63,10 @@ where
 
         debug!("Write File Executing: File Path: {}", file_path);
 
-        let path = self.get_relative_path(&file_path);
-
-        // Ensure path is within root if root is set
-        if self.root_dir().is_some() {
-            self.ensure_within_root(&path)
-                .map_err(|e| ToolCallError::RuntimeError(Box::new(e)))?;
-        }
-
-        // Create parent directory if it doesn't exist
-        if let Some(parent) = path.parent() {
-            fs::create_dir_all(parent)
-                .await
-                .map_err(|e| ToolCallError::RuntimeError(Box::new(e)))?;
-        }
+        let path = prepare_mutation_path(self.sandbox(), &file_path).await?;
 
         let encoding = "utf8".to_string();
 
-        // Decode content based on encoding
         let bytes = match encoding.as_str() {
             "utf8" | "utf-8" => content.into_bytes(),
             "base64" => {
@@ -95,7 +82,6 @@ where
             }
         };
 
-        // Write or append to file
         if append {
             use tokio::fs::OpenOptions;
             use tokio::io::AsyncWriteExt;
@@ -135,9 +121,9 @@ mod tests {
         let temp_dir = tempdir().expect("Failed to create temp dir");
         let file_path = temp_dir.path().join("new_file.txt");
 
-        let write_file = WriteFile::default();
+        let write_file = WriteFile::new(temp_dir.path()).expect("sandbox");
         let args = json!({
-            "file_path": file_path.display().to_string(),
+            "file_path": "new_file.txt",
             "content": "Hello, World!",
             "append": false
         });
@@ -148,7 +134,6 @@ mod tests {
             .expect("Failed to write file");
         assert!(result.get("success").and_then(|v| v.as_bool()).unwrap());
 
-        // Verify file content
         let content = std::fs::read_to_string(&file_path).expect("Failed to read file");
         assert_eq!(content, "Hello, World!");
     }
@@ -158,12 +143,11 @@ mod tests {
         let temp_dir = tempdir().expect("Failed to create temp dir");
         let file_path = temp_dir.path().join("test.txt");
 
-        // Create initial file
         std::fs::write(&file_path, "Initial content").expect("Failed to create initial file");
 
-        let write_file = WriteFile::default();
+        let write_file = WriteFile::new(temp_dir.path()).expect("sandbox");
         let args = json!({
-            "file_path": file_path.display().to_string(),
+            "file_path": "test.txt",
             "content": "New content",
             "append": false
         });
@@ -174,21 +158,15 @@ mod tests {
             .expect("Failed to write file");
         assert!(result.get("success").and_then(|v| v.as_bool()).unwrap());
 
-        // Verify file was overwritten
         let content = std::fs::read_to_string(&file_path).expect("Failed to read file");
         assert_eq!(content, "New content");
     }
 
-    // Append test removed - feature not implemented in simplified version
-
-    // Base64 test removed - feature not implemented in simplified version
-
     #[tokio::test]
     async fn test_write_file_with_root_dir() {
         let temp_dir = tempdir().expect("Failed to create temp dir");
-        let root_dir = temp_dir.path().to_str().unwrap().to_string();
 
-        let write_file = WriteFile::new_with_root_dir(root_dir);
+        let write_file = WriteFile::new(temp_dir.path()).expect("sandbox");
         let args = json!({
             "file_path": "test.txt",
             "content": "Test content",

--- a/crates/autoagents-toolkit/tests/filesystem_sandbox.rs
+++ b/crates/autoagents-toolkit/tests/filesystem_sandbox.rs
@@ -1,0 +1,316 @@
+use autoagents::core::tool::{ToolCallError, ToolRuntime};
+use autoagents_toolkit::tools::filesystem::{
+    CopyFile, CreateDir, DeleteFile, FilesystemSandbox, ListDir, MoveFile, ReadFile, SearchFile,
+    WriteFile,
+};
+use serde_json::json;
+use std::fs;
+use std::io::ErrorKind;
+use std::path::PathBuf;
+use tempfile::tempdir;
+
+fn assert_tool_runtime_error(result: Result<serde_json::Value, ToolCallError>) {
+    match result {
+        Err(ToolCallError::RuntimeError(_)) => {}
+        other => panic!("expected runtime error, got: {other:?}"),
+    }
+}
+
+fn outside_temp_file(label: &str) -> PathBuf {
+    let path = std::env::temp_dir().join(format!(
+        "autoagents-fs-sandbox-{label}-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos()
+    ));
+    fs::write(&path, "outside-secret").expect("write outside file");
+    path
+}
+
+#[tokio::test]
+async fn all_tools_reject_parent_dir_traversal() {
+    let root = tempdir().expect("tempdir");
+    let tools: Vec<(&str, serde_json::Value)> = vec![
+        ("read", json!({ "file_path": "../outside.txt" })),
+        (
+            "write",
+            json!({ "file_path": "../outside.txt", "content": "x", "append": false }),
+        ),
+        ("delete", json!({ "path": "../outside.txt" })),
+        ("list", json!({ "directory_path": "../outside" })),
+        (
+            "search",
+            json!({ "directory": "../outside", "pattern": "*" }),
+        ),
+        (
+            "copy",
+            json!({ "source_path": "../outside.txt", "destination_path": "dest.txt" }),
+        ),
+        (
+            "move",
+            json!({ "source_path": "../outside.txt", "destination_path": "dest.txt" }),
+        ),
+        (
+            "create_dir",
+            json!({ "directory_path": "../outside", "recursive": true }),
+        ),
+    ];
+
+    let read = ReadFile::new(root.path()).expect("read");
+    let write = WriteFile::new(root.path()).expect("write");
+    let delete = DeleteFile::new(root.path()).expect("delete");
+    let list = ListDir::new(root.path()).expect("list");
+    let search = SearchFile::new(root.path(), 10).expect("search");
+    let copy = CopyFile::new(root.path()).expect("copy");
+    let mov = MoveFile::new(root.path()).expect("move");
+    let create = CreateDir::new(root.path()).expect("create");
+
+    for (name, args) in tools {
+        let err = match name {
+            "read" => read.execute(args).await,
+            "write" => write.execute(args).await,
+            "delete" => delete.execute(args).await,
+            "list" => list.execute(args).await,
+            "search" => search.execute(args).await,
+            "copy" => copy.execute(args).await,
+            "move" => mov.execute(args).await,
+            "create_dir" => create.execute(args).await,
+            _ => unreachable!(),
+        };
+        assert!(err.is_err(), "{name} should reject traversal");
+    }
+}
+
+#[tokio::test]
+async fn all_tools_reject_absolute_paths() {
+    let root = tempdir().expect("tempdir");
+    let outside = outside_temp_file("absolute");
+
+    let read = ReadFile::new(root.path()).expect("read");
+    let write = WriteFile::new(root.path()).expect("write");
+    let delete = DeleteFile::new(root.path()).expect("delete");
+    let list = ListDir::new(root.path()).expect("list");
+    let search = SearchFile::new(root.path(), 10).expect("search");
+    let copy = CopyFile::new(root.path()).expect("copy");
+    let mov = MoveFile::new(root.path()).expect("move");
+    let create = CreateDir::new(root.path()).expect("create");
+
+    let abs = outside.to_string_lossy().to_string();
+
+    assert!(read.execute(json!({ "file_path": abs })).await.is_err());
+    assert!(
+        write
+            .execute(json!({ "file_path": abs, "content": "x", "append": false }))
+            .await
+            .is_err()
+    );
+    assert!(delete.execute(json!({ "path": abs })).await.is_err());
+    assert!(
+        list.execute(json!({ "directory_path": abs }))
+            .await
+            .is_err()
+    );
+    assert!(
+        search
+            .execute(json!({ "directory": abs, "pattern": "*" }))
+            .await
+            .is_err()
+    );
+    assert!(
+        copy.execute(json!({
+            "source_path": abs,
+            "destination_path": "dest.txt"
+        }))
+        .await
+        .is_err()
+    );
+    assert!(
+        mov.execute(json!({
+            "source_path": abs,
+            "destination_path": "dest.txt"
+        }))
+        .await
+        .is_err()
+    );
+    assert!(
+        create
+            .execute(json!({ "directory_path": abs, "recursive": true }))
+            .await
+            .is_err()
+    );
+
+    let _ = fs::remove_file(outside);
+}
+
+#[tokio::test]
+async fn write_to_new_path_inside_root_succeeds() {
+    let root = tempdir().expect("tempdir");
+    let write = WriteFile::new(root.path()).expect("write");
+
+    let result = write
+        .execute(json!({
+            "file_path": "nested/new.txt",
+            "content": "hello",
+            "append": false
+        }))
+        .await
+        .expect("write should succeed");
+
+    assert_eq!(result.get("success").and_then(|v| v.as_bool()), Some(true));
+    let written = root.path().join("nested/new.txt");
+    assert_eq!(fs::read_to_string(written).expect("read"), "hello");
+}
+
+#[tokio::test]
+async fn delete_non_recursive_non_empty_directory_fails() {
+    let root = tempdir().expect("tempdir");
+    fs::create_dir_all(root.path().join("dir/nested")).expect("mkdir");
+
+    let delete = DeleteFile::new(root.path()).expect("delete");
+    let err = delete
+        .execute(json!({ "path": "dir" }))
+        .await
+        .expect_err("non-recursive delete should fail");
+    assert_tool_runtime_error(Err(err));
+    assert!(root.path().join("dir").exists());
+}
+
+#[tokio::test]
+async fn delete_recursive_opt_in_removes_nested_directory() {
+    let root = tempdir().expect("tempdir");
+    fs::create_dir_all(root.path().join("dir/nested")).expect("mkdir");
+    fs::write(root.path().join("dir/nested/file.txt"), "data").expect("write");
+
+    let delete = DeleteFile::new(root.path()).expect("delete");
+    delete
+        .execute(json!({ "path": "dir", "recursive": true }))
+        .await
+        .expect("recursive delete");
+    assert!(!root.path().join("dir").exists());
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn read_rejects_symlink_escape() {
+    use std::os::unix::fs::symlink;
+
+    let root = tempdir().expect("tempdir");
+    let outside = outside_temp_file("symlink-read");
+    let link = root.path().join("escape.txt");
+    symlink(&outside, &link).expect("symlink");
+
+    let read = ReadFile::new(root.path()).expect("read");
+    let err = read
+        .execute(json!({ "file_path": "escape.txt" }))
+        .await
+        .expect_err("symlink escape");
+    assert_tool_runtime_error(Err(err));
+
+    let _ = fs::remove_file(outside);
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn write_rejects_symlink_escape_via_parent() {
+    use std::os::unix::fs::symlink;
+
+    let root = tempdir().expect("tempdir");
+    let outside_dir = std::env::temp_dir().join(format!(
+        "autoagents-outside-dir-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("clock")
+            .as_nanos()
+    ));
+    fs::create_dir_all(&outside_dir).expect("outside dir");
+    let link_parent = root.path().join("linked");
+    symlink(&outside_dir, &link_parent).expect("symlink dir");
+
+    let write = WriteFile::new(root.path()).expect("write");
+    let err = write
+        .execute(json!({
+            "file_path": "linked/secret.txt",
+            "content": "escaped",
+            "append": false
+        }))
+        .await
+        .expect_err("write through symlink parent");
+
+    assert_tool_runtime_error(Err(err));
+    assert!(!outside_dir.join("secret.txt").exists());
+
+    let _ = fs::remove_dir_all(outside_dir);
+}
+
+#[test]
+fn sandbox_prefix_boundary_rejects_sibling_root() {
+    let parent = tempdir().expect("tempdir");
+    let root = parent.path().join("workspace");
+    let sibling = parent.path().join("workspace_extra");
+    fs::create_dir_all(&root).expect("root");
+    fs::create_dir_all(&sibling).expect("sibling");
+    let secret = sibling.join("secret.txt");
+    fs::write(&secret, "secret").expect("write");
+
+    let sandbox = FilesystemSandbox::new(&root).expect("sandbox");
+    let err = sandbox
+        .ensure_resolved(&secret)
+        .expect_err("sibling escape");
+    assert_eq!(err.kind(), ErrorKind::PermissionDenied);
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn search_fails_fast_on_symlink_escape_entry() {
+    use std::os::unix::fs::symlink;
+
+    let root = tempdir().expect("tempdir");
+    fs::write(root.path().join("allowed.txt"), "ok").expect("write");
+    let outside = outside_temp_file("search-symlink");
+    let link = root.path().join("escape_link.txt");
+    symlink(&outside, &link).expect("symlink");
+
+    let search = SearchFile::new(root.path(), 100).expect("search");
+    let err = search
+        .execute(json!({ "directory": ".", "pattern": "*" }))
+        .await
+        .expect_err("search should fail on symlink escape");
+
+    assert_tool_runtime_error(Err(err));
+    let _ = fs::remove_file(outside);
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn delete_rejects_symlink_escape() {
+    use std::os::unix::fs::symlink;
+
+    let root = tempdir().expect("tempdir");
+    let outside = outside_temp_file("delete-symlink");
+    let link = root.path().join("escape.txt");
+    symlink(&outside, &link).expect("symlink");
+
+    let delete = DeleteFile::new(root.path()).expect("delete");
+    let err = delete
+        .execute(json!({ "path": "escape.txt" }))
+        .await
+        .expect_err("delete should reject symlink escape");
+
+    assert_tool_runtime_error(Err(err));
+    assert!(outside.exists());
+
+    let _ = fs::remove_file(outside);
+}
+
+#[test]
+fn resolve_relative_rejects_whitespace_only_paths() {
+    let root = tempdir().expect("tempdir");
+    let sandbox = FilesystemSandbox::new(root.path()).expect("sandbox");
+    let err = sandbox
+        .resolve_relative("   ")
+        .expect_err("whitespace path");
+    assert_eq!(err.kind(), ErrorKind::InvalidInput);
+}

--- a/docs/content/core-concepts/tools.md
+++ b/docs/content/core-concepts/tools.md
@@ -40,6 +40,42 @@ Reusable tools are in `autoagents-toolkit`:
 
 Enable features in your `Cargo.toml` as needed.
 
+### Filesystem sandboxing (v0.4.0)
+
+Filesystem tools require an explicit workspace root at construction. Unscoped constructors were removed in v0.4.0.
+
+```rust
+use autoagents_toolkit::tools::filesystem::{FilesystemSandbox, ReadFile, WriteFile};
+
+let workspace = std::env::current_dir()?;
+let read = ReadFile::new(&workspace)?;
+let write = WriteFile::new(&workspace)?;
+```
+
+Rules enforced by `FilesystemSandbox`:
+
+- User paths must be **relative** to the workspace root (absolute paths are rejected).
+- `..` traversal components are rejected.
+- Existing paths are canonicalized and verified to stay within the root (symlink escapes fail closed).
+- Directory walks use `follow_links(false)`.
+- `delete_file` deletes directories non-recursively by default; pass `"recursive": true` to remove a directory tree.
+- Mutating tools re-validate paths after creating parent directories to close TOCTOU races.
+
+Symlink-escape regression tests run on Unix in CI. On Windows, the same canonicalization checks apply at runtime, but dedicated Windows junction fixtures are not yet in the test suite.
+
+### v0.4.0 migration
+
+| Before | After |
+| ------ | ----- |
+| `ReadFile::new()` | `ReadFile::new(&workspace)?` |
+| `new_with_root_dir(s)` | `new(&s)?` or `with_sandbox(sandbox)` |
+| `SearchFile::new(100)` | `SearchFile::new(&workspace, 100)?` |
+| Recursive directory delete (implicit) | Pass `"recursive": true` to `delete_file` |
+
+See [CHANGELOG.md](../../../CHANGELOG.md) for the full migration guide.
+
+For dynamic tool wiring (workspace known only at runtime), see `examples/coding_agent` and `examples/basic/src/manual_tool_agent.rs`.
+
 ## MCP
 
 Model Context Protocol (MCP) integrations are available via `autoagents-toolkit::mcp` — load tool definitions from MCP servers and expose them as `ToolT`. See `McpTools` for managing connections and wrapping MCP tools for use by agents.

--- a/examples/coding_agent/README.md
+++ b/examples/coding_agent/README.md
@@ -1,19 +1,39 @@
 # Coding Agent Example
 
-A ReAct (Reasoning + Acting) based coding agent that demonstrates file manipulation capabilities similar to AI coding assistants. This agent systematically reasons through tasks and uses tools to search, read, write, and analyze code files in a project.
+A ReAct (Reasoning + Acting) based coding agent that demonstrates **sandboxed** file manipulation capabilities. All filesystem tools are scoped to an explicit workspace root; relative paths only, with traversal and symlink escapes rejected.
 
-## Use Cases
+## Workspace
 
-### Basic Coding Agent
+By default the agent uses the current working directory as the workspace sandbox. Override it with `--workspace`:
+
 ```sh
 export OPENAI_API_KEY=your_openai_api_key_here
-cargo run --package coding_agent -- --usecase simple
+cargo run --package coding_agent -- --usecase interactive --workspace /path/to/project
 ```
-Shows a basic coding agent that can help with file operations.
 
-### Interactive Coding Agent
+At startup the canonical workspace path is printed to the terminal.
+
+## Interactive session
+
 ```sh
 export OPENAI_API_KEY=your_openai_api_key_here
 cargo run --package coding_agent -- --usecase interactive
 ```
-Provides an interactive session where you can ask the agent to perform various coding tasks.
+
+## Sandboxed tool wiring
+
+The example builds filesystem tools with a required workspace root (see `examples/coding_agent/src/agent.rs`):
+
+```rust
+ReadFile::new(&workspace_root)?;
+WriteFile::new(&workspace_root)?;
+DeleteFile::new(&workspace_root)?;
+```
+
+Custom tools (`GrepTool`, `AnalyzeCodeTool`) use the same `FilesystemSandbox` from `autoagents-toolkit`.
+
+## Safety notes
+
+- Paths must be relative to the workspace root (`..` and absolute paths are rejected).
+- Directory deletion is non-recursive by default; pass `"recursive": true` to `delete_file` when needed.
+- Directory walks do not follow symlinks.

--- a/examples/coding_agent/src/agent.rs
+++ b/examples/coding_agent/src/agent.rs
@@ -1,20 +1,32 @@
-use autoagents_derive::{AgentHooks, agent};
-use autoagents_toolkit::tools::filesystem::{DeleteFile, ListDir, ReadFile, SearchFile, WriteFile};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use autoagents::core::agent::AgentDeriveT;
+use autoagents::core::tool::{ToolT, shared_tools_to_boxes};
+use autoagents_derive::AgentHooks;
+use autoagents_toolkit::tools::filesystem::{
+    DeleteFile, FilesystemSandbox, ListDir, ReadFile, SearchFile, WriteFile,
+};
+use serde_json::Value;
 
 use crate::tools::{AnalyzeCodeTool, GrepTool};
 
-#[agent(
-    name = "coding_agent",
-    description = "You are a coding agent operating within the AutoAgents framework using the ReAct (Reasoning + Acting) execution pattern. Your primary role is to help users with software engineering tasks through systematic reasoning and tool usage.
+const AGENT_NAME: &str = "coding_agent";
+
+const AGENT_DESCRIPTION_TEMPLATE: &str = "You are a coding agent operating within the AutoAgents framework using the ReAct (Reasoning + Acting) execution pattern. Your primary role is to help users with software engineering tasks through systematic reasoning and tool usage.
+
+## Workspace
+All file operations are sandboxed to this workspace root: {workspace_root}
+Use relative paths only. Absolute paths and parent-directory traversal (`..`) are rejected.
 
 ## Core Capabilities
 You can:
-- Search for files using glob patterns (FileSearchTool)
+- Search for files using glob patterns (search_file)
 - Search file contents with regex patterns (GrepTool)
-- Read file contents (ReadFileTool)
-- Write and create files (WriteFileTool)
-- Delete files (DeleteFileTool)
-- List directory contents (ListDirectoryTool)
+- Read file contents (read_file)
+- Write and create files (write_file)
+- Delete files (delete_file)
+- List directory contents (list_dir)
 - Analyze code structure and complexity (AnalyzeCodeTool)
 
 ## ReAct Execution Pattern
@@ -25,36 +37,93 @@ As a ReAct agent, you follow this pattern for each task:
 4. **Repeat**: Continue the thought-action-observation cycle until the task is complete
 
 ## Working Principles
-- **Be Precise**: Always use exact file paths. When given a working directory, use it as the base for all operations
+- **Be Precise**: Always use relative paths from the workspace root
 - **Verify Before Acting**: Check if files/directories exist before attempting operations
 - **Incremental Progress**: Break complex tasks into smaller, manageable steps
 - **Clear Communication**: Explain your reasoning and actions, but be concise
-- **Safety First**: Never delete or overwrite files without clear intent
+- **Safety First**: Never delete or overwrite files without clear intent. Directory deletion requires `recursive: true`
 - **Follow Conventions**: Respect existing code style and project structure
 
 ## Task Execution Guidelines
-- Start by understanding the codebase structure using ListDirectoryTool or FileSearchTool
+- Start by understanding the codebase structure using list_dir or search_file
 - Use GrepTool to find patterns across multiple files efficiently
 - Read files to understand context before making modifications
 - When writing code, follow the existing style and conventions
 - Always provide clear feedback about what was accomplished
 
 ## Important Constraints
-- All file paths should be relative to the provided base directory
+- All file paths must be relative to the workspace root
 - You cannot execute shell commands or run code directly
 - Focus on file manipulation and code analysis tasks
 - Be explicit about limitations when you cannot complete a request
 
-Remember: You are a systematic problem solver. Think through each step, use your tools effectively, and provide clear, actionable results.",
-    tools = [
-        SearchFile::new(100),
-        GrepTool,
-        ReadFile::new(),
-        WriteFile::new(),
-        DeleteFile::new(),
-        ListDir::new(),
-        AnalyzeCodeTool
-    ],
-)]
+Remember: You are a systematic problem solver. Think through each step, use your tools effectively, and provide clear, actionable results.";
+
 #[derive(Clone, AgentHooks)]
-pub struct CodingAgent {}
+pub struct CodingAgent {
+    workspace_root: PathBuf,
+    description: Arc<String>,
+    tools: Arc<Vec<Arc<dyn ToolT>>>,
+}
+
+impl CodingAgent {
+    pub fn new(workspace_root: impl AsRef<Path>) -> std::io::Result<Self> {
+        let sandbox = FilesystemSandbox::new(workspace_root)?;
+        let canonical_root = sandbox.root().to_path_buf();
+        let description = Arc::new(
+            AGENT_DESCRIPTION_TEMPLATE
+                .replace("{workspace_root}", &canonical_root.display().to_string()),
+        );
+        let tools = Arc::new(build_tools(sandbox)?);
+
+        Ok(Self {
+            workspace_root: canonical_root,
+            description,
+            tools,
+        })
+    }
+
+    pub fn workspace_root(&self) -> &Path {
+        &self.workspace_root
+    }
+}
+
+fn build_tools(sandbox: FilesystemSandbox) -> std::io::Result<Vec<Arc<dyn ToolT>>> {
+    Ok(vec![
+        Arc::new(SearchFile::with_sandbox(sandbox.clone(), 100)),
+        Arc::new(GrepTool::with_sandbox(sandbox.clone())),
+        Arc::new(ReadFile::with_sandbox(sandbox.clone())),
+        Arc::new(WriteFile::with_sandbox(sandbox.clone())),
+        Arc::new(DeleteFile::with_sandbox(sandbox.clone())),
+        Arc::new(ListDir::with_sandbox(sandbox.clone())),
+        Arc::new(AnalyzeCodeTool::with_sandbox(sandbox)),
+    ])
+}
+
+impl AgentDeriveT for CodingAgent {
+    type Output = String;
+
+    fn description(&self) -> &str {
+        &self.description
+    }
+
+    fn output_schema(&self) -> Option<Value> {
+        None
+    }
+
+    fn name(&self) -> &str {
+        AGENT_NAME
+    }
+
+    fn tools(&self) -> Vec<Box<dyn ToolT>> {
+        shared_tools_to_boxes(&self.tools)
+    }
+}
+
+impl std::fmt::Debug for CodingAgent {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CodingAgent")
+            .field("workspace_root", &self.workspace_root)
+            .finish()
+    }
+}

--- a/examples/coding_agent/src/interactive.rs
+++ b/examples/coding_agent/src/interactive.rs
@@ -39,7 +39,6 @@ pub async fn run_interactive_session(
     // Create topic for coding tasks
     let coding_topic = Topic::<Task>::new(CODING_TASK_TOPIC);
 
-    let workspace_root = coding_agent.workspace_root().to_path_buf();
     let react_agent = ReActAgent::new(coding_agent);
 
     // Build the agent
@@ -99,8 +98,7 @@ pub async fn run_interactive_session(
                 println!("\n🔄 Processing your request...\n");
 
                 let task = Task::new(format!(
-                    "[Workspace sandbox: {}]\n{input}",
-                    workspace_root.display()
+                    "[Workspace sandbox: use relative paths from . (workspace root)]\n{input}"
                 ));
 
                 // Publish to topic for all subscribers

--- a/examples/coding_agent/src/interactive.rs
+++ b/examples/coding_agent/src/interactive.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use crate::agent::CodingAgent;
 use autoagents::core::actor::Topic;
 use autoagents::core::agent::AgentBuilder;
@@ -18,8 +20,15 @@ use tokio_stream::StreamExt;
 
 const CODING_TASK_TOPIC: &str = "coding_task";
 
-pub async fn run_interactive_session(llm: Arc<dyn LLMProvider>) -> Result<(), Error> {
+pub async fn run_interactive_session(
+    llm: Arc<dyn LLMProvider>,
+    workspace: PathBuf,
+) -> Result<(), Error> {
+    let coding_agent = CodingAgent::new(&workspace)
+        .map_err(|error| Error::CustomError(format!("failed to build coding agent: {error}")))?;
+
     println!("🚀 Starting Interactive Coding Agent Session");
+    println!("📁 Workspace: {}", coding_agent.workspace_root().display());
     println!("💡 Type 'help' for available commands, 'quit' to exit\n");
 
     // Create memory with larger window for complex tasks
@@ -30,11 +39,11 @@ pub async fn run_interactive_session(llm: Arc<dyn LLMProvider>) -> Result<(), Er
     // Create topic for coding tasks
     let coding_topic = Topic::<Task>::new(CODING_TASK_TOPIC);
 
-    // Create the coding agent
-    let coding_agent = ReActAgent::new(CodingAgent {});
+    let workspace_root = coding_agent.workspace_root().to_path_buf();
+    let react_agent = ReActAgent::new(coding_agent);
 
     // Build the agent
-    let _ = AgentBuilder::new(coding_agent)
+    let _ = AgentBuilder::new(react_agent)
         .llm(llm)
         .runtime(runtime.clone())
         .subscribe(coding_topic.clone())
@@ -87,11 +96,12 @@ pub async fn run_interactive_session(llm: Arc<dyn LLMProvider>) -> Result<(), Er
                 continue;
             }
             _ => {
-                // Process the task
                 println!("\n🔄 Processing your request...\n");
 
-                // Create task and send using the new messaging system
-                let task = Task::new(input);
+                let task = Task::new(format!(
+                    "[Workspace sandbox: {}]\n{input}",
+                    workspace_root.display()
+                ));
 
                 // Publish to topic for all subscribers
                 runtime.publish(&coding_topic, task).await?;

--- a/examples/coding_agent/src/main.rs
+++ b/examples/coding_agent/src/main.rs
@@ -1,8 +1,11 @@
 use clap::{Parser, ValueEnum};
+use std::path::PathBuf;
 use std::sync::Arc;
+
 mod agent;
 mod interactive;
 mod tools;
+
 use autoagents::{core::error::Error, llm::backends::openai::OpenAI, llm::builder::LLMBuilder};
 
 #[derive(Debug, Clone, ValueEnum)]
@@ -10,33 +13,46 @@ enum UseCase {
     Interactive,
 }
 
-/// Coding agent that demonstrates file manipulation capabilities
+/// Coding agent that demonstrates sandboxed file manipulation capabilities
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
 struct Args {
     #[arg(short, long, help = "usecase to run")]
     usecase: UseCase,
+    #[arg(
+        long,
+        value_name = "PATH",
+        help = "Workspace root for sandboxed file tools (defaults to the current directory)"
+    )]
+    workspace: Option<PathBuf>,
+}
+
+fn workspace_path(path: Option<PathBuf>) -> PathBuf {
+    path.unwrap_or_else(|| {
+        std::env::current_dir().expect("failed to read current working directory")
+    })
 }
 
 #[tokio::main]
 #[allow(clippy::result_large_err)]
 async fn main() -> Result<(), Error> {
     let args = Args::parse();
+    let workspace = workspace_path(args.workspace);
 
-    // Check if API key is set
     let api_key = std::env::var("OPENAI_API_KEY").expect("OPENAI_API_KEY must be set");
 
-    // Initialize and configure the LLM client
     let llm: Arc<OpenAI> = LLMBuilder::<OpenAI>::new()
         .api_key(api_key)
         .model("gpt-4o")
         .max_tokens(2048)
-        .temperature(0.1) // Lower temperature for more consistent code generation
+        .temperature(0.1)
         .build()
         .expect("Failed to build LLM");
 
     match args.usecase {
-        UseCase::Interactive => interactive::run_interactive_session(llm).await?,
+        UseCase::Interactive => {
+            interactive::run_interactive_session(llm, workspace).await?;
+        }
     }
 
     Ok(())

--- a/examples/coding_agent/src/tools.rs
+++ b/examples/coding_agent/src/tools.rs
@@ -190,8 +190,8 @@ impl ToolRuntime for AnalyzeCodeTool {
 
         match args.analysis_type.as_str() {
             "structure" => Ok(analyze_structure(&self.sandbox, &path)?.into()),
-            "complexity" => Ok(analyze_complexity(&path)?.into()),
-            "dependencies" => Ok(analyze_dependencies(&path)?.into()),
+            "complexity" => Ok(analyze_complexity(&self.sandbox, &path)?.into()),
+            "dependencies" => Ok(analyze_dependencies(&self.sandbox, &path)?.into()),
             _ => Err(ToolCallError::RuntimeError(
                 "Invalid analysis type. Choose 'structure', 'complexity', or 'dependencies'".into(),
             )),
@@ -253,20 +253,169 @@ fn analyze_structure(sandbox: &FilesystemSandbox, path: &Path) -> Result<String,
     ))
 }
 
-fn analyze_complexity(_path: &Path) -> Result<String, ToolCallError> {
-    Ok(
-        "Complexity analysis: This is a placeholder. In a real implementation, \
-        this would calculate cyclomatic complexity, function lengths, and other metrics."
-            .to_string(),
-    )
+fn collect_source_files(
+    sandbox: &FilesystemSandbox,
+    path: &Path,
+) -> Result<Vec<std::path::PathBuf>, ToolCallError> {
+    let mut files = Vec::new();
+
+    if path.is_file() {
+        files.push(path.to_path_buf());
+        return Ok(files);
+    }
+
+    for entry in sandbox.walk_dir(path).into_iter().filter_map(|e| e.ok()) {
+        let entry_path = entry.path();
+        let validated_path = sandbox
+            .validate_walk_entry(entry_path)
+            .map_err(io_sandbox_error)?;
+
+        if validated_path.is_file() {
+            files.push(validated_path);
+        }
+    }
+
+    Ok(files)
 }
 
-fn analyze_dependencies(_path: &Path) -> Result<String, ToolCallError> {
-    Ok(
-        "Dependency analysis: This is a placeholder. In a real implementation, \
-        this would parse import statements and analyze module dependencies."
-            .to_string(),
-    )
+fn relative_display(sandbox: &FilesystemSandbox, path: &Path) -> String {
+    path.strip_prefix(sandbox.root())
+        .unwrap_or(path)
+        .display()
+        .to_string()
+}
+
+fn count_regex_matches(content: &str, pattern: &str) -> usize {
+    Regex::new(pattern)
+        .map(|regex| regex.find_iter(content).count())
+        .unwrap_or(0)
+}
+
+fn analyze_complexity(sandbox: &FilesystemSandbox, path: &Path) -> Result<String, ToolCallError> {
+    let files = collect_source_files(sandbox, path)?;
+    if files.is_empty() {
+        return Ok("Complexity Analysis:\nNo source files found.".to_string());
+    }
+
+    let file_count = files.len();
+    let mut report = String::from("Complexity Analysis:\n");
+    let mut total_lines = 0usize;
+    let mut total_functions = 0usize;
+    let mut total_complexity = 0usize;
+
+    for file in files {
+        let content = fs::read_to_string(&file).map_err(|e| {
+            ToolCallError::RuntimeError(
+                format!("Failed to read {}: {}", relative_display(sandbox, &file), e).into(),
+            )
+        })?;
+
+        let lines = content.lines().count();
+        let functions = count_regex_matches(
+            &content,
+            r"(?m)^\s*(pub\s+)?(async\s+)?fn\s+\w+|^\s*def\s+\w+|^\s*function\s+\w+",
+        );
+        let decision_points = count_regex_matches(
+            &content,
+            r"\b(if|else if|for|while|match|case|catch|&&|\|\|)\b|\?",
+        );
+        let complexity = 1 + decision_points;
+
+        total_lines += lines;
+        total_functions += functions;
+        total_complexity += complexity;
+
+        report.push_str(&format!(
+            "\n{}:\n  Lines: {}\n  Functions: {}\n  Estimated cyclomatic complexity: {}\n",
+            relative_display(sandbox, &file),
+            lines,
+            functions,
+            complexity
+        ));
+    }
+
+    report.push_str(&format!(
+        "\nTotals:\n  Files: {}\n  Lines: {}\n  Functions: {}\n  Combined estimated cyclomatic complexity: {}\n",
+        file_count,
+        total_lines,
+        total_functions,
+        total_complexity
+    ));
+
+    Ok(report)
+}
+
+fn extract_dependencies(content: &str) -> Vec<String> {
+    let patterns = [
+        r"(?m)^\s*use\s+([^;{]+)",
+        r"(?m)^\s*mod\s+(\w+)",
+        r"(?m)^\s*import\s+(.+)",
+        r"(?m)^\s*from\s+([^\s]+)\s+import",
+        r#"(?m)require\(\s*['"]([^'"]+)['"]\s*\)"#,
+    ];
+
+    let mut deps = Vec::new();
+    for pattern in patterns {
+        if let Ok(regex) = Regex::new(pattern) {
+            for cap in regex.captures_iter(content) {
+                if let Some(dep) = cap.get(1) {
+                    let value = dep.as_str().trim();
+                    if !value.is_empty() {
+                        deps.push(value.to_string());
+                    }
+                }
+            }
+        }
+    }
+    deps.sort();
+    deps.dedup();
+    deps
+}
+
+fn analyze_dependencies(sandbox: &FilesystemSandbox, path: &Path) -> Result<String, ToolCallError> {
+    let files = collect_source_files(sandbox, path)?;
+    if files.is_empty() {
+        return Ok("Dependency Analysis:\nNo source files found.".to_string());
+    }
+
+    let mut report = String::from("Dependency Analysis:\n");
+    let mut all_dependencies = Vec::new();
+
+    for file in files {
+        let content = fs::read_to_string(&file).map_err(|e| {
+            ToolCallError::RuntimeError(
+                format!("Failed to read {}: {}", relative_display(sandbox, &file), e).into(),
+            )
+        })?;
+
+        let deps = extract_dependencies(&content);
+        if deps.is_empty() {
+            continue;
+        }
+
+        report.push_str(&format!("\n{}:\n", relative_display(sandbox, &file)));
+        for dep in &deps {
+            report.push_str(&format!("  - {}\n", dep));
+            all_dependencies.push(dep.clone());
+        }
+    }
+
+    all_dependencies.sort();
+    all_dependencies.dedup();
+
+    if all_dependencies.is_empty() {
+        report.push_str("\nNo import/use statements found.");
+    } else {
+        report.push_str(&format!(
+            "\nUnique dependencies ({}):\n",
+            all_dependencies.len()
+        ));
+        for dep in all_dependencies {
+            report.push_str(&format!("  - {}\n", dep));
+        }
+    }
+
+    Ok(report)
 }
 
 #[cfg(test)]
@@ -441,8 +590,9 @@ mod tests {
             complexity
                 .as_str()
                 .expect("complexity output should be a string")
-                .contains("cyclomatic complexity")
+                .contains("Estimated cyclomatic complexity")
         );
+        assert!(complexity.as_str().unwrap().contains("src/lib.rs"));
 
         let dependencies = tool
             .execute(json!({
@@ -455,7 +605,7 @@ mod tests {
             dependencies
                 .as_str()
                 .expect("dependency output should be a string")
-                .contains("Dependency analysis")
+                .contains("Dependency Analysis")
         );
 
         let invalid_type = tool

--- a/examples/coding_agent/src/tools.rs
+++ b/examples/coding_agent/src/tools.rs
@@ -1,11 +1,13 @@
+use std::fs;
+use std::path::Path;
+
 use autoagents::async_trait;
 use autoagents::core::tool::{ToolCallError, ToolRuntime, ToolT};
 use autoagents_derive::{ToolInput, tool};
+use autoagents_toolkit::tools::filesystem::FilesystemSandbox;
+use glob::Pattern;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
-use std::fs;
-use std::path::Path;
-use walkdir::WalkDir;
 
 #[derive(Serialize, Deserialize, ToolInput, Debug)]
 pub struct GrepArgs {
@@ -13,66 +15,112 @@ pub struct GrepArgs {
     pattern: String,
     #[input(description = "File glob pattern to search in (e.g., '*.rs')")]
     file_pattern: String,
-    #[input(description = "Base directory to search in")]
-    base_dir: String,
+    #[serde(default = "default_subdirectory")]
+    #[input(description = "Relative subdirectory within the workspace to search in")]
+    subdirectory: String,
+}
+
+fn default_subdirectory() -> String {
+    ".".to_string()
+}
+
+const MAX_MATCH_RESULTS: usize = 50;
+const MAX_FILES_SCANNED: usize = 500;
+
+fn io_sandbox_error(error: std::io::Error) -> ToolCallError {
+    ToolCallError::RuntimeError(Box::new(error))
 }
 
 #[tool(
     name = "GrepTool",
-    description = "Search for content in files using regex patterns",
+    description = "Search for content in files using regex patterns within the workspace sandbox",
     input = GrepArgs,
 )]
-pub struct GrepTool {}
+pub struct GrepTool {
+    sandbox: FilesystemSandbox,
+}
+
+impl GrepTool {
+    pub fn with_sandbox(sandbox: FilesystemSandbox) -> Self {
+        Self { sandbox }
+    }
+}
 
 #[async_trait]
 impl ToolRuntime for GrepTool {
     async fn execute(&self, args: serde_json::Value) -> Result<serde_json::Value, ToolCallError> {
         let args: GrepArgs = serde_json::from_value(args)?;
-        println!("🔎 Grepping for: {} in {}", args.pattern, args.file_pattern);
 
         let regex = Regex::new(&args.pattern)
             .map_err(|e| ToolCallError::RuntimeError(format!("Invalid regex: {}", e).into()))?;
 
-        let base_path = Path::new(&args.base_dir);
+        let base_path = self
+            .sandbox
+            .resolve_relative(&args.subdirectory)
+            .map_err(io_sandbox_error)?;
+        let base_path = self
+            .sandbox
+            .ensure_resolved(&base_path)
+            .map_err(io_sandbox_error)?;
+
         if !base_path.exists() {
             return Err(ToolCallError::RuntimeError(
-                format!("Directory {} does not exist", args.base_dir).into(),
+                format!("Subdirectory {} does not exist", base_path.display()).into(),
             ));
         }
 
-        let file_pattern = glob::Pattern::new(&args.file_pattern).map_err(|e| {
+        if !base_path.is_dir() {
+            return Err(ToolCallError::RuntimeError(
+                format!("Subdirectory {} is not a directory", base_path.display()).into(),
+            ));
+        }
+
+        let file_pattern = Pattern::new(&args.file_pattern).map_err(|e| {
             ToolCallError::RuntimeError(format!("Invalid file pattern: {}", e).into())
         })?;
 
         let mut results = Vec::new();
-        let max_results = 50;
+        let mut files_scanned = 0usize;
 
-        for entry in WalkDir::new(&args.base_dir)
-            .follow_links(true)
+        for entry in self
+            .sandbox
+            .walk_dir(&base_path)
             .into_iter()
             .filter_map(|e| e.ok())
         {
-            if results.len() >= max_results {
+            if results.len() >= MAX_MATCH_RESULTS || files_scanned >= MAX_FILES_SCANNED {
                 break;
             }
 
             let path = entry.path();
-            if path.is_file() {
-                let relative_path = path.strip_prefix(&args.base_dir).unwrap_or(path);
-                if file_pattern.matches_path(relative_path)
-                    && let Ok(content) = fs::read_to_string(path)
-                {
-                    for (line_num, line) in content.lines().enumerate() {
-                        if regex.is_match(line) {
-                            results.push(format!(
-                                "{}:{}: {}",
-                                relative_path.display(),
-                                line_num + 1,
-                                line.trim()
-                            ));
-                            if results.len() >= max_results {
-                                break;
-                            }
+            if !path.is_file() {
+                continue;
+            }
+
+            files_scanned += 1;
+
+            let validated_path = self
+                .sandbox
+                .validate_walk_entry(path)
+                .map_err(io_sandbox_error)?;
+
+            let relative_path = validated_path
+                .strip_prefix(self.sandbox.root())
+                .unwrap_or(&validated_path);
+
+            if file_pattern.matches_path(relative_path)
+                && let Ok(content) = fs::read_to_string(&validated_path)
+            {
+                for (line_num, line) in content.lines().enumerate() {
+                    if regex.is_match(line) {
+                        results.push(format!(
+                            "{}:{}: {}",
+                            relative_path.display(),
+                            line_num + 1,
+                            line.trim()
+                        ));
+                        if results.len() >= MAX_MATCH_RESULTS {
+                            break;
                         }
                     }
                 }
@@ -83,9 +131,10 @@ impl ToolRuntime for GrepTool {
             Ok("No matches found.".to_string().into())
         } else {
             Ok(format!(
-                "Found {} matches (showing up to {}):\n{}",
+                "Found {} matches (showing up to {}, scanned up to {} files):\n{}",
                 results.len(),
-                max_results,
+                MAX_MATCH_RESULTS,
+                MAX_FILES_SCANNED,
                 results.join("\n")
             )
             .into())
@@ -95,7 +144,9 @@ impl ToolRuntime for GrepTool {
 
 #[derive(Serialize, Deserialize, ToolInput, Debug)]
 pub struct AnalyzeCodeArgs {
-    #[input(description = "Path to the file or directory to analyze")]
+    #[input(
+        description = "Relative path to the file or directory to analyze within the workspace"
+    )]
     path: String,
     #[input(description = "Type of analysis: 'structure', 'complexity', 'dependencies'")]
     analysis_type: String,
@@ -103,28 +154,44 @@ pub struct AnalyzeCodeArgs {
 
 #[tool(
     name = "AnalyzeCodeTool",
-    description = "Analyze code structure, complexity, or dependencies",
+    description = "Analyze code structure, complexity, or dependencies within the workspace sandbox",
     input = AnalyzeCodeArgs,
 )]
-pub struct AnalyzeCodeTool {}
+pub struct AnalyzeCodeTool {
+    sandbox: FilesystemSandbox,
+}
+
+impl AnalyzeCodeTool {
+    pub fn with_sandbox(sandbox: FilesystemSandbox) -> Self {
+        Self { sandbox }
+    }
+}
 
 #[async_trait]
 impl ToolRuntime for AnalyzeCodeTool {
     async fn execute(&self, args: serde_json::Value) -> Result<serde_json::Value, ToolCallError> {
         let args: AnalyzeCodeArgs = serde_json::from_value(args)?;
-        println!("🔬 Analyzing code: {} ({})", args.path, args.analysis_type);
 
-        let path = Path::new(&args.path);
+        let path = self
+            .sandbox
+            .resolve_relative(&args.path)
+            .map_err(io_sandbox_error)?;
+
         if !path.exists() {
             return Err(ToolCallError::RuntimeError(
-                format!("Path {} does not exist", args.path).into(),
+                format!("Path {} does not exist", path.display()).into(),
             ));
         }
 
+        let path = self
+            .sandbox
+            .ensure_resolved(&path)
+            .map_err(io_sandbox_error)?;
+
         match args.analysis_type.as_str() {
-            "structure" => Ok(analyze_structure(path)?.into()),
-            "complexity" => Ok(analyze_complexity(path)?.into()),
-            "dependencies" => Ok(analyze_dependencies(path)?.into()),
+            "structure" => Ok(analyze_structure(&self.sandbox, &path)?.into()),
+            "complexity" => Ok(analyze_complexity(&path)?.into()),
+            "dependencies" => Ok(analyze_dependencies(&path)?.into()),
             _ => Err(ToolCallError::RuntimeError(
                 "Invalid analysis type. Choose 'structure', 'complexity', or 'dependencies'".into(),
             )),
@@ -132,7 +199,7 @@ impl ToolRuntime for AnalyzeCodeTool {
     }
 }
 
-fn analyze_structure(path: &Path) -> Result<String, ToolCallError> {
+fn analyze_structure(sandbox: &FilesystemSandbox, path: &Path) -> Result<String, ToolCallError> {
     let mut file_count = 0;
     let mut dir_count = 0;
     let mut total_lines = 0;
@@ -149,19 +216,23 @@ fn analyze_structure(path: &Path) -> Result<String, ToolCallError> {
                 .or_insert(0) += 1;
         }
     } else {
-        for entry in WalkDir::new(path).into_iter().filter_map(|e| e.ok()) {
+        for entry in sandbox.walk_dir(path).into_iter().filter_map(|e| e.ok()) {
             let entry_path = entry.path();
-            if entry_path.is_file() {
+            let validated_path = sandbox
+                .validate_walk_entry(entry_path)
+                .map_err(io_sandbox_error)?;
+
+            if validated_path.is_file() {
                 file_count += 1;
-                if let Ok(content) = fs::read_to_string(entry_path) {
+                if let Ok(content) = fs::read_to_string(&validated_path) {
                     total_lines += content.lines().count();
                 }
-                if let Some(ext) = entry_path.extension() {
+                if let Some(ext) = validated_path.extension() {
                     *extensions
                         .entry(ext.to_string_lossy().to_string())
                         .or_insert(0) += 1;
                 }
-            } else if entry_path.is_dir() {
+            } else if validated_path.is_dir() && validated_path != path {
                 dir_count += 1;
             }
         }
@@ -183,7 +254,6 @@ fn analyze_structure(path: &Path) -> Result<String, ToolCallError> {
 }
 
 fn analyze_complexity(_path: &Path) -> Result<String, ToolCallError> {
-    // Simplified complexity analysis
     Ok(
         "Complexity analysis: This is a placeholder. In a real implementation, \
         this would calculate cyclomatic complexity, function lengths, and other metrics."
@@ -192,7 +262,6 @@ fn analyze_complexity(_path: &Path) -> Result<String, ToolCallError> {
 }
 
 fn analyze_dependencies(_path: &Path) -> Result<String, ToolCallError> {
-    // Simplified dependency analysis
     Ok(
         "Dependency analysis: This is a placeholder. In a real implementation, \
         this would parse import statements and analyze module dependencies."
@@ -239,11 +308,11 @@ mod tests {
             "needle should not match this glob\n",
         );
 
-        let result = GrepTool {}
+        let result = GrepTool::with_sandbox(FilesystemSandbox::new(&dir).expect("sandbox"))
             .execute(json!({
                 "pattern": "needle",
                 "file_pattern": "src/*.rs",
-                "base_dir": dir.to_string_lossy(),
+                "subdirectory": ".",
             }))
             .await
             .expect("grep should succeed");
@@ -261,45 +330,69 @@ mod tests {
         let dir = temp_fixture_dir("grep-errors");
         write(&dir.join("src/lib.rs"), "fn present() {}\n");
 
-        let no_match = GrepTool {}
+        let tool = GrepTool::with_sandbox(FilesystemSandbox::new(&dir).expect("sandbox"));
+
+        let no_match = tool
             .execute(json!({
                 "pattern": "missing",
                 "file_pattern": "src/*.rs",
-                "base_dir": dir.to_string_lossy(),
+                "subdirectory": ".",
             }))
             .await
             .expect("grep should succeed even when there are no matches");
         assert_eq!(no_match, json!("No matches found."));
 
-        let invalid_regex = GrepTool {}
+        let invalid_regex = tool
             .execute(json!({
                 "pattern": "(",
                 "file_pattern": "src/*.rs",
-                "base_dir": dir.to_string_lossy(),
+                "subdirectory": ".",
             }))
             .await
             .expect_err("invalid regex should fail");
         assert!(invalid_regex.to_string().contains("Invalid regex"));
 
-        let invalid_glob = GrepTool {}
+        let invalid_glob = tool
             .execute(json!({
                 "pattern": "present",
                 "file_pattern": "[*.rs",
-                "base_dir": dir.to_string_lossy(),
+                "subdirectory": ".",
             }))
             .await
             .expect_err("invalid glob should fail");
         assert!(invalid_glob.to_string().contains("Invalid file pattern"));
 
-        let missing_dir = GrepTool {}
+        let missing_dir = tool
             .execute(json!({
                 "pattern": "present",
                 "file_pattern": "*.rs",
-                "base_dir": dir.join("missing").to_string_lossy(),
+                "subdirectory": "missing",
             }))
             .await
             .expect_err("missing directory should fail");
         assert!(missing_dir.to_string().contains("does not exist"));
+
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[tokio::test]
+    async fn grep_tool_rejects_path_outside_workspace() {
+        let dir = temp_fixture_dir("grep-escape");
+        let tool = GrepTool::with_sandbox(FilesystemSandbox::new(&dir).expect("sandbox"));
+
+        let err = tool
+            .execute(json!({
+                "pattern": "needle",
+                "file_pattern": "*.rs",
+                "subdirectory": "../outside",
+            }))
+            .await
+            .expect_err("traversal should fail");
+        assert!(
+            err.to_string().contains("traversal")
+                || err.to_string().contains("not allowed")
+                || err.to_string().contains("RuntimeError")
+        );
 
         let _ = fs::remove_dir_all(dir);
     }
@@ -316,9 +409,11 @@ mod tests {
             "def greet(name):\n    return name\n",
         );
 
-        let structure = AnalyzeCodeTool {}
+        let tool = AnalyzeCodeTool::with_sandbox(FilesystemSandbox::new(&dir).expect("sandbox"));
+
+        let structure = tool
             .execute(json!({
-                "path": dir.to_string_lossy(),
+                "path": ".",
                 "analysis_type": "structure",
             }))
             .await
@@ -329,14 +424,15 @@ mod tests {
         assert!(summary.contains(".rs: 1 files"));
         assert!(summary.contains(".py: 1 files"));
 
-        let single_file_summary = analyze_structure(&dir.join("src/lib.rs"))
+        let sandbox = FilesystemSandbox::new(&dir).expect("sandbox");
+        let single_file_summary = analyze_structure(&sandbox, &dir.join("src/lib.rs"))
             .expect("single-file structure analysis should succeed");
         assert!(single_file_summary.contains("- Files: 1"));
         assert!(single_file_summary.contains(".rs: 1 files"));
 
-        let complexity = AnalyzeCodeTool {}
+        let complexity = tool
             .execute(json!({
-                "path": dir.to_string_lossy(),
+                "path": ".",
                 "analysis_type": "complexity",
             }))
             .await
@@ -348,9 +444,9 @@ mod tests {
                 .contains("cyclomatic complexity")
         );
 
-        let dependencies = AnalyzeCodeTool {}
+        let dependencies = tool
             .execute(json!({
-                "path": dir.to_string_lossy(),
+                "path": ".",
                 "analysis_type": "dependencies",
             }))
             .await
@@ -362,18 +458,18 @@ mod tests {
                 .contains("Dependency analysis")
         );
 
-        let invalid_type = AnalyzeCodeTool {}
+        let invalid_type = tool
             .execute(json!({
-                "path": dir.to_string_lossy(),
+                "path": ".",
                 "analysis_type": "unknown",
             }))
             .await
             .expect_err("unknown analysis type should fail");
         assert!(invalid_type.to_string().contains("Invalid analysis type"));
 
-        let missing_path = AnalyzeCodeTool {}
+        let missing_path = tool
             .execute(json!({
-                "path": dir.join("missing").to_string_lossy(),
+                "path": "missing",
                 "analysis_type": "structure",
             }))
             .await

--- a/examples/coding_agent/src/tools.rs
+++ b/examples/coding_agent/src/tools.rs
@@ -297,18 +297,17 @@ fn analyze_complexity(sandbox: &FilesystemSandbox, path: &Path) -> Result<String
         return Ok("Complexity Analysis:\nNo source files found.".to_string());
     }
 
-    let file_count = files.len();
+    let mut analyzed_files = 0usize;
     let mut report = String::from("Complexity Analysis:\n");
     let mut total_lines = 0usize;
     let mut total_functions = 0usize;
     let mut total_complexity = 0usize;
 
     for file in files {
-        let content = fs::read_to_string(&file).map_err(|e| {
-            ToolCallError::RuntimeError(
-                format!("Failed to read {}: {}", relative_display(sandbox, &file), e).into(),
-            )
-        })?;
+        let Ok(content) = fs::read_to_string(&file) else {
+            continue;
+        };
+        analyzed_files += 1;
 
         let lines = content.lines().count();
         let functions = count_regex_matches(
@@ -317,7 +316,7 @@ fn analyze_complexity(sandbox: &FilesystemSandbox, path: &Path) -> Result<String
         );
         let decision_points = count_regex_matches(
             &content,
-            r"\b(if|else if|for|while|match|case|catch|&&|\|\|)\b",
+            r"\b(if|else if|for|while|match|case|catch)\b|&&|\|\|",
         );
         let complexity = 1 + decision_points;
 
@@ -334,9 +333,13 @@ fn analyze_complexity(sandbox: &FilesystemSandbox, path: &Path) -> Result<String
         ));
     }
 
+    if analyzed_files == 0 {
+        return Ok("Complexity Analysis:\nNo readable source files found.".to_string());
+    }
+
     report.push_str(&format!(
         "\nTotals:\n  Files: {}\n  Lines: {}\n  Functions: {}\n  Combined estimated cyclomatic complexity: {}\n",
-        file_count,
+        analyzed_files,
         total_lines,
         total_functions,
         total_complexity
@@ -382,11 +385,9 @@ fn analyze_dependencies(sandbox: &FilesystemSandbox, path: &Path) -> Result<Stri
     let mut all_dependencies = Vec::new();
 
     for file in files {
-        let content = fs::read_to_string(&file).map_err(|e| {
-            ToolCallError::RuntimeError(
-                format!("Failed to read {}: {}", relative_display(sandbox, &file), e).into(),
-            )
-        })?;
+        let Ok(content) = fs::read_to_string(&file) else {
+            continue;
+        };
 
         let deps = extract_dependencies(&content);
         if deps.is_empty() {
@@ -616,6 +617,35 @@ mod tests {
             .await
             .expect_err("unknown analysis type should fail");
         assert!(invalid_type.to_string().contains("Invalid analysis type"));
+
+        fs::write(dir.join("binary.dat"), [0u8, 1, 2, 255]).expect("binary fixture");
+        let complexity_with_binary = tool
+            .execute(json!({
+                "path": ".",
+                "analysis_type": "complexity",
+            }))
+            .await
+            .expect("complexity analysis should skip binary files");
+        assert!(
+            complexity_with_binary
+                .as_str()
+                .expect("complexity output should be a string")
+                .contains("Estimated cyclomatic complexity")
+        );
+
+        let dependencies_with_binary = tool
+            .execute(json!({
+                "path": ".",
+                "analysis_type": "dependencies",
+            }))
+            .await
+            .expect("dependency analysis should skip binary files");
+        assert!(
+            dependencies_with_binary
+                .as_str()
+                .expect("dependency output should be a string")
+                .contains("Dependency Analysis")
+        );
 
         let missing_path = tool
             .execute(json!({

--- a/examples/coding_agent/src/tools.rs
+++ b/examples/coding_agent/src/tools.rs
@@ -317,7 +317,7 @@ fn analyze_complexity(sandbox: &FilesystemSandbox, path: &Path) -> Result<String
         );
         let decision_points = count_regex_matches(
             &content,
-            r"\b(if|else if|for|while|match|case|catch|&&|\|\|)\b|\?",
+            r"\b(if|else if|for|while|match|case|catch|&&|\|\|)\b",
         );
         let complexity = 1 + decision_points;
 


### PR DESCRIPTION
## Summary

- Introduce mandatory `FilesystemSandbox` for all toolkit filesystem tools: reject absolute paths, `..` traversal, and symlink escapes; re-validate paths after parent directory creation to close TOCTOU gaps on write/copy/move.
- Make recursive directory deletion opt-in via `delete_file` (`recursive` defaults to `false`).
- Update `coding_agent` to wire root-scoped tools from a single shared sandbox, add `--workspace` (defaults to CWD), and document the safe integration pattern.
- Add integration regression tests and a v0.4.0 migration guide in `CHANGELOG.md`.

Closes #248.

## Test plan

- [x] `cargo clippy -p autoagents-toolkit -p coding_agent --features filesystem --all-targets -- -D warnings`
- [x] `cargo test -p autoagents-toolkit --features filesystem` (52 tests)
- [x] `cargo test -p coding_agent` (4 tests)
- [x] Pre-commit hooks (fmt, clippy, test) passed on commit


Made with [Cursor](https://cursor.com)