### PR TITLE
[FEATURE]: Add WASI Preview2 OpenAI Responses support

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,3 @@
+# Browser WASM (wasm32-unknown-unknown) needs the `wasm_js` getrandom backend.
 [target.wasm32-unknown-unknown]
 rustflags = ["--cfg", 'getrandom_backend="wasm_js"']

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -573,6 +573,7 @@ dependencies = [
  "either",
  "futures",
  "getrandom 0.4.2",
+ "golem-wasi-http",
  "http",
  "http-body-util",
  "httpmock",
@@ -590,6 +591,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "ureq 3.3.0",
+ "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
 ]
@@ -3930,6 +3932,25 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
+name = "golem-wasi-http"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e80794383f6d363e1f756c5ec9fa6ca0459824e54f9eef53b6b03491fb9d166"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "encoding_rs",
+ "http",
+ "mime",
+ "percent-encoding",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "url",
+ "wasip2",
+]
 
 [[package]]
 name = "guardrails-example"
@@ -12228,6 +12249,9 @@ name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+dependencies = [
+ "bitflags 2.12.1",
+]
 
 [[package]]
 name = "wit-bindgen-core"

--- a/crates/autoagents-llm/Cargo.toml
+++ b/crates/autoagents-llm/Cargo.toml
@@ -37,6 +37,24 @@ azure_openai = []
 openrouter = []
 minimax = []
 optim = []
+# WASI Preview2 (`wasm32-wasip2`) HTTP transport for the OpenAI Responses
+# backend via `golem-wasi-http`. Only `openai` + Responses mode is supported, so
+# enabling `wasi-http` implies `openai` (the transport's only consumer); this
+# keeps the `wasi_http` module from becoming dead code when the feature is
+# enabled on its own.
+wasi-http = ["dep:golem-wasi-http", "openai"]
+
+# Examples live under `examples/wasm_smoke/` (a coherent smoke-test suite), so
+# cargo's default flat discovery does not find them; declare them explicitly.
+[[example]]
+name = "wasm_agent"
+path = "examples/wasm_smoke/agent.rs"
+required-features = ["wasi-http", "openai"]
+
+[[example]]
+name = "wasm_mock_server"
+path = "examples/wasm_smoke/mock_server.rs"
+required-features = ["openai"]
 
 [dependencies]
 async-trait = { workspace = true }
@@ -51,6 +69,9 @@ chrono = { workspace = true }
 base64 = { workspace = true }
 either = { workspace = true }
 autoagents-protocol = { workspace = true }
+# `url` is always available so provider base URLs can be parsed without reqwest
+# (required by the WASI Preview2 transport which has no reqwest).
+url = { workspace = true }
 
 # Non-WASM dependencies (only when not targeting wasm32)
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
@@ -61,6 +82,11 @@ ureq = { workspace = true }
 dirs = { workspace = true }
 bytes = { workspace = true }
 
+# WASI Preview2 (wasm32-wasip2) HTTP transport dependencies. Used only by the
+# `wasi-http` feature for the OpenAI Responses backend.
+[target.'cfg(all(target_arch = "wasm32", target_os = "wasi", target_env = "p2"))'.dependencies]
+golem-wasi-http = { version = "0.2.0", features = ["json"], optional = true }
+
 # Browser WASM dependencies (only when targeting wasm32 outside WASI)
 [target.'cfg(all(target_arch = "wasm32", not(target_os = "wasi")))'.dependencies]
 wasm-bindgen = { workspace = true }
@@ -68,12 +94,12 @@ wasm-bindgen-futures = { workspace = true }
 serde-wasm-bindgen = { workspace = true }
 getrandom = { workspace = true, features = ["wasm_js"] }
 
-[dev-dependencies]
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 tempfile = { workspace = true }
-tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 rstest = "0.26"
 bytes = { workspace = true }
 http = "1.2"
 http-body-util = "0.1"
 hyper = "1.5"
 httpmock = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/crates/autoagents-llm/build.rs
+++ b/crates/autoagents-llm/build.rs
@@ -14,6 +14,15 @@
 //! script's `#[cfg]` reflects the **host** platform, which would wrongly light
 //! up `native` when cross-compiling to wasm.
 
+/// Env-var name for the target architecture injected by Cargo.
+const ENV_CARGO_CFG_TARGET_ARCH: &str = "CARGO_CFG_TARGET_ARCH";
+/// Env-var name for the target OS injected by Cargo.
+const ENV_CARGO_CFG_TARGET_OS: &str = "CARGO_CFG_TARGET_OS";
+/// Env-var name for the target environment injected by Cargo.
+const ENV_CARGO_CFG_TARGET_ENV: &str = "CARGO_CFG_TARGET_ENV";
+/// Env-var name for the `wasi-http` feature flag.
+const ENV_CARGO_FEATURE_WASI_HTTP: &str = "CARGO_FEATURE_WASI_HTTP";
+
 fn main() {
     // Declare the cfg flags so a typo is a hard build error (Rust 1.80+).
     println!("cargo::rustc-check-cfg=cfg(native)");
@@ -21,10 +30,10 @@ fn main() {
     println!("cargo::rerun-if-changed=build.rs");
 
     // Target platform injected by cargo (not the host); see module docs.
-    let target_arch = std::env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();
-    let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
-    let target_env = std::env::var("CARGO_CFG_TARGET_ENV").unwrap_or_default();
-    let wasi_http_feature = std::env::var("CARGO_FEATURE_WASI_HTTP").is_ok();
+    let target_arch = std::env::var(ENV_CARGO_CFG_TARGET_ARCH).unwrap_or_default();
+    let target_os = std::env::var(ENV_CARGO_CFG_TARGET_OS).unwrap_or_default();
+    let target_env = std::env::var(ENV_CARGO_CFG_TARGET_ENV).unwrap_or_default();
+    let wasi_http_feature = std::env::var(ENV_CARGO_FEATURE_WASI_HTTP).is_ok();
 
     if target_arch != "wasm32" {
         println!("cargo::rustc-cfg=native");

--- a/crates/autoagents-llm/build.rs
+++ b/crates/autoagents-llm/build.rs
@@ -1,0 +1,38 @@
+//! Build-script cfg aliases for the OpenAI HTTP transports.
+//!
+//! To avoid repeating the long target/feature predicates throughout the crate,
+//! this script derives two cfg flags:
+//!
+//! - `native`    — any non-`wasm32` target (reqwest/ureq, full feature set).
+//! - `wasi_http` — `wasm32-wasip2` with the `wasi-http` feature
+//!   (`golem-wasi-http` over the `wasi:http` interface; OpenAI Responses only).
+//!
+//! Browser wasm (`wasm32-unknown-unknown`) is rejected by `compile_error!` in
+//! `src/lib.rs`, so it never reaches the HTTP code gated here.
+//!
+//! The flags are read from `CARGO_CFG_TARGET_*` rather than `#[cfg]`: a build
+//! script's `#[cfg]` reflects the **host** platform, which would wrongly light
+//! up `native` when cross-compiling to wasm.
+
+fn main() {
+    // Declare the cfg flags so a typo is a hard build error (Rust 1.80+).
+    println!("cargo::rustc-check-cfg=cfg(native)");
+    println!("cargo::rustc-check-cfg=cfg(wasi_http)");
+    println!("cargo::rerun-if-changed=build.rs");
+
+    // Target platform injected by cargo (not the host); see module docs.
+    let target_arch = std::env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();
+    let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+    let target_env = std::env::var("CARGO_CFG_TARGET_ENV").unwrap_or_default();
+    let wasi_http_feature = std::env::var("CARGO_FEATURE_WASI_HTTP").is_ok();
+
+    if target_arch != "wasm32" {
+        println!("cargo::rustc-cfg=native");
+    }
+
+    // The feature is only honored on the matching target so enabling it on a
+    // native build (where it is irrelevant) does not light up the wasm transport.
+    if target_arch == "wasm32" && target_os == "wasi" && target_env == "p2" && wasi_http_feature {
+        println!("cargo::rustc-cfg=wasi_http");
+    }
+}

--- a/crates/autoagents-llm/examples/wasm_smoke/agent.rs
+++ b/crates/autoagents-llm/examples/wasm_smoke/agent.rs
@@ -27,6 +27,15 @@ use autoagents_llm::error::LLMError;
 use futures::StreamExt;
 use serde_json::{Map, Value, json};
 
+// Environment variable names (defined as constants to prevent typos).
+const ENV_BASE_URL: &str = "BASE_URL";
+const ENV_OPENAI_API_KEY: &str = "OPENAI_API_KEY";
+const ENV_MODEL: &str = "MODEL";
+const ENV_REASONING_EFFORT: &str = "REASONING_EFFORT";
+const ENV_REASONING_SUMMARY: &str = "REASONING_SUMMARY";
+const ENV_NON_STREAM_PROMPT: &str = "NON_STREAM_PROMPT";
+const ENV_STREAM_PROMPT: &str = "STREAM_PROMPT";
+
 fn main() {
     if let Err(err) = futures::executor::block_on(run()) {
         eprintln!("WASM provider smoke failed: {err}");
@@ -34,31 +43,74 @@ fn main() {
     }
 }
 
+/// Configuration read from environment variables for the smoke test.
+struct SmokeConfig {
+    api_key: String,
+    base_url: String,
+    model: String,
+    strict_mock_expectations: bool,
+    run_error_test: bool,
+    reasoning_effort: Option<String>,
+    reasoning_summary: Option<String>,
+    non_stream_prompt: String,
+    stream_prompt: String,
+}
+
+/// Reads smoke-test configuration from environment variables.
+fn read_smoke_config() -> SmokeConfig {
+    SmokeConfig {
+        api_key: std::env::var(ENV_OPENAI_API_KEY)
+            .unwrap_or_else(|_| panic!("Please set {ENV_OPENAI_API_KEY} environment variable")),
+        base_url: std::env::var(ENV_BASE_URL)
+            .unwrap_or_else(|_| panic!("Please set {ENV_BASE_URL} environment variable")),
+        model: std::env::var(ENV_MODEL).unwrap_or_else(|_| "gpt-4o".to_string()),
+        strict_mock_expectations: env_flag("STRICT_MOCK_EXPECTATIONS", true),
+        run_error_test: env_flag("RUN_ERROR_TEST", true),
+        reasoning_effort: std::env::var(ENV_REASONING_EFFORT).ok(),
+        reasoning_summary: std::env::var(ENV_REASONING_SUMMARY).ok(),
+        non_stream_prompt: std::env::var(ENV_NON_STREAM_PROMPT)
+            .unwrap_or_else(|_| "Hello from provider-level WASM smoke".to_string()),
+        stream_prompt: std::env::var(ENV_STREAM_PROMPT)
+            .unwrap_or_else(|_| "Hello from provider-level WASM smoke stream".to_string()),
+    }
+}
+
 async fn run() -> Result<(), LLMError> {
-    let base_url = std::env::var("BASE_URL")
-        .unwrap_or_else(|_| panic!("Please set BASE_URL environment variable"));
-    let api_key = std::env::var("OPENAI_API_KEY")
-        .unwrap_or_else(|_| panic!("Please set OPENAI_API_KEY environment variable"));
-    let model = std::env::var("MODEL").unwrap_or_else(|_| "gpt-4o".to_string());
-    let strict_mock_expectations = env_flag("STRICT_MOCK_EXPECTATIONS", true);
-    let run_error_test = env_flag("RUN_ERROR_TEST", true);
-    let reasoning_effort = std::env::var("REASONING_EFFORT").ok();
-    let reasoning_summary = std::env::var("REASONING_SUMMARY").ok();
+    let cfg = read_smoke_config();
 
     let provider = build_provider(
-        api_key,
-        base_url,
-        model,
-        reasoning_effort,
-        reasoning_summary,
+        cfg.api_key,
+        cfg.base_url,
+        cfg.model,
+        cfg.reasoning_effort,
+        cfg.reasoning_summary,
     )?;
 
-    let non_stream_prompt = std::env::var("NON_STREAM_PROMPT")
-        .unwrap_or_else(|_| "Hello from provider-level WASM smoke".to_string());
-    let non_stream_messages = [ChatMessage::user().content(non_stream_prompt).build()];
-    let response = provider
-        .chat_with_tools(&non_stream_messages, None, None)
-        .await?;
+    run_non_stream_smoke(
+        &provider,
+        cfg.strict_mock_expectations,
+        &cfg.non_stream_prompt,
+    )
+    .await?;
+    run_stream_smoke(&provider, cfg.strict_mock_expectations, &cfg.stream_prompt).await?;
+
+    if cfg.run_error_test {
+        run_error_smoke(&provider).await?;
+    } else {
+        println!("PROVIDER_ERROR_429_SKIPPED");
+    }
+
+    Ok(())
+}
+
+/// Performs a non-streaming chat request and validates the response.
+async fn run_non_stream_smoke(
+    provider: &OpenAI,
+    strict_mock_expectations: bool,
+    prompt: &str,
+) -> Result<(), LLMError> {
+    let messages = [ChatMessage::user().content(prompt.to_string()).build()];
+    let response = provider.chat_with_tools(&messages, None, None).await?;
     let text = response.text().unwrap_or_default();
     if strict_mock_expectations && text != "hello from mock" {
         return Err(LLMError::ResponseFormatError {
@@ -76,19 +128,23 @@ async fn run() -> Result<(), LLMError> {
     if !strict_mock_expectations {
         println!("PROVIDER_NON_STREAM_TEXT {}", preview(&text, 240));
     }
+    Ok(())
+}
 
-    let stream_prompt = std::env::var("STREAM_PROMPT")
-        .unwrap_or_else(|_| "Hello from provider-level WASM smoke stream".to_string());
-    let stream_messages = [ChatMessage::user().content(stream_prompt).build()];
-    let mut stream = provider
-        .chat_stream_struct(&stream_messages, None, None)
-        .await?;
+/// Performs a streaming chat request, collects deltas, and validates expected markers.
+async fn run_stream_smoke(
+    provider: &OpenAI,
+    strict_mock_expectations: bool,
+    prompt: &str,
+) -> Result<(), LLMError> {
+    let messages = [ChatMessage::user().content(prompt.to_string()).build()];
+    let mut stream = provider.chat_stream_struct(&messages, None, None).await?;
     let mut saw_text_delta = false;
     let mut saw_reasoning_delta = false;
     let mut saw_tool_call = false;
     let mut saw_usage = false;
-    let mut streamed_text = String::new();
-    let mut streamed_reasoning = String::new();
+    let mut streamed_text = String::default();
+    let mut streamed_reasoning = String::default();
     while let Some(chunk) = stream.next().await {
         let chunk = chunk?;
         if let Some(choice) = chunk.choices.first() {
@@ -110,7 +166,6 @@ async fn run() -> Result<(), LLMError> {
                 .as_ref()
                 .is_some_and(|calls| !calls.is_empty())
             {
-                // Function-call streaming events also prove that the Responses SSE parser ran.
                 saw_tool_call = true;
             }
         }
@@ -123,13 +178,13 @@ async fn run() -> Result<(), LLMError> {
             message: format!(
                 "stream parser did not observe expected mock markers: text={saw_text_delta} reasoning={saw_reasoning_delta} tool_call={saw_tool_call} usage={saw_usage}"
             ),
-            raw_response: String::new(),
+            raw_response: String::default(),
         });
     }
     if !strict_mock_expectations && !saw_text_delta {
         return Err(LLMError::ResponseFormatError {
             message: "real API stream did not produce a text delta".to_string(),
-            raw_response: String::new(),
+            raw_response: String::default(),
         });
     }
     println!(
@@ -144,28 +199,25 @@ async fn run() -> Result<(), LLMError> {
             );
         }
     }
-
-    if run_error_test {
-        let error_messages = [ChatMessage::user()
-            .content("please trigger rate_limit")
-            .build()];
-        match provider.chat_with_tools(&error_messages, None, None).await {
-            Err(err) if err.http_status_code() == Some(429) => {
-                println!("PROVIDER_ERROR_429_OK {err}");
-            }
-            Err(err) => return Err(err),
-            Ok(response) => {
-                return Err(LLMError::ResponseFormatError {
-                    message: "expected provider-level 429 error, got success".to_string(),
-                    raw_response: response.to_string(),
-                });
-            }
-        }
-    } else {
-        println!("PROVIDER_ERROR_429_SKIPPED");
-    }
-
     Ok(())
+}
+
+/// Sends a message designed to trigger a 429 rate-limit error and validates the response.
+async fn run_error_smoke(provider: &OpenAI) -> Result<(), LLMError> {
+    let error_messages = [ChatMessage::user()
+        .content("please trigger rate_limit")
+        .build()];
+    match provider.chat_with_tools(&error_messages, None, None).await {
+        Err(err) if err.http_status_code() == Some(429) => {
+            println!("PROVIDER_ERROR_429_OK {err}");
+            Ok(())
+        }
+        Err(err) => Err(err),
+        Ok(response) => Err(LLMError::ResponseFormatError {
+            message: "expected provider-level 429 error, got success".to_string(),
+            raw_response: response.to_string(),
+        }),
+    }
 }
 
 fn build_provider(

--- a/crates/autoagents-llm/examples/wasm_smoke/agent.rs
+++ b/crates/autoagents-llm/examples/wasm_smoke/agent.rs
@@ -1,0 +1,237 @@
+//! Provider-level WASM smoke test for the OpenAI Responses path on WASI HTTP.
+//!
+//! Build:
+//!   RUSTFLAGS="-C linker=wasm-component-ld" cargo build -p autoagents-llm \
+//!     --target wasm32-wasip2 --features wasi-http,openai --example wasm_agent
+//! Run:
+//!   wasmtime run -W component-model=y -S http=true \
+//!     --env BASE_URL=http://127.0.0.1:18765/v1 \
+//!     --env OPENAI_API_KEY=sk-test \
+//!     target/wasm32-wasip2/debug/examples/wasm_agent.wasm
+//!
+//! Optional environment variables:
+//! - MODEL: model name (defaults to gpt-4o for the local mock)
+//! - STRICT_MOCK_EXPECTATIONS: true by default; set false for real APIs whose
+//!   exact text/reasoning/usage output differs from the local mock
+//! - RUN_ERROR_TEST: true by default; set false for real APIs unless you intend
+//!   to trigger a real 429
+//! - REASONING_EFFORT: optional OpenAI Responses reasoning effort (for example,
+//!   medium) for models/endpoints that expose reasoning deltas
+//! - REASONING_SUMMARY: optional OpenAI Responses reasoning summary mode (for
+//!   example, detailed) for endpoints that stream reasoning summaries
+//! - NON_STREAM_PROMPT / STREAM_PROMPT: optional prompts for real API smoke runs
+
+use autoagents_llm::backends::openai::{OpenAI, OpenAIApiMode};
+use autoagents_llm::chat::{ChatMessage, ChatProvider};
+use autoagents_llm::error::LLMError;
+use futures::StreamExt;
+use serde_json::{Map, Value, json};
+
+fn main() {
+    if let Err(err) = futures::executor::block_on(run()) {
+        eprintln!("WASM provider smoke failed: {err}");
+        std::process::exit(1);
+    }
+}
+
+async fn run() -> Result<(), LLMError> {
+    let base_url = std::env::var("BASE_URL")
+        .unwrap_or_else(|_| panic!("Please set BASE_URL environment variable"));
+    let api_key = std::env::var("OPENAI_API_KEY")
+        .unwrap_or_else(|_| panic!("Please set OPENAI_API_KEY environment variable"));
+    let model = std::env::var("MODEL").unwrap_or_else(|_| "gpt-4o".to_string());
+    let strict_mock_expectations = env_flag("STRICT_MOCK_EXPECTATIONS", true);
+    let run_error_test = env_flag("RUN_ERROR_TEST", true);
+    let reasoning_effort = std::env::var("REASONING_EFFORT").ok();
+    let reasoning_summary = std::env::var("REASONING_SUMMARY").ok();
+
+    let provider = build_provider(
+        api_key,
+        base_url,
+        model,
+        reasoning_effort,
+        reasoning_summary,
+    )?;
+
+    let non_stream_prompt = std::env::var("NON_STREAM_PROMPT")
+        .unwrap_or_else(|_| "Hello from provider-level WASM smoke".to_string());
+    let non_stream_messages = [ChatMessage::user().content(non_stream_prompt).build()];
+    let response = provider
+        .chat_with_tools(&non_stream_messages, None, None)
+        .await?;
+    let text = response.text().unwrap_or_default();
+    if strict_mock_expectations && text != "hello from mock" {
+        return Err(LLMError::ResponseFormatError {
+            message: "unexpected non-streaming provider response text".to_string(),
+            raw_response: text,
+        });
+    }
+    if !strict_mock_expectations && text.trim().is_empty() {
+        return Err(LLMError::ResponseFormatError {
+            message: "real API non-streaming response text was empty".to_string(),
+            raw_response: text,
+        });
+    }
+    println!("PROVIDER_NON_STREAM_OK text_len={}", text.len());
+    if !strict_mock_expectations {
+        println!("PROVIDER_NON_STREAM_TEXT {}", preview(&text, 240));
+    }
+
+    let stream_prompt = std::env::var("STREAM_PROMPT")
+        .unwrap_or_else(|_| "Hello from provider-level WASM smoke stream".to_string());
+    let stream_messages = [ChatMessage::user().content(stream_prompt).build()];
+    let mut stream = provider
+        .chat_stream_struct(&stream_messages, None, None)
+        .await?;
+    let mut saw_text_delta = false;
+    let mut saw_reasoning_delta = false;
+    let mut saw_tool_call = false;
+    let mut saw_usage = false;
+    let mut streamed_text = String::new();
+    let mut streamed_reasoning = String::new();
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk?;
+        if let Some(choice) = chunk.choices.first() {
+            if let Some(content) = choice.delta.content.as_deref()
+                && !content.is_empty()
+            {
+                saw_text_delta = true;
+                streamed_text.push_str(content);
+            }
+            if let Some(reasoning) = choice.delta.reasoning_content.as_deref()
+                && !reasoning.is_empty()
+            {
+                saw_reasoning_delta = true;
+                streamed_reasoning.push_str(reasoning);
+            }
+            if choice
+                .delta
+                .tool_calls
+                .as_ref()
+                .is_some_and(|calls| !calls.is_empty())
+            {
+                // Function-call streaming events also prove that the Responses SSE parser ran.
+                saw_tool_call = true;
+            }
+        }
+        saw_usage |= chunk.usage.is_some();
+    }
+    if strict_mock_expectations
+        && (!saw_text_delta || !saw_reasoning_delta || !saw_tool_call || !saw_usage)
+    {
+        return Err(LLMError::ResponseFormatError {
+            message: format!(
+                "stream parser did not observe expected mock markers: text={saw_text_delta} reasoning={saw_reasoning_delta} tool_call={saw_tool_call} usage={saw_usage}"
+            ),
+            raw_response: String::new(),
+        });
+    }
+    if !strict_mock_expectations && !saw_text_delta {
+        return Err(LLMError::ResponseFormatError {
+            message: "real API stream did not produce a text delta".to_string(),
+            raw_response: String::new(),
+        });
+    }
+    println!(
+        "PROVIDER_STREAM_OK text_delta={saw_text_delta} reasoning_delta={saw_reasoning_delta} tool_call={saw_tool_call} usage={saw_usage}"
+    );
+    if !strict_mock_expectations {
+        println!("PROVIDER_STREAM_TEXT {}", preview(&streamed_text, 240));
+        if saw_reasoning_delta {
+            println!(
+                "PROVIDER_STREAM_REASONING {}",
+                preview(&streamed_reasoning, 240)
+            );
+        }
+    }
+
+    if run_error_test {
+        let error_messages = [ChatMessage::user()
+            .content("please trigger rate_limit")
+            .build()];
+        match provider.chat_with_tools(&error_messages, None, None).await {
+            Err(err) if err.http_status_code() == Some(429) => {
+                println!("PROVIDER_ERROR_429_OK {err}");
+            }
+            Err(err) => return Err(err),
+            Ok(response) => {
+                return Err(LLMError::ResponseFormatError {
+                    message: "expected provider-level 429 error, got success".to_string(),
+                    raw_response: response.to_string(),
+                });
+            }
+        }
+    } else {
+        println!("PROVIDER_ERROR_429_SKIPPED");
+    }
+
+    Ok(())
+}
+
+fn build_provider(
+    api_key: String,
+    base_url: String,
+    model: String,
+    reasoning_effort: Option<String>,
+    reasoning_summary: Option<String>,
+) -> Result<OpenAI, LLMError> {
+    let mut extra_body = Map::new();
+    let native_reasoning_effort = if let Some(summary) = reasoning_summary {
+        let effort = reasoning_effort.unwrap_or_else(|| "medium".to_string());
+        extra_body.insert(
+            "reasoning".to_string(),
+            json!({
+                "effort": effort,
+                "summary": summary,
+            }),
+        );
+        None
+    } else {
+        reasoning_effort
+    };
+    let extra_body = if extra_body.is_empty() {
+        None
+    } else {
+        Some(Value::Object(extra_body))
+    };
+
+    OpenAI::new(
+        api_key,
+        Some(base_url),
+        Some(model),
+        None,
+        None,
+        Some(30),
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        native_reasoning_effort,
+        None,
+        OpenAIApiMode::Responses,
+        extra_body,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+    )
+}
+
+fn env_flag(name: &str, default: bool) -> bool {
+    match std::env::var(name) {
+        Ok(value) => matches!(value.as_str(), "1" | "true" | "TRUE" | "yes" | "YES"),
+        Err(_) => default,
+    }
+}
+
+fn preview(text: &str, max_chars: usize) -> String {
+    let mut preview: String = text.chars().take(max_chars).collect();
+    if text.chars().count() > max_chars {
+        preview.push('…');
+    }
+    preview.replace('\n', "\\n")
+}

--- a/crates/autoagents-llm/examples/wasm_smoke/mock_server.rs
+++ b/crates/autoagents-llm/examples/wasm_smoke/mock_server.rs
@@ -14,6 +14,14 @@ const HOST: &str = "127.0.0.1";
 const PORT: u16 = 18765;
 const RETRY_AFTER_SECONDS: &str = "5";
 
+/// Parsed HTTP request components returned after reading the wire.
+struct ParsedRequest {
+    method: String,
+    path: String,
+    headers: HashMap<String, String>,
+    body: Vec<u8>,
+}
+
 fn main() -> io::Result<()> {
     let listener = TcpListener::bind((HOST, PORT))?;
     eprintln!("[MOCK] Starting mock server on {HOST}:{PORT}");
@@ -38,134 +46,204 @@ fn handle_client(mut stream: TcpStream) -> io::Result<()> {
     let mut data = Vec::new();
     let mut buf = [0_u8; 65_536];
 
+    // Read and parse the HTTP request.
+    let Some((method, path, req_json)) = read_request(&mut stream, &mut data, &mut buf)? else {
+        return Ok(());
+    };
+
+    // Route and write the response.
+    route_response(&mut stream, &method, &path, &req_json)
+}
+
+/// Reads raw bytes until the header terminator is found, then parses the request
+/// line, headers, body, and JSON payload. Returns `None` when an error response
+/// has already been written (e.g. bad request / invalid JSON).
+fn read_request(
+    stream: &mut TcpStream,
+    data: &mut Vec<u8>,
+    buf: &mut [u8; 65_536],
+) -> io::Result<Option<(String, String, Value)>> {
     loop {
-        let n = stream.read(&mut buf)?;
+        let n = stream.read(buf)?;
         if n == 0 {
-            return Ok(());
+            return Ok(None);
         }
         data.extend_from_slice(&buf[..n]);
 
-        let Some(header_end) = find_header_end(&data) else {
+        let Some(header_end) = find_header_end(data) else {
             continue;
         };
 
-        let header_text = String::from_utf8_lossy(&data[..header_end]);
-        let mut lines = header_text.trim().split("\r\n");
-        let Some(request_line) = lines.next() else {
-            send_response(
-                &mut stream,
-                400,
-                "application/json",
-                b"{\"error\":\"bad request\"}",
-                &[],
-            )?;
-            return Ok(());
+        let Some(result) = parse_request(data, header_end, stream, buf)? else {
+            return Ok(None);
         };
 
-        let mut request_parts = request_line.splitn(3, ' ');
-        let method = request_parts.next().unwrap_or_default().to_string();
-        let path = request_parts.next().unwrap_or_default().to_string();
-
-        let mut headers = HashMap::new();
-        for line in lines {
-            if let Some((name, value)) = line.split_once(':') {
-                headers.insert(name.trim().to_ascii_lowercase(), value.trim().to_string());
-            }
-        }
-
-        let body_start = header_end + 4;
-        let is_chunked = headers
-            .get("transfer-encoding")
-            .map(|value| {
-                value
-                    .split(',')
-                    .any(|part| part.trim().eq_ignore_ascii_case("chunked"))
-            })
-            .unwrap_or(false);
-        let content_len = headers
-            .get("content-length")
-            .and_then(|value| value.parse::<usize>().ok())
-            .unwrap_or(0);
-
-        let body = if is_chunked {
-            let mut raw_body = data[body_start..].to_vec();
-            // Deadlock guard: if the complete chunked body arrived together with
-            // the headers, do not perform another blocking read.
-            while !chunked_body_complete(&raw_body) {
-                let n = stream.read(&mut buf)?;
-                if n == 0 {
-                    break;
-                }
-                raw_body.extend_from_slice(&buf[..n]);
-            }
-            decode_chunked(&raw_body)
-        } else if content_len > 0 {
-            let mut body_data = data[body_start..].to_vec();
-            while body_data.len() < content_len {
-                let remaining = content_len - body_data.len();
-                let read_len = remaining.min(buf.len());
-                let n = stream.read(&mut buf[..read_len])?;
-                if n == 0 {
-                    break;
-                }
-                body_data.extend_from_slice(&buf[..n]);
-            }
-            body_data.truncate(content_len);
-            body_data
-        } else {
-            data[body_start..].to_vec()
-        };
+        let req_json = parse_body(stream, &result.body)?;
+        let (method, path) = (result.method, result.path);
 
         eprintln!(
-            "[MOCK] {method} {path} chunked={is_chunked} len={}",
-            body.len()
+            "[MOCK] {method} {path} chunked={} len={}",
+            result
+                .headers
+                .get("transfer-encoding")
+                .map(|v| v.contains("chunked"))
+                .unwrap_or(false),
+            result.body.len()
         );
-
-        let req_json: Value = if body.iter().all(u8::is_ascii_whitespace) {
-            Value::Object(Default::default())
-        } else {
-            match serde_json::from_slice(&body) {
-                Ok(value) => value,
-                Err(err) => {
-                    eprintln!("[MOCK] JSON error: {err}");
-                    send_response(
-                        &mut stream,
-                        400,
-                        "application/json",
-                        b"{\"error\":\"invalid json\"}",
-                        &[],
-                    )?;
-                    return Ok(());
-                }
-            }
-        };
 
         if let Some(object) = req_json.as_object() {
             let keys = object.keys().cloned().collect::<Vec<_>>();
             eprintln!("[MOCK] parsed keys={keys:?}");
         }
 
-        if method == "POST" && path == "/v1/responses" {
-            if req_json.get("test_error").and_then(Value::as_str) == Some("rate_limit")
-                || contains_marker(&req_json, "rate_limit")
-            {
-                send_response(
-                    &mut stream,
-                    429,
-                    "application/json",
-                    b"{\"error\":\"rate limited\"}\n",
-                    &[("Retry-After", RETRY_AFTER_SECONDS)],
-                )?;
-            } else if req_json
-                .get("stream")
-                .and_then(Value::as_bool)
-                .unwrap_or(false)
-            {
-                send_response(
-                    &mut stream,
-                    200,
-                    "text/event-stream",
-                    br#"data: {"type":"response.output_text.delta","delta":"hello "}
+        return Ok(Some((method, path, req_json)));
+    }
+}
+
+/// Parses the request line and headers from the received data. Returns
+/// `(method, path, headers, body_bytes)` or sends an error response and
+/// returns `None` if the request line is missing.
+fn parse_request(
+    data: &[u8],
+    header_end: usize,
+    stream: &mut TcpStream,
+    buf: &mut [u8; 65_536],
+) -> io::Result<Option<ParsedRequest>> {
+    let header_text = String::from_utf8_lossy(&data[..header_end]);
+    let mut lines = header_text.trim().lines();
+    let Some(request_line) = lines.next() else {
+        send_response(
+            stream,
+            400,
+            "application/json",
+            b"{\"error\":\"bad request\"}",
+            &[],
+        )?;
+        return Ok(None);
+    };
+
+    let mut request_parts = request_line.splitn(3, ' ');
+    let method = request_parts.next().unwrap_or_default().to_string();
+    let path = request_parts.next().unwrap_or_default().to_string();
+
+    let mut headers = HashMap::new();
+    for line in lines {
+        if let Some((name, value)) = line.split_once(':') {
+            headers.insert(name.trim().to_ascii_lowercase(), value.trim().to_string());
+        }
+    }
+
+    let body = extract_body(data, header_end, stream, &headers, buf)?;
+
+    Ok(Some(ParsedRequest {
+        method,
+        path,
+        headers,
+        body,
+    }))
+}
+
+/// Reads the HTTP body from the data buffer (and optionally the stream) based on
+/// Transfer-Encoding or Content-Length.
+fn extract_body(
+    data: &[u8],
+    header_end: usize,
+    stream: &mut TcpStream,
+    headers: &HashMap<String, String>,
+    buf: &mut [u8; 65_536],
+) -> io::Result<Vec<u8>> {
+    let body_start = header_end + 4;
+    let is_chunked = headers.get("transfer-encoding").is_some_and(|value| {
+        value
+            .split(',')
+            .any(|part| part.trim().eq_ignore_ascii_case("chunked"))
+    });
+    let content_len = headers
+        .get("content-length")
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(0);
+
+    if is_chunked {
+        let mut raw_body = data[body_start..].to_vec();
+        while !chunked_body_complete(&raw_body) {
+            let n = stream.read(buf)?;
+            if n == 0 {
+                break;
+            }
+            raw_body.extend_from_slice(&buf[..n]);
+        }
+        Ok(decode_chunked(&raw_body))
+    } else if content_len > 0 {
+        let mut body_data = data[body_start..].to_vec();
+        while body_data.len() < content_len {
+            let remaining = content_len - body_data.len();
+            let read_len = remaining.min(buf.len());
+            let n = stream.read(&mut buf[..read_len])?;
+            if n == 0 {
+                break;
+            }
+            body_data.extend_from_slice(&buf[..n]);
+        }
+        body_data.truncate(content_len);
+        Ok(body_data)
+    } else {
+        Ok(data[body_start..].to_vec())
+    }
+}
+
+/// Tries to parse the body bytes as JSON. Returns `Value::Object(Map::default())`
+/// for empty/whitespace-only bodies.
+fn parse_body(stream: &mut TcpStream, body: &[u8]) -> io::Result<Value> {
+    if body.iter().all(u8::is_ascii_whitespace) {
+        return Ok(Value::Object(serde_json::Map::<String, Value>::default()));
+    }
+    match serde_json::from_slice(body) {
+        Ok(value) => Ok(value),
+        Err(err) => {
+            eprintln!("[MOCK] JSON error: {err}");
+            send_response(
+                stream,
+                400,
+                "application/json",
+                b"{\"error\":\"invalid json\"}",
+                &[],
+            )?;
+            Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "invalid JSON body",
+            ))
+        }
+    }
+}
+
+/// Routes the parsed request to the appropriate response handler.
+fn route_response(
+    stream: &mut TcpStream,
+    method: &str,
+    path: &str,
+    req_json: &Value,
+) -> io::Result<()> {
+    if method == "POST" && path == "/v1/responses" {
+        if req_json.get("test_error").and_then(Value::as_str) == Some("rate_limit")
+            || contains_marker(req_json, "rate_limit")
+        {
+            send_response(
+                stream,
+                429,
+                "application/json",
+                b"{\"error\":\"rate limited\"}\n",
+                &[("Retry-After", RETRY_AFTER_SECONDS)],
+            )
+        } else if req_json
+            .get("stream")
+            .and_then(Value::as_bool)
+            .unwrap_or(false)
+        {
+            send_response(
+                stream,
+                200,
+                "text/event-stream",
+                br#"data: {"type":"response.output_text.delta","delta":"hello "}
 
 data: {"type":"response.reasoning_text.delta","delta":"think"}
 
@@ -178,14 +256,14 @@ data: {"type":"response.done","response":{"usage":{"input_tokens":2,"output_toke
 data: [DONE]
 
 "#,
-                    &[("Cache-Control", "no-cache")],
-                )?;
-            } else {
-                send_response(
-                    &mut stream,
-                    200,
-                    "application/json",
-                    br#"{
+                &[("Cache-Control", "no-cache")],
+            )
+        } else {
+            send_response(
+                stream,
+                200,
+                "application/json",
+                br#"{
   "output": [
     {
       "type": "reasoning",
@@ -218,20 +296,17 @@ data: [DONE]
   }
 }
 "#,
-                    &[],
-                )?;
-            }
-        } else {
-            send_response(
-                &mut stream,
-                404,
-                "application/json",
-                b"{\"error\":\"not found\"}",
                 &[],
-            )?;
+            )
         }
-
-        return Ok(());
+    } else {
+        send_response(
+            stream,
+            404,
+            "application/json",
+            b"{\"error\":\"not found\"}",
+            &[],
+        )
     }
 }
 

--- a/crates/autoagents-llm/examples/wasm_smoke/mock_server.rs
+++ b/crates/autoagents-llm/examples/wasm_smoke/mock_server.rs
@@ -1,0 +1,339 @@
+//! Mock OpenAI Responses API server for provider-level WASM smoke tests.
+//!
+//! This intentionally uses only `std::net` + `std::io` for HTTP request parsing
+//! so the smoke test exercises the WASI HTTP client against raw socket I/O
+//! without adding a test-server runtime dependency.
+
+use serde_json::Value;
+use std::collections::HashMap;
+use std::io::{self, Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::thread;
+
+const HOST: &str = "127.0.0.1";
+const PORT: u16 = 18765;
+const RETRY_AFTER_SECONDS: &str = "5";
+
+fn main() -> io::Result<()> {
+    let listener = TcpListener::bind((HOST, PORT))?;
+    eprintln!("[MOCK] Starting mock server on {HOST}:{PORT}");
+
+    for stream in listener.incoming() {
+        match stream {
+            Ok(stream) => {
+                thread::spawn(|| {
+                    if let Err(err) = handle_client(stream) {
+                        eprintln!("[MOCK] Error: {err}");
+                    }
+                });
+            }
+            Err(err) => eprintln!("[MOCK] accept error: {err}"),
+        }
+    }
+
+    Ok(())
+}
+
+fn handle_client(mut stream: TcpStream) -> io::Result<()> {
+    let mut data = Vec::new();
+    let mut buf = [0_u8; 65_536];
+
+    loop {
+        let n = stream.read(&mut buf)?;
+        if n == 0 {
+            return Ok(());
+        }
+        data.extend_from_slice(&buf[..n]);
+
+        let Some(header_end) = find_header_end(&data) else {
+            continue;
+        };
+
+        let header_text = String::from_utf8_lossy(&data[..header_end]);
+        let mut lines = header_text.trim().split("\r\n");
+        let Some(request_line) = lines.next() else {
+            send_response(
+                &mut stream,
+                400,
+                "application/json",
+                b"{\"error\":\"bad request\"}",
+                &[],
+            )?;
+            return Ok(());
+        };
+
+        let mut request_parts = request_line.splitn(3, ' ');
+        let method = request_parts.next().unwrap_or_default().to_string();
+        let path = request_parts.next().unwrap_or_default().to_string();
+
+        let mut headers = HashMap::new();
+        for line in lines {
+            if let Some((name, value)) = line.split_once(':') {
+                headers.insert(name.trim().to_ascii_lowercase(), value.trim().to_string());
+            }
+        }
+
+        let body_start = header_end + 4;
+        let is_chunked = headers
+            .get("transfer-encoding")
+            .map(|value| {
+                value
+                    .split(',')
+                    .any(|part| part.trim().eq_ignore_ascii_case("chunked"))
+            })
+            .unwrap_or(false);
+        let content_len = headers
+            .get("content-length")
+            .and_then(|value| value.parse::<usize>().ok())
+            .unwrap_or(0);
+
+        let body = if is_chunked {
+            let mut raw_body = data[body_start..].to_vec();
+            // Deadlock guard: if the complete chunked body arrived together with
+            // the headers, do not perform another blocking read.
+            while !chunked_body_complete(&raw_body) {
+                let n = stream.read(&mut buf)?;
+                if n == 0 {
+                    break;
+                }
+                raw_body.extend_from_slice(&buf[..n]);
+            }
+            decode_chunked(&raw_body)
+        } else if content_len > 0 {
+            let mut body_data = data[body_start..].to_vec();
+            while body_data.len() < content_len {
+                let remaining = content_len - body_data.len();
+                let read_len = remaining.min(buf.len());
+                let n = stream.read(&mut buf[..read_len])?;
+                if n == 0 {
+                    break;
+                }
+                body_data.extend_from_slice(&buf[..n]);
+            }
+            body_data.truncate(content_len);
+            body_data
+        } else {
+            data[body_start..].to_vec()
+        };
+
+        eprintln!(
+            "[MOCK] {method} {path} chunked={is_chunked} len={}",
+            body.len()
+        );
+
+        let req_json: Value = if body.iter().all(u8::is_ascii_whitespace) {
+            Value::Object(Default::default())
+        } else {
+            match serde_json::from_slice(&body) {
+                Ok(value) => value,
+                Err(err) => {
+                    eprintln!("[MOCK] JSON error: {err}");
+                    send_response(
+                        &mut stream,
+                        400,
+                        "application/json",
+                        b"{\"error\":\"invalid json\"}",
+                        &[],
+                    )?;
+                    return Ok(());
+                }
+            }
+        };
+
+        if let Some(object) = req_json.as_object() {
+            let keys = object.keys().cloned().collect::<Vec<_>>();
+            eprintln!("[MOCK] parsed keys={keys:?}");
+        }
+
+        if method == "POST" && path == "/v1/responses" {
+            if req_json.get("test_error").and_then(Value::as_str) == Some("rate_limit")
+                || contains_marker(&req_json, "rate_limit")
+            {
+                send_response(
+                    &mut stream,
+                    429,
+                    "application/json",
+                    b"{\"error\":\"rate limited\"}\n",
+                    &[("Retry-After", RETRY_AFTER_SECONDS)],
+                )?;
+            } else if req_json
+                .get("stream")
+                .and_then(Value::as_bool)
+                .unwrap_or(false)
+            {
+                send_response(
+                    &mut stream,
+                    200,
+                    "text/event-stream",
+                    br#"data: {"type":"response.output_text.delta","delta":"hello "}
+
+data: {"type":"response.reasoning_text.delta","delta":"think"}
+
+data: {"type":"response.output_item.added","output_index":0,"item":{"type":"function_call","id":"fc_1","call_id":"call_1","name":"lookup","arguments":""}}
+
+data: {"type":"response.function_call_arguments.done","output_index":0,"item":{"type":"function_call","id":"fc_1","call_id":"call_1","name":"lookup","arguments":"{\"q\":\"value\"}"}}
+
+data: {"type":"response.done","response":{"usage":{"input_tokens":2,"output_tokens":3,"total_tokens":5}}}
+
+data: [DONE]
+
+"#,
+                    &[("Cache-Control", "no-cache")],
+                )?;
+            } else {
+                send_response(
+                    &mut stream,
+                    200,
+                    "application/json",
+                    br#"{
+  "output": [
+    {
+      "type": "reasoning",
+      "summary": [
+        {
+          "text": "plan"
+        }
+      ]
+    },
+    {
+      "type": "function_call",
+      "name": "lookup",
+      "arguments": "{\"q\":\"value\"}",
+      "call_id": "call_1"
+    },
+    {
+      "type": "message",
+      "content": [
+        {
+          "type": "output_text",
+          "text": "hello from mock"
+        }
+      ]
+    }
+  ],
+  "usage": {
+    "input_tokens": 2,
+    "output_tokens": 3,
+    "total_tokens": 5
+  }
+}
+"#,
+                    &[],
+                )?;
+            }
+        } else {
+            send_response(
+                &mut stream,
+                404,
+                "application/json",
+                b"{\"error\":\"not found\"}",
+                &[],
+            )?;
+        }
+
+        return Ok(());
+    }
+}
+
+fn find_header_end(data: &[u8]) -> Option<usize> {
+    data.windows(4).position(|window| window == b"\r\n\r\n")
+}
+
+fn chunked_body_complete(body: &[u8]) -> bool {
+    let mut pos = 0;
+    while pos < body.len() {
+        let Some(size_end_rel) = body[pos..].windows(2).position(|w| w == b"\r\n") else {
+            return false;
+        };
+        let size_end = pos + size_end_rel;
+        let size_line = String::from_utf8_lossy(&body[pos..size_end]);
+        let size_hex = size_line.split(';').next().unwrap_or_default().trim();
+        let Ok(size) = usize::from_str_radix(size_hex, 16) else {
+            return false;
+        };
+        pos = size_end + 2;
+
+        if size == 0 {
+            return body[pos..].windows(2).any(|w| w == b"\r\n") || pos == body.len();
+        }
+
+        if body.len() < pos + size + 2 {
+            return false;
+        }
+        pos += size;
+        if body.get(pos..pos + 2) != Some(b"\r\n") {
+            return false;
+        }
+        pos += 2;
+    }
+
+    false
+}
+
+fn decode_chunked(body: &[u8]) -> Vec<u8> {
+    let mut decoded = Vec::new();
+    let mut pos = 0;
+
+    while pos < body.len() {
+        let Some(size_end_rel) = body[pos..].windows(2).position(|w| w == b"\r\n") else {
+            break;
+        };
+        let size_end = pos + size_end_rel;
+        let size_line = String::from_utf8_lossy(&body[pos..size_end]);
+        let size_hex = size_line.split(';').next().unwrap_or_default().trim();
+        let Ok(size) = usize::from_str_radix(size_hex, 16) else {
+            break;
+        };
+        pos = size_end + 2;
+
+        if size == 0 {
+            break;
+        }
+        if body.len() < pos + size {
+            break;
+        }
+        decoded.extend_from_slice(&body[pos..pos + size]);
+        pos += size;
+        if body.get(pos..pos + 2) == Some(b"\r\n") {
+            pos += 2;
+        }
+    }
+
+    decoded
+}
+
+fn contains_marker(value: &Value, marker: &str) -> bool {
+    match value {
+        Value::String(text) => text.contains(marker),
+        Value::Array(items) => items.iter().any(|item| contains_marker(item, marker)),
+        Value::Object(map) => map.values().any(|item| contains_marker(item, marker)),
+        _ => false,
+    }
+}
+
+fn send_response(
+    stream: &mut TcpStream,
+    status: u16,
+    content_type: &str,
+    body: &[u8],
+    extra_headers: &[(&str, &str)],
+) -> io::Result<()> {
+    let status_text = match status {
+        200 => "OK",
+        400 => "Bad Request",
+        404 => "Not Found",
+        429 => "Too Many Requests",
+        _ => "Unknown",
+    };
+
+    write!(
+        stream,
+        "HTTP/1.1 {status} {status_text}\r\nContent-Type: {content_type}\r\nConnection: close\r\n"
+    )?;
+    for (name, value) in extra_headers {
+        write!(stream, "{name}: {value}\r\n")?;
+    }
+    write!(stream, "Content-Length: {}\r\n\r\n", body.len())?;
+    stream.write_all(body)?;
+    stream.flush()
+}

--- a/crates/autoagents-llm/examples/wasm_smoke/run.sh
+++ b/crates/autoagents-llm/examples/wasm_smoke/run.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+CRATE_DIR="$ROOT_DIR/crates/autoagents-llm"
+BASE_URL="http://127.0.0.1:18765/v1"
+WASM_PATH="$ROOT_DIR/target/wasm32-wasip2/debug/examples/wasm_agent.wasm"
+
+missing=()
+command -v cargo >/dev/null 2>&1 || missing+=(cargo)
+command -v wasmtime >/dev/null 2>&1 || missing+=(wasmtime)
+command -v wasm-component-ld >/dev/null 2>&1 || missing+=(wasm-component-ld)
+if ! rustup target list --installed 2>/dev/null | grep -qx 'wasm32-wasip2'; then
+  missing+=(rust-target-wasm32-wasip2)
+fi
+
+if ((${#missing[@]})); then
+  printf 'SKIP: missing prerequisites: %s\n' "${missing[*]}" >&2
+  exit 2
+fi
+
+server_log="$(mktemp)"
+stdout_log="$(mktemp)"
+cleanup() {
+  if [[ -n "${server_pid:-}" ]]; then
+    kill "$server_pid" >/dev/null 2>&1 || true
+    wait "$server_pid" >/dev/null 2>&1 || true
+  fi
+  rm -f "$server_log" "$stdout_log"
+}
+trap cleanup EXIT
+
+(
+  cd "$ROOT_DIR"
+  cargo run -p autoagents-llm --features openai,wasi-http --example wasm_mock_server
+) >"$server_log" 2>&1 &
+server_pid=$!
+
+for _ in {1..300}; do
+  if grep -q "Starting mock server" "$server_log"; then
+    break
+  fi
+  if ! kill -0 "$server_pid" >/dev/null 2>&1; then
+    printf 'mock server exited early:\n' >&2
+    cat "$server_log" >&2
+    exit 1
+  fi
+  sleep 0.1
+done
+if ! grep -q "Starting mock server" "$server_log"; then
+  printf 'mock server did not become ready:\n' >&2
+  cat "$server_log" >&2
+  exit 1
+fi
+
+(
+  cd "$ROOT_DIR"
+  # Link as a WebAssembly *component* (not a plain module): the `wasi:http`
+  # imports the agent uses are component-model interfaces, so the default
+  # module linker would fail to resolve them at runtime.
+  RUSTFLAGS='-C linker=wasm-component-ld' \
+    cargo build -p autoagents-llm --target wasm32-wasip2 --features wasi-http,openai --example wasm_agent
+
+  wasmtime run -W component-model=y -S http=true \
+    --env BASE_URL="$BASE_URL" \
+    --env OPENAI_API_KEY=sk-test \
+    --env STRICT_MOCK_EXPECTATIONS=true \
+    --env RUN_ERROR_TEST=true \
+    "$WASM_PATH"
+) | tee "$stdout_log"
+
+grep -q 'PROVIDER_NON_STREAM_OK' "$stdout_log"
+grep -q 'PROVIDER_STREAM_OK text_delta=true reasoning_delta=true tool_call=true usage=true' "$stdout_log"
+grep -q 'PROVIDER_ERROR_429_OK' "$stdout_log"
+
+printf 'WASM_SMOKE_OK\n'

--- a/crates/autoagents-llm/src/backends/mod.rs
+++ b/crates/autoagents-llm/src/backends/mod.rs
@@ -1,4 +1,23 @@
-#[cfg(all(feature = "openai", not(target_arch = "wasm32")))]
+// On native targets every backend is available as before. On WASI Preview2
+// (`wasm32-wasip2`) only the OpenAI Responses backend is wired up (via the
+// `wasi-http` feature); the other HTTP backends remain native-only for now.
+//
+// The module-level cfg guards below ensure the OpenAI backend compiles on
+// `wasm32-wasip2` only when the `wasi-http` feature is enabled. The crate-level
+// `compile_error!`s in `lib.rs` make the unsupported combinations fail loudly.
+
+#[cfg(all(
+    feature = "openai",
+    any(
+        not(target_arch = "wasm32"),
+        all(
+            target_arch = "wasm32",
+            target_os = "wasi",
+            target_env = "p2",
+            feature = "wasi-http"
+        )
+    )
+))]
 pub mod openai;
 
 #[cfg(all(feature = "anthropic", not(target_arch = "wasm32")))]

--- a/crates/autoagents-llm/src/backends/openai.rs
+++ b/crates/autoagents-llm/src/backends/openai.rs
@@ -1918,6 +1918,21 @@ impl OpenAI {
     }
 }
 
+/// Flushes any remaining buffered bytes as a final SSE event candidate when
+/// the stream reaches EOF without a trailing `\n\n` delimiter.
+#[cfg(wasi_http)]
+fn responses_eof_flush(
+    buffer: &mut Vec<u8>,
+    state: &mut ResponsesStreamState,
+) -> Result<Vec<StreamChunk>, LLMError> {
+    if buffer.is_empty() {
+        return Ok(Vec::new());
+    }
+    let event_bytes = std::mem::take(buffer);
+    let event = String::from_utf8_lossy(&event_bytes).into_owned();
+    parse_responses_sse_event(event.trim(), state)
+}
+
 /// Incremental SSE parser over a WASI HTTP response body; the WASI Preview2
 /// counterpart of [`create_responses_tool_stream`].
 ///
@@ -2001,11 +2016,25 @@ impl Stream for WasiResponsesStream {
                     // loop back to parse the freshly buffered bytes
                 }
                 Ok(None) => {
-                    // EOF. Any trailing bytes without a final `\n\n` delimiter
-                    // are dropped, matching the native `bytes_stream().scan()`
-                    // behavior (which only parses on boundary).
+                    // EOF. Flush any remaining buffered bytes as a final event
+                    // candidate so that a last SSE event without a trailing
+                    // `\n\n` delimiter is still parsed.
                     self.finished = true;
-                    return std::task::Poll::Ready(None);
+                    match responses_eof_flush(&mut self.buffer, &mut self.state) {
+                        Ok(chunks) if chunks.is_empty() => {
+                            return std::task::Poll::Ready(None);
+                        }
+                        Ok(chunks) => {
+                            self.pending.extend(chunks);
+                            if let Some(chunk) = self.pending.pop_front() {
+                                return std::task::Poll::Ready(Some(Ok(chunk)));
+                            }
+                            return std::task::Poll::Ready(None);
+                        }
+                        Err(err) => {
+                            return std::task::Poll::Ready(Some(Err(err)));
+                        }
+                    }
                 }
                 Err(err) => {
                     self.finished = true;
@@ -3218,5 +3247,65 @@ data: [DONE]
         );
         assert!(stream.next().await.is_none());
         stream_mock.assert();
+    }
+
+    // ── EOF flush tests (WASI-only) ──────────────────────────────────
+
+    #[cfg(wasi_http)]
+    #[test]
+    fn test_responses_eof_flush_valid_event() {
+        let mut buffer =
+            b"data: {\"type\":\"response.output_text.delta\",\"delta\":\"Hello\"}".to_vec();
+        let mut state = ResponsesStreamState::default();
+
+        let chunks =
+            responses_eof_flush(&mut buffer, &mut state).expect("eof flush should succeed");
+        assert_eq!(chunks.len(), 1);
+        assert!(matches!(&chunks[0], StreamChunk::Text(text) if text == "Hello"));
+        assert!(buffer.is_empty(), "buffer should be cleared after flush");
+    }
+
+    #[cfg(wasi_http)]
+    #[test]
+    fn test_responses_eof_flush_done_with_usage() {
+        let mut buffer =
+            br#"data: {"type":"response.done","response":{"usage":{"input_tokens":2,"output_tokens":3,"total_tokens":5}}}"#
+                .to_vec();
+        let mut state = ResponsesStreamState::default();
+
+        let chunks =
+            responses_eof_flush(&mut buffer, &mut state).expect("eof flush should succeed");
+        assert_eq!(chunks.len(), 2);
+        assert!(matches!(&chunks[0], StreamChunk::Usage(usage) if usage.total_tokens == 5));
+        assert!(
+            matches!(&chunks[1], StreamChunk::Done { stop_reason } if stop_reason == "end_turn")
+        );
+        assert!(buffer.is_empty(), "buffer should be cleared after flush");
+    }
+
+    #[cfg(wasi_http)]
+    #[test]
+    fn test_responses_eof_flush_garbage_event() {
+        let mut buffer = b"data: not-valid-json-trailing-garbage".to_vec();
+        let mut state = ResponsesStreamState::default();
+
+        let err = responses_eof_flush(&mut buffer, &mut state)
+            .expect_err("eof flush should fail on garbage");
+        assert!(err.to_string().contains("not-valid-json-trailing-garbage"));
+        assert!(
+            buffer.is_empty(),
+            "buffer should be cleared after failed flush"
+        );
+    }
+
+    #[cfg(wasi_http)]
+    #[test]
+    fn test_responses_eof_flush_empty_buffer() {
+        let mut buffer = Vec::new();
+        let mut state = ResponsesStreamState::default();
+
+        let chunks = responses_eof_flush(&mut buffer, &mut state)
+            .expect("eof flush on empty buffer should succeed");
+        assert!(chunks.is_empty());
     }
 }

--- a/crates/autoagents-llm/src/backends/openai.rs
+++ b/crates/autoagents-llm/src/backends/openai.rs
@@ -2,31 +2,47 @@
 //!
 //! This module provides integration with OpenAI's GPT models through their API.
 
-use crate::builder::{LLMBackend, LLMBuilder};
+#[cfg(native)]
+use crate::builder::LLMBackend;
+use crate::builder::LLMBuilder;
 use crate::chat::Usage;
+// Available wherever OpenAI streaming is wired up: native (reqwest SSE) and
+// WASI Preview2 + `wasi-http` (blocking `InputStream` SSE).
+#[cfg(any(native, wasi_http))]
+use crate::chat::{StreamChoice, StreamChunk, StreamDelta, StreamResponse};
 use crate::embedding::EmbeddingBuilder;
+#[cfg(native)]
 use crate::http::ensure_success;
+#[cfg(wasi_http)]
+use crate::http::map_http_status_to_error;
+#[cfg(native)]
+use crate::models::StandardModelListResponse;
+#[cfg(native)]
 use crate::providers::openai_compatible::{
-    OpenAIChatMessage, OpenAIChatResponse, OpenAICompatibleProvider, OpenAIProviderConfig,
-    OpenAIResponseFormat, OpenAIStreamOptions, create_sse_stream,
+    OpenAIChatMessage, OpenAIChatResponse, OpenAIResponseFormat, OpenAIStreamOptions,
+    create_sse_stream,
 };
+use crate::providers::openai_compatible::{OpenAICompatibleProvider, OpenAIProviderConfig};
 use crate::{
     FunctionCall, LLMProvider, ToolCall,
     chat::{
-        ChatMessage, ChatProvider, ChatResponse, ChatRole, MessageType, StreamChoice, StreamChunk,
-        StreamDelta, StreamResponse, StructuredOutputFormat, Tool, ToolChoice,
+        ChatMessage, ChatProvider, ChatResponse, ChatRole, MessageType, StructuredOutputFormat,
+        Tool, ToolChoice,
     },
     completion::{CompletionProvider, CompletionRequest, CompletionResponse},
     embedding::EmbeddingProvider,
     error::LLMError,
-    models::{ModelListRequest, ModelListResponse, ModelsProvider, StandardModelListResponse},
+    models::{ModelListRequest, ModelListResponse, ModelsProvider},
 };
 use async_trait::async_trait;
 use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64};
+#[cfg(any(native, wasi_http))]
 use futures::{Stream, StreamExt};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+#[cfg(any(native, wasi_http))]
 use std::collections::HashMap;
+#[cfg(any(native, wasi_http))]
 use std::pin::Pin;
 use std::sync::Arc;
 
@@ -73,6 +89,7 @@ pub struct OpenAI {
 }
 
 /// Legacy chat/completions tool representation.
+#[cfg(native)]
 #[derive(Serialize, Debug)]
 #[serde(untagged)]
 pub enum OpenAITool {
@@ -125,6 +142,7 @@ pub struct ApproximateLocation {
 }
 
 /// Request payload for OpenAI's chat/completions endpoint.
+#[cfg(native)]
 #[derive(Serialize, Debug)]
 pub struct OpenAIAPIChatRequest<'a> {
     pub model: &'a str,
@@ -524,6 +542,10 @@ fn schema_is_nullable(schema: &Value) -> bool {
         .is_some_and(|variants| variants.iter().any(schema_is_nullable))
 }
 
+// Transport-agnostic Responses SSE state machine: `create_responses_tool_stream`
+// (native) and `WasiResponsesStream` (WASI) both feed bytes into the shared
+// parser below.
+#[cfg(any(native, wasi_http))]
 #[derive(Debug, Default)]
 struct ResponsesToolCallState {
     call_id: String,
@@ -533,6 +555,7 @@ struct ResponsesToolCallState {
     started: bool,
 }
 
+#[cfg(any(native, wasi_http))]
 #[derive(Debug, Default)]
 struct ResponsesStreamState {
     tool_states: HashMap<usize, ResponsesToolCallState>,
@@ -604,6 +627,7 @@ impl OpenAI {
     }
 }
 
+#[cfg(native)]
 #[derive(Serialize)]
 struct OpenAIEmbeddingRequest {
     model: String,
@@ -614,16 +638,23 @@ struct OpenAIEmbeddingRequest {
     dimensions: Option<u32>,
 }
 
+#[cfg(native)]
 #[derive(Deserialize, Debug)]
 struct OpenAIEmbeddingData {
     embedding: Vec<f32>,
 }
 
+#[cfg(native)]
 #[derive(Deserialize, Debug)]
 struct OpenAIEmbeddingResponse {
     data: Vec<OpenAIEmbeddingData>,
 }
 
+// `chat_with_tools` / `chat_with_web_search` / `model` are available on every
+// target the OpenAI backend compiles for (native + WASI Preview2). The
+// streaming overrides are native-only; on WASI Preview2 they are absent from
+// this impl block, so the `ChatProvider` trait's default `Generic("... not
+// supported ...")` implementations apply automatically.
 #[async_trait]
 impl ChatProvider for OpenAI {
     async fn chat_with_tools(
@@ -638,8 +669,15 @@ impl ChatProvider for OpenAI {
                     .await
             }
             OpenAIApiMode::ChatCompletions => {
-                self.chat_with_tools_legacy(messages, tools, json_schema)
-                    .await
+                #[cfg(native)]
+                {
+                    self.chat_with_tools_legacy(messages, tools, json_schema)
+                        .await
+                }
+                #[cfg(wasi_http)]
+                {
+                    Err(Self::wasi_unsupported("OpenAI ChatCompletions API mode"))
+                }
             }
         }
     }
@@ -650,6 +688,13 @@ impl ChatProvider for OpenAI {
             .await
     }
 
+    /// Streaming chat: emits text-content deltas as plain `String` chunks.
+    ///
+    /// On native this uses `reqwest` SSE; on WASI Preview2 + `wasi-http` it
+    /// reads the SSE response body via blocking `InputStream` reads. On other
+    /// targets (e.g. WASI Preview1) this override is absent and the trait
+    /// default ("not supported") applies.
+    #[cfg(any(native, wasi_http))]
     async fn chat_stream(
         &self,
         messages: &[ChatMessage],
@@ -673,6 +718,15 @@ impl ChatProvider for OpenAI {
         Ok(Box::pin(content_stream))
     }
 
+    /// Structured streaming: emits [`StreamResponse`] chunks that mimic the
+    /// OpenAI streaming shape (`.choices[0].delta.*` + optional `.usage`).
+    ///
+    /// The `StreamChunk` -> `StreamResponse` mapping is shared across
+    /// transports via [`responses_chunk_stream_to_struct_stream`]; only the
+    /// source of the chunk stream differs (reqwest SSE on native, blocking
+    /// `InputStream` SSE on WASI Preview2 + `wasi-http`). On other targets
+    /// this override is absent and the trait default applies.
+    #[cfg(any(native, wasi_http))]
     async fn chat_stream_struct(
         &self,
         messages: &[ChatMessage],
@@ -682,68 +736,40 @@ impl ChatProvider for OpenAI {
     {
         match self.api_mode {
             OpenAIApiMode::Responses => {
+                // Only the chunk-stream source differs between transports;
+                // the `StreamChunk` -> `StreamResponse` projection is shared.
+                #[cfg(native)]
                 let chunk_stream = self
                     .chat_stream_with_tools_responses(messages, tools, json_schema)
                     .await?;
-                let struct_stream = chunk_stream.filter_map(|result| async move {
-                    match result {
-                        Ok(StreamChunk::Text(content)) => Some(Ok(StreamResponse {
-                            choices: vec![StreamChoice {
-                                delta: StreamDelta {
-                                    content: Some(content),
-                                    reasoning_content: None,
-                                    tool_calls: None,
-                                },
-                            }],
-                            usage: None,
-                        })),
-                        Ok(StreamChunk::ReasoningContent(content)) => Some(Ok(StreamResponse {
-                            choices: vec![StreamChoice {
-                                delta: StreamDelta {
-                                    content: None,
-                                    reasoning_content: Some(content),
-                                    tool_calls: None,
-                                },
-                            }],
-                            usage: None,
-                        })),
-                        Ok(StreamChunk::ToolUseComplete { tool_call, .. }) => {
-                            Some(Ok(StreamResponse {
-                                choices: vec![StreamChoice {
-                                    delta: StreamDelta {
-                                        content: None,
-                                        reasoning_content: None,
-                                        tool_calls: Some(vec![tool_call]),
-                                    },
-                                }],
-                                usage: None,
-                            }))
-                        }
-                        Ok(StreamChunk::Usage(usage)) => Some(Ok(StreamResponse {
-                            choices: vec![StreamChoice {
-                                delta: StreamDelta {
-                                    content: None,
-                                    reasoning_content: None,
-                                    tool_calls: None,
-                                },
-                            }],
-                            usage: Some(usage),
-                        })),
-                        Ok(StreamChunk::Done { .. })
-                        | Ok(StreamChunk::ToolUseStart { .. })
-                        | Ok(StreamChunk::ToolUseInputDelta { .. }) => None,
-                        Err(err) => Some(Err(err)),
-                    }
-                });
-                Ok(Box::pin(struct_stream))
+                #[cfg(wasi_http)]
+                let chunk_stream = self
+                    .chat_stream_with_tools_responses_wasi(messages, tools, json_schema)
+                    .await?;
+                Ok(responses_chunk_stream_to_struct_stream(chunk_stream))
             }
             OpenAIApiMode::ChatCompletions => {
-                self.chat_stream_struct_legacy(messages, tools, json_schema)
-                    .await
+                #[cfg(native)]
+                {
+                    self.chat_stream_struct_legacy(messages, tools, json_schema)
+                        .await
+                }
+                #[cfg(wasi_http)]
+                {
+                    Err(Self::wasi_unsupported("OpenAI ChatCompletions streaming"))
+                }
             }
         }
     }
 
+    /// Tool-aware streaming: emits [`StreamChunk`] events (text/reasoning
+    /// deltas, tool-use start/input/complete, usage, done).
+    ///
+    /// Responses mode is supported on native (reqwest SSE) and WASI Preview2
+    /// + `wasi-http` (blocking `InputStream` SSE). ChatCompletions mode, which
+    /// depends on the `reqwest`-backed `OpenAICompatibleProvider`, remains
+    /// native-only; on WASI Preview2 it returns a clear error.
+    #[cfg(any(native, wasi_http))]
     async fn chat_stream_with_tools(
         &self,
         messages: &[ChatMessage],
@@ -752,21 +778,51 @@ impl ChatProvider for OpenAI {
     ) -> Result<Pin<Box<dyn Stream<Item = Result<StreamChunk, LLMError>> + Send>>, LLMError> {
         match self.api_mode {
             OpenAIApiMode::Responses => {
-                self.chat_stream_with_tools_responses(messages, tools, json_schema)
-                    .await
+                #[cfg(native)]
+                {
+                    self.chat_stream_with_tools_responses(messages, tools, json_schema)
+                        .await
+                }
+                #[cfg(wasi_http)]
+                {
+                    self.chat_stream_with_tools_responses_wasi(messages, tools, json_schema)
+                        .await
+                }
             }
             OpenAIApiMode::ChatCompletions => {
-                self.provider
-                    .chat_stream_with_tools(messages, tools, json_schema)
-                    .await
+                #[cfg(native)]
+                {
+                    self.provider
+                        .chat_stream_with_tools(messages, tools, json_schema)
+                        .await
+                }
+                #[cfg(wasi_http)]
+                {
+                    Err(Self::wasi_unsupported("OpenAI ChatCompletions streaming"))
+                }
             }
         }
     }
 
     fn model(&self) -> &str {
-        self.provider.model()
+        self.provider.model.as_str()
     }
 }
+
+#[cfg(all(target_arch = "wasm32", target_os = "wasi", target_env = "p2"))]
+impl OpenAI {
+    /// Renders a clear error for API modes / transports that the WASI Preview2
+    /// backend does not implement yet.
+    fn wasi_unsupported(feature: &str) -> LLMError {
+        LLMError::Generic(format!(
+            "{feature} is not supported by the OpenAI WASI Preview2 HTTP backend yet; \
+use a native target for this code path"
+        ))
+    }
+}
+
+// Native-only completion/model-listing impls use `reqwest`, which is
+// unavailable on WASI; streaming trait methods are gated per-method above.
 
 #[async_trait]
 impl CompletionProvider for OpenAI {
@@ -781,6 +837,10 @@ impl CompletionProvider for OpenAI {
     }
 }
 
+// Model listing goes through `reqwest`; gate the override native-only so that
+// on WASI Preview2 the trait's default `list_models` ("List Models not
+// supported") applies.
+#[cfg(native)]
 #[async_trait]
 impl ModelsProvider for OpenAI {
     async fn list_models(
@@ -808,6 +868,20 @@ impl ModelsProvider for OpenAI {
     }
 }
 
+// On WASI Preview2 model listing is not implemented yet; return a clear error
+// so the `LLMProvider` trait bound (which requires `ModelsProvider`) is
+// satisfied.
+#[cfg(wasi_http)]
+#[async_trait]
+impl ModelsProvider for OpenAI {
+    async fn list_models(
+        &self,
+        _request: Option<&ModelListRequest>,
+    ) -> Result<Box<dyn ModelListResponse>, LLMError> {
+        Err(Self::wasi_unsupported("OpenAI model listing"))
+    }
+}
+
 impl LLMProvider for OpenAI {}
 
 impl crate::HasConfig for OpenAI {
@@ -823,7 +897,11 @@ impl OpenAI {
         &self.provider.model
     }
 
-    pub fn base_url(&self) -> &reqwest::Url {
+    /// Native HTTP client; only available on non-wasm32 targets. The WASI
+    /// Preview2 transport uses `golem-wasi-http` over the `wasi:http` host
+    /// interface and does not expose a `reqwest::Client`.
+    #[cfg(native)]
+    pub fn base_url(&self) -> &url::Url {
         &self.provider.base_url
     }
 
@@ -831,10 +909,12 @@ impl OpenAI {
         self.provider.timeout_seconds
     }
 
+    #[cfg(native)]
     pub fn client(&self) -> &reqwest::Client {
         &self.provider.client
     }
 
+    #[cfg(native)]
     fn build_legacy_function_tools(&self, tools: Option<&[Tool]>) -> Option<Vec<OpenAITool>> {
         let mut openai_tools = Vec::new();
         if let Some(tools) = tools {
@@ -877,6 +957,7 @@ impl OpenAI {
         }
     }
 
+    #[cfg(native)]
     fn resolve_legacy_tool_choice_for_request(
         &self,
         tools: &Option<Vec<OpenAITool>>,
@@ -1114,6 +1195,12 @@ impl OpenAI {
         }
     }
 
+    /// Native Responses transport: issues the request over `reqwest` and returns
+    /// the raw [`reqwest::Response`] after ensuring a success status. Used by the
+    /// native streaming path; the non-streaming callers use
+    /// [`send_responses_request_text`](Self::send_responses_request_text) which
+    /// works on both native and WASI Preview2.
+    #[cfg(native)]
     async fn send_responses_request(
         &self,
         body: &OpenAIResponsesRequest,
@@ -1141,6 +1228,67 @@ impl OpenAI {
         ensure_success(response, "OpenAI").await
     }
 
+    /// Sends a non-streaming Responses request and returns the decoded response
+    /// body text after ensuring a success status.
+    ///
+    /// This is the cross-platform transport boundary used by
+    /// [`chat_with_tools_responses`](Self::chat_with_tools_responses) and
+    /// [`chat_with_hosted_tools`](Self::chat_with_hosted_tools). On native it
+    /// reuses the `reqwest` path; on WASI Preview2 it posts via
+    /// `golem-wasi-http` and applies the shared status mapper.
+    async fn send_responses_request_text(
+        &self,
+        body: &OpenAIResponsesRequest,
+    ) -> Result<String, LLMError> {
+        if log::log_enabled!(log::Level::Trace)
+            && let Ok(json) = serde_json::to_string(body)
+        {
+            log::trace!("OpenAI Responses payload: {}", json);
+        }
+
+        #[cfg(native)]
+        {
+            let response = self.send_responses_request(body).await?;
+            log::debug!("OpenAI Responses HTTP status: {}", response.status());
+            response.text().await.map_err(LLMError::from)
+        }
+
+        #[cfg(wasi_http)]
+        {
+            self.send_responses_request_text_wasi(body).await
+        }
+    }
+
+    /// WASI Preview2 transport for non-streaming Responses requests.
+    #[cfg(wasi_http)]
+    async fn send_responses_request_text_wasi(
+        &self,
+        body: &OpenAIResponsesRequest,
+    ) -> Result<String, LLMError> {
+        let url = self.responses_url()?;
+        let json = Self::serialize_request(body)?;
+
+        let response = crate::wasi_http::post_json_bearer(
+            url.as_str(),
+            &self.provider.api_key,
+            &json,
+            self.provider.timeout_seconds,
+        )?;
+        log::debug!("OpenAI Responses HTTP status: {}", response.status);
+
+        if (200..300).contains(&response.status) {
+            return Ok(response.body);
+        }
+
+        let retry_after = crate::http::find_retry_after(&response.headers);
+        Err(map_http_status_to_error(
+            "OpenAI",
+            response.status,
+            response.body,
+            retry_after,
+        ))
+    }
+
     async fn chat_with_tools_responses(
         &self,
         messages: &[ChatMessage],
@@ -1148,8 +1296,7 @@ impl OpenAI {
         json_schema: Option<StructuredOutputFormat>,
     ) -> Result<Box<dyn ChatResponse>, LLMError> {
         let body = self.build_responses_request(messages, tools, json_schema, false)?;
-        let response = self.send_responses_request(&body).await?;
-        let resp_text = response.text().await?;
+        let resp_text = self.send_responses_request_text(&body).await?;
         let json_resp: Result<OpenAIResponsesResponse, serde_json::Error> =
             serde_json::from_str(&resp_text);
         match json_resp {
@@ -1161,6 +1308,7 @@ impl OpenAI {
         }
     }
 
+    #[cfg(native)]
     async fn chat_with_tools_legacy(
         &self,
         messages: &[ChatMessage],
@@ -1219,6 +1367,7 @@ impl OpenAI {
         }
     }
 
+    #[cfg(native)]
     async fn chat_stream_struct_legacy(
         &self,
         messages: &[ChatMessage],
@@ -1267,6 +1416,7 @@ impl OpenAI {
         ))
     }
 
+    #[cfg(native)]
     async fn chat_stream_with_tools_responses(
         &self,
         messages: &[ChatMessage],
@@ -1276,6 +1426,60 @@ impl OpenAI {
         let body = self.build_responses_request(messages, tools, json_schema, true)?;
         let response = self.send_responses_request(&body).await?;
         Ok(create_responses_tool_stream(response))
+    }
+
+    /// WASI Preview2 Responses streaming transport.
+    ///
+    /// Issues a `stream: true` Responses request via the WASI HTTP bindings
+    /// and wraps the response body in [`WasiResponsesStream`], which parses
+    /// SSE events using the same shared parser as the native path
+    /// ([`find_sse_event_boundary`] / [`parse_responses_sse_event`]). On a
+    /// non-success status the body is buffered and mapped through the shared
+    /// [`map_http_status_to_error`](crate::http::map_http_status_to_error),
+    /// mirroring the native `ensure_success` behavior.
+    #[cfg(wasi_http)]
+    async fn chat_stream_with_tools_responses_wasi(
+        &self,
+        messages: &[ChatMessage],
+        tools: Option<&[Tool]>,
+        json_schema: Option<StructuredOutputFormat>,
+    ) -> Result<Pin<Box<dyn Stream<Item = Result<StreamChunk, LLMError>> + Send>>, LLMError> {
+        let body = self.build_responses_request(messages, tools, json_schema, true)?;
+
+        if log::log_enabled!(log::Level::Trace)
+            && let Ok(json) = serde_json::to_string(&body)
+        {
+            log::trace!("OpenAI Responses payload: {}", json);
+        }
+
+        let url = self.responses_url()?;
+        let json = Self::serialize_request(&body)?;
+
+        let streaming = crate::wasi_http::post_json_bearer_stream(
+            url.as_str(),
+            &self.provider.api_key,
+            &json,
+            self.provider.timeout_seconds,
+        )?;
+        log::debug!(
+            "OpenAI Responses streaming HTTP status: {}",
+            streaming.status()
+        );
+
+        let status = streaming.status();
+        if !(200..300).contains(&status) {
+            let retry_after = crate::http::find_retry_after(streaming.headers());
+            let error_body = streaming.into_bounded_error_text()?;
+            return Err(map_http_status_to_error(
+                "OpenAI",
+                status,
+                error_body,
+                retry_after,
+            ));
+        }
+
+        let byte_reader = streaming.into_byte_stream()?;
+        Ok(Box::pin(WasiResponsesStream::new(byte_reader)))
     }
 
     async fn chat_with_hosted_tools(
@@ -1293,8 +1497,7 @@ impl OpenAI {
             Some(hosted_tools),
             false,
         );
-        let response = self.send_responses_request(&body).await?;
-        let resp_text = response.text().await?;
+        let resp_text = self.send_responses_request_text(&body).await?;
         let json_resp: Result<OpenAIResponsesResponse, serde_json::Error> =
             serde_json::from_str(&resp_text);
         match json_resp {
@@ -1307,6 +1510,7 @@ impl OpenAI {
     }
 }
 
+#[cfg(any(native, wasi_http))]
 fn find_sse_event_boundary(buffer: &[u8]) -> Option<(usize, usize)> {
     let lf = buffer
         .windows(2)
@@ -1324,6 +1528,7 @@ fn find_sse_event_boundary(buffer: &[u8]) -> Option<(usize, usize)> {
     }
 }
 
+#[cfg(any(native, wasi_http))]
 fn parse_sse_data_payload(event: &str) -> Option<String> {
     let mut payload = String::default();
     for line in event.lines() {
@@ -1343,6 +1548,7 @@ fn parse_sse_data_payload(event: &str) -> Option<String> {
     }
 }
 
+#[cfg(any(native, wasi_http))]
 fn usage_from_value(value: &Value) -> Option<Usage> {
     if let Some(usage_value) = value.get("usage") {
         serde_json::from_value(usage_value.clone()).ok()
@@ -1354,6 +1560,7 @@ fn usage_from_value(value: &Value) -> Option<Usage> {
     }
 }
 
+#[cfg(any(native, wasi_http))]
 fn finalize_responses_stream(
     state: &mut ResponsesStreamState,
     include_done: bool,
@@ -1390,6 +1597,7 @@ fn finalize_responses_stream(
     results
 }
 
+#[cfg(any(native, wasi_http))]
 fn parse_responses_sse_event(
     event: &str,
     state: &mut ResponsesStreamState,
@@ -1434,6 +1642,7 @@ fn parse_responses_sse_event(
     }
 }
 
+#[cfg(any(native, wasi_http))]
 fn parse_responses_text_delta(value: &Value, reasoning: bool) -> Vec<StreamChunk> {
     let Some(delta) = value.get("delta").and_then(Value::as_str) else {
         return Vec::new();
@@ -1449,6 +1658,7 @@ fn parse_responses_text_delta(value: &Value, reasoning: bool) -> Vec<StreamChunk
     }]
 }
 
+#[cfg(any(native, wasi_http))]
 fn responses_output_index(value: &Value) -> usize {
     value
         .get("output_index")
@@ -1456,6 +1666,7 @@ fn responses_output_index(value: &Value) -> usize {
         .unwrap_or(0) as usize
 }
 
+#[cfg(any(native, wasi_http))]
 fn handle_responses_output_item_added(
     value: &Value,
     state: &mut ResponsesStreamState,
@@ -1494,6 +1705,7 @@ fn handle_responses_output_item_added(
     }]
 }
 
+#[cfg(any(native, wasi_http))]
 fn handle_responses_function_call_arguments_delta(
     value: &Value,
     state: &mut ResponsesStreamState,
@@ -1522,6 +1734,7 @@ fn handle_responses_function_call_arguments_delta(
     }]
 }
 
+#[cfg(any(native, wasi_http))]
 fn handle_responses_function_call_completion(
     event_type: &str,
     value: &Value,
@@ -1552,6 +1765,7 @@ fn handle_responses_function_call_completion(
     complete_responses_tool_call(output_index, state)
 }
 
+#[cfg(any(native, wasi_http))]
 fn complete_responses_tool_call(
     output_index: usize,
     state: &mut ResponsesStreamState,
@@ -1577,6 +1791,7 @@ fn complete_responses_tool_call(
     }]
 }
 
+#[cfg(any(native, wasi_http))]
 fn handle_responses_done(value: &Value, state: &mut ResponsesStreamState) -> Vec<StreamChunk> {
     let mut results = Vec::new();
     if let Some(usage) = usage_from_value(value) {
@@ -1586,6 +1801,7 @@ fn handle_responses_done(value: &Value, state: &mut ResponsesStreamState) -> Vec
     results
 }
 
+#[cfg(native)]
 fn create_responses_tool_stream(
     response: reqwest::Response,
 ) -> Pin<Box<dyn Stream<Item = Result<StreamChunk, LLMError>> + Send>> {
@@ -1619,6 +1835,185 @@ fn create_responses_tool_stream(
         )
         .flat_map(futures::stream::iter);
     Box::pin(stream)
+}
+
+/// Projects a [`StreamChunk`] stream (the transport-level Responses event
+/// stream) onto the provider-agnostic [`StreamResponse`] shape
+/// (`.choices[0].delta.*` + optional `.usage`).
+///
+/// Shared by the native and WASI streaming paths so both expose identical
+/// `chat_stream_struct` output — only the underlying chunk source differs
+/// (`reqwest` SSE on native, blocking `InputStream` SSE on WASI Preview2).
+#[cfg(any(native, wasi_http))]
+fn responses_chunk_stream_to_struct_stream(
+    chunk_stream: Pin<Box<dyn Stream<Item = Result<StreamChunk, LLMError>> + Send>>,
+) -> Pin<Box<dyn Stream<Item = Result<StreamResponse, LLMError>> + Send>> {
+    let struct_stream = chunk_stream.filter_map(|result| async move {
+        match result {
+            Ok(StreamChunk::Text(content)) => Some(Ok(StreamResponse {
+                choices: vec![StreamChoice {
+                    delta: StreamDelta {
+                        content: Some(content),
+                        reasoning_content: None,
+                        tool_calls: None,
+                    },
+                }],
+                usage: None,
+            })),
+            Ok(StreamChunk::ReasoningContent(content)) => Some(Ok(StreamResponse {
+                choices: vec![StreamChoice {
+                    delta: StreamDelta {
+                        content: None,
+                        reasoning_content: Some(content),
+                        tool_calls: None,
+                    },
+                }],
+                usage: None,
+            })),
+            Ok(StreamChunk::ToolUseComplete { tool_call, .. }) => Some(Ok(StreamResponse {
+                choices: vec![StreamChoice {
+                    delta: StreamDelta {
+                        content: None,
+                        reasoning_content: None,
+                        tool_calls: Some(vec![tool_call]),
+                    },
+                }],
+                usage: None,
+            })),
+            Ok(StreamChunk::Usage(usage)) => Some(Ok(StreamResponse {
+                choices: vec![StreamChoice {
+                    delta: StreamDelta {
+                        content: None,
+                        reasoning_content: None,
+                        tool_calls: None,
+                    },
+                }],
+                usage: Some(usage),
+            })),
+            Ok(StreamChunk::Done { .. })
+            | Ok(StreamChunk::ToolUseStart { .. })
+            | Ok(StreamChunk::ToolUseInputDelta { .. }) => None,
+            Err(err) => Some(Err(err)),
+        }
+    });
+    Box::pin(struct_stream)
+}
+
+/// Shared WASI Preview2 request helpers (URL building + body serialization),
+/// used by both the non-streaming and streaming Responses transports.
+#[cfg(wasi_http)]
+impl OpenAI {
+    /// Builds the responses API URL from the provider's base URL.
+    fn responses_url(&self) -> Result<url::Url, LLMError> {
+        self.provider
+            .base_url
+            .join("responses")
+            .map_err(|e| LLMError::HttpError(e.to_string()))
+    }
+
+    /// Serializes a request body for the WASI transport (shared by streaming
+    /// and non-streaming paths).
+    fn serialize_request(body: &impl serde::Serialize) -> Result<Vec<u8>, LLMError> {
+        serde_json::to_vec(body).map_err(LLMError::from)
+    }
+}
+
+/// Incremental SSE parser over a WASI HTTP response body; the WASI Preview2
+/// counterpart of [`create_responses_tool_stream`].
+///
+/// `InputStream::blocking_read` blocks the current thread (the host multiplexes
+/// other work while blocked), so it is safe to call directly from
+/// [`Stream::poll_next`] with no async runtime — this keeps the stream
+/// compatible with single-threaded WASI components.
+///
+/// On an SSE parse error this stream terminates (fail-fast), unlike the native
+/// path which emits the error and continues. In practice both converge because
+/// OpenAI closes the connection on error/`response.failed` events; a corrupted
+/// state machine should not keep producing.
+#[cfg(wasi_http)]
+struct WasiResponsesStream {
+    byte_reader: crate::wasi_http::WasiResponseStream,
+    buffer: Vec<u8>,
+    state: ResponsesStreamState,
+    pending: std::collections::VecDeque<StreamChunk>,
+    finished: bool,
+}
+
+#[cfg(wasi_http)]
+impl WasiResponsesStream {
+    fn new(byte_reader: crate::wasi_http::WasiResponseStream) -> Self {
+        Self {
+            byte_reader,
+            buffer: Vec::new(),
+            state: ResponsesStreamState::default(),
+            pending: std::collections::VecDeque::new(),
+            finished: false,
+        }
+    }
+}
+
+#[cfg(wasi_http)]
+impl Stream for WasiResponsesStream {
+    type Item = Result<StreamChunk, LLMError>;
+
+    fn poll_next(
+        mut self: Pin<&mut Self>,
+        _cx: &mut std::task::Context<'_>,
+    ) -> std::task::Poll<Option<Self::Item>> {
+        // Drain previously-parsed chunks first so a single read can yield
+        // multiple events across successive polls.
+        if let Some(chunk) = self.pending.pop_front() {
+            return std::task::Poll::Ready(Some(Ok(chunk)));
+        }
+
+        loop {
+            // Parse every complete SSE event currently buffered.
+            if let Some((pos, delimiter_len)) = find_sse_event_boundary(&self.buffer) {
+                let event_bytes = self.buffer[..pos].to_vec();
+                self.buffer.drain(..pos + delimiter_len);
+                let event = String::from_utf8_lossy(&event_bytes).into_owned();
+                match parse_responses_sse_event(event.trim(), &mut self.state) {
+                    Ok(chunks) => {
+                        self.pending.extend(chunks);
+                        // If this event produced any chunks, hand back the
+                        // first now and keep the rest pending. Otherwise loop
+                        // to parse the next buffered event or read more bytes.
+                        if let Some(chunk) = self.pending.pop_front() {
+                            return std::task::Poll::Ready(Some(Ok(chunk)));
+                        }
+                        continue;
+                    }
+                    Err(err) => {
+                        // Poison the stream: stop reading and surface the error.
+                        self.finished = true;
+                        return std::task::Poll::Ready(Some(Err(err)));
+                    }
+                }
+            }
+
+            // No complete event buffered: pull more bytes (blocking on WASI).
+            if self.finished {
+                return std::task::Poll::Ready(None);
+            }
+            match self.byte_reader.read_chunk() {
+                Ok(Some(bytes)) => {
+                    self.buffer.extend_from_slice(&bytes);
+                    // loop back to parse the freshly buffered bytes
+                }
+                Ok(None) => {
+                    // EOF. Any trailing bytes without a final `\n\n` delimiter
+                    // are dropped, matching the native `bytes_stream().scan()`
+                    // behavior (which only parses on boundary).
+                    self.finished = true;
+                    return std::task::Poll::Ready(None);
+                }
+                Err(err) => {
+                    self.finished = true;
+                    return std::task::Poll::Ready(Some(Err(err)));
+                }
+            }
+        }
+    }
 }
 
 impl From<&ToolChoice> for OpenAIResponsesToolChoice {
@@ -1681,7 +2076,10 @@ impl LLMBuilder<OpenAI> {
     }
 }
 
-#[cfg(feature = "openai")]
+// Embeddings go over `reqwest`; the WASI Preview2 transport does not implement
+// them in this first pass. Split into a native impl and a WASI stub so the
+// `EmbeddingProvider` trait (which has no default `embed`) is always satisfied.
+#[cfg(all(feature = "openai", not(target_arch = "wasm32")))]
 #[async_trait]
 impl EmbeddingProvider for OpenAI {
     async fn embed(&self, input: Vec<String>) -> Result<Vec<Vec<f32>>, LLMError> {
@@ -1727,6 +2125,14 @@ impl EmbeddingProvider for OpenAI {
     }
 }
 
+#[cfg(all(feature = "openai", wasi_http))]
+#[async_trait]
+impl EmbeddingProvider for OpenAI {
+    async fn embed(&self, _input: Vec<String>) -> Result<Vec<Vec<f32>>, LLMError> {
+        Err(Self::wasi_unsupported("OpenAI embeddings"))
+    }
+}
+
 impl EmbeddingBuilder<OpenAI> {
     /// Build an OpenAI embedding provider.
     pub fn build(self) -> Result<Arc<OpenAI>, LLMError> {
@@ -1767,7 +2173,7 @@ impl EmbeddingBuilder<OpenAI> {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(target_arch = "wasm32")))]
 mod tests {
     use super::*;
     use crate::builder::LLMBuilder;
@@ -1779,6 +2185,7 @@ mod tests {
         MockServer,
     };
     use serde_json::json;
+    use std::time::Duration;
 
     fn sample_function_tool() -> Tool {
         Tool {
@@ -2507,12 +2914,12 @@ mod tests {
                     },
                     {
                         "type": "message",
-                        "content": [{ "type": "output_text", "text": "hello responses" }]
+                        "content": [{ "type": "output_text", "text": "hello from mock" }]
                     }
                 ],
                 "usage": {
-                    "prompt_tokens": 2,
-                    "completion_tokens": 3,
+                    "input_tokens": 2,
+                    "output_tokens": 3,
                     "total_tokens": 5
                 }
             }));
@@ -2525,7 +2932,7 @@ mod tests {
             .chat_with_tools(&messages, Some(&tools), Some(sample_schema()))
             .await
             .expect("responses chat should succeed");
-        assert_eq!(response.text().as_deref(), Some("hello responses"));
+        assert_eq!(response.text().as_deref(), Some("hello from mock"));
         assert_eq!(response.thinking().as_deref(), Some("plan"));
         assert_eq!(
             response.tool_calls().expect("tool calls should exist")[0]
@@ -2533,6 +2940,13 @@ mod tests {
                 .name,
             "lookup"
         );
+        assert_eq!(
+            response.tool_calls().expect("tool calls should exist")[0]
+                .function
+                .arguments,
+            "{\"q\":\"value\"}"
+        );
+        assert_eq!(response.usage().map(|usage| usage.total_tokens), Some(5));
         chat_mock.assert();
 
         let stream_mock = server.mock(|when, then| {
@@ -2542,12 +2956,18 @@ mod tests {
             then.status(200)
                 .header("content-type", "text/event-stream")
                 .body(
-                    "data: {\"type\":\"response.output_text.delta\",\"delta\":\"hello \"}\n\n\
-                     data: {\"type\":\"response.reasoning_text.delta\",\"delta\":\"think\"}\n\n\
-                     data: {\"type\":\"response.output_item.added\",\"output_index\":0,\"item\":{\"type\":\"function_call\",\"id\":\"fc_1\",\"call_id\":\"call_1\",\"name\":\"lookup\",\"arguments\":\"\"}}\n\n\
-                     data: {\"type\":\"response.function_call_arguments.done\",\"output_index\":0,\"item\":{\"type\":\"function_call\",\"id\":\"fc_1\",\"call_id\":\"call_1\",\"name\":\"lookup\",\"arguments\":\"{\\\"q\\\":\\\"value\\\"}\"}}\n\n\
-                     data: {\"type\":\"response.done\",\"response\":{\"usage\":{\"input_tokens\":2,\"output_tokens\":3,\"total_tokens\":5}}}\n\n\
-                     data: [DONE]\n\n",
+                    r#"data: {"type":"response.output_text.delta","delta":"hello "}
+
+data: {"type":"response.reasoning_text.delta","delta":"think"}
+
+data: {"type":"response.output_item.added","output_index":0,"item":{"type":"function_call","id":"fc_1","call_id":"call_1","name":"lookup","arguments":""}}
+
+data: {"type":"response.function_call_arguments.done","output_index":0,"item":{"type":"function_call","id":"fc_1","call_id":"call_1","name":"lookup","arguments":"{\"q\":\"value\"}"}}
+
+data: {"type":"response.done","response":{"usage":{"input_tokens":2,"output_tokens":3,"total_tokens":5}}}
+
+data: [DONE]
+"#,
                 );
         });
 
@@ -2634,20 +3054,24 @@ mod tests {
             when.method(POST)
                 .path("/v1/responses")
                 .body_includes("\"stream\":false");
-            then.status(502).body("bad gateway");
+            then.status(429)
+                .header("Retry-After", "5")
+                .body(r#"{"error":"rate limited"}"#);
         });
         let err = provider
             .chat_with_tools(&messages, None, None)
             .await
             .expect_err("error status should fail");
         match err {
-            LLMError::HttpStatusError {
+            LLMError::RateLimitError {
                 status_code,
                 response_body,
+                retry_after,
                 ..
             } => {
-                assert_eq!(status_code, 502);
-                assert_eq!(response_body.as_ref(), "bad gateway");
+                assert_eq!(status_code, 429);
+                assert_eq!(response_body.as_ref(), r#"{"error":"rate limited"}"#);
+                assert_eq!(retry_after, Some(Duration::from_secs(5)));
             }
             other => panic!("unexpected error: {other:?}"),
         }

--- a/crates/autoagents-llm/src/http.rs
+++ b/crates/autoagents-llm/src/http.rs
@@ -1,15 +1,25 @@
 //! Centralized HTTP response handling for LLM provider backends.
+//!
+//! The status-code mapping logic
+//! ([`map_http_status_to_error`][crate::http::map_http_status_to_error] and
+//! [`parse_retry_after_value`][crate::http::parse_retry_after_value]) is target-independent
+//! and is reused by both the native `reqwest` transport and the WASI Preview2 transport.
+//! The `reqwest::Response`-based entry point ([`ensure_success`][crate::http::ensure_success])
+//! and its integration tests are only compiled on non-wasm32 targets.
 
 use std::time::Duration;
 
 use chrono::{DateTime, Utc};
-use futures::StreamExt;
-use reqwest::{Response, StatusCode};
 
 use crate::error::LLMError;
 
 /// Maximum bytes read from a non-success HTTP response body.
-const MAX_HTTP_ERROR_BODY_BYTES: usize = 65_536;
+///
+/// Shared by the native `reqwest` transport (`read_bounded_error_body`) and the
+/// WASI Preview2 transport (`crate::wasi_http::read_bounded_error_body`) so both
+/// apply the same cap to error bodies, keeping multi-MB CDN/WAF error pages out
+/// of memory (and, on `wasm32-wasip2`, out of the constrained linear memory).
+pub(crate) const MAX_HTTP_ERROR_BODY_BYTES: usize = 65_536;
 
 /// Parsed provider error payload extracted from a non-success response body.
 #[derive(Debug, Default)]
@@ -18,112 +28,178 @@ struct ProviderErrorDetails {
     provider_code: Option<String>,
 }
 
-/// Ensures an HTTP response has a success status, mapping failures to typed errors.
-///
-/// On success, returns the original response unchanged so callers can decode the body.
-/// On failure, reads the response body once and maps status codes to
-/// [`AuthError`](LLMError::AuthError), [`RateLimitError`](LLMError::RateLimitError),
-/// [`HttpStatusError`](LLMError::HttpStatusError), or [`InvalidRequest`](LLMError::InvalidRequest).
-pub async fn ensure_success(response: Response, provider: &str) -> Result<Response, LLMError> {
-    if response.status().is_success() {
-        return Ok(response);
+#[cfg(not(target_arch = "wasm32"))]
+mod native {
+    use super::*;
+    use futures::StreamExt;
+    use reqwest::Response;
+
+    /// Ensures an HTTP response has a success status, mapping failures to typed errors.
+    ///
+    /// On success, returns the original response unchanged so callers can decode the body.
+    /// On failure, reads the response body once and maps status codes to
+    /// [`AuthError`](LLMError::AuthError), [`RateLimitError`](LLMError::RateLimitError),
+    /// [`HttpStatusError`](LLMError::HttpStatusError), or [`InvalidRequest`](LLMError::InvalidRequest).
+    pub async fn ensure_success(response: Response, provider: &str) -> Result<Response, LLMError> {
+        if response.status().is_success() {
+            return Ok(response);
+        }
+
+        let status_code = response.status().as_u16();
+        let retry_after = parse_retry_after(response.headers());
+        let body = read_bounded_error_body(response).await?;
+
+        Err(map_http_status_to_error(
+            provider,
+            status_code,
+            body,
+            retry_after,
+        ))
     }
 
-    let status_code = response.status().as_u16();
-    let retry_after = parse_retry_after(response.headers());
-    let body = read_bounded_error_body(response).await?;
-    let details = parse_provider_error_body(&body);
+    async fn read_bounded_error_body(response: Response) -> Result<String, LLMError> {
+        // Reads at most `MAX_HTTP_ERROR_BODY_BYTES` from the wire on error responses.
+        //
+        // When `Content-Length` exceeds the cap, the body is not read at all and a placeholder
+        // is returned instead. This avoids pulling multi-megabyte CDN/WAF HTML pages into memory.
+        //
+        // Otherwise the body is streamed and accumulation stops at the cap. The remainder is not
+        // drained, so the connection may not be reused; that tradeoff is intentional on the
+        // error path where bounded memory use matters more than keep-alive reuse.
+        if let Some(content_length) = response.content_length()
+            && content_length > MAX_HTTP_ERROR_BODY_BYTES as u64
+        {
+            return Ok(format!(
+                "... [body omitted, Content-Length: {content_length} bytes]"
+            ));
+        }
 
-    map_http_status_error(provider, status_code, body, details, retry_after)
-}
+        let mut stream = response.bytes_stream();
+        let mut collected = Vec::with_capacity(MAX_HTTP_ERROR_BODY_BYTES.min(8192));
+        let mut total_received = 0usize;
+        let mut at_capacity = false;
 
-fn default_error_message(provider: &str, status_code: u16) -> String {
-    match StatusCode::from_u16(status_code) {
-        Ok(status) => format!("{provider} API returned error status: {status}"),
-        Err(_) => format!("{provider} API returned error status: {status_code}"),
-    }
-}
+        while let Some(chunk_result) = stream.next().await {
+            let chunk = chunk_result?;
+            let chunk_len = chunk.len();
+            total_received += chunk_len;
 
-fn http_status_error(
-    status_code: u16,
-    message: String,
-    response_body: impl Into<Box<str>>,
-    provider_code: Option<Box<str>>,
-    retry_after: Option<Duration>,
-) -> LLMError {
-    LLMError::HttpStatusError {
-        status_code,
-        message,
-        response_body: response_body.into(),
-        retry_after,
-        provider_code,
-    }
-}
-
-async fn read_bounded_error_body(response: Response) -> Result<String, LLMError> {
-    // Reads at most `MAX_HTTP_ERROR_BODY_BYTES` from the wire on error responses.
-    //
-    // When `Content-Length` exceeds the cap, the body is not read at all and a placeholder
-    // is returned instead. This avoids pulling multi-megabyte CDN/WAF HTML pages into memory.
-    //
-    // Otherwise the body is streamed and accumulation stops at the cap. The remainder is not
-    // drained, so the connection may not be reused; that tradeoff is intentional on the
-    // error path where bounded memory use matters more than keep-alive reuse.
-    if let Some(content_length) = response.content_length()
-        && content_length > MAX_HTTP_ERROR_BODY_BYTES as u64
-    {
-        return Ok(format!(
-            "... [body omitted, Content-Length: {content_length} bytes]"
-        ));
-    }
-
-    let mut stream = response.bytes_stream();
-    let mut collected = Vec::with_capacity(MAX_HTTP_ERROR_BODY_BYTES.min(8192));
-    let mut total_received = 0usize;
-    let mut at_capacity = false;
-
-    while let Some(chunk_result) = stream.next().await {
-        let chunk = chunk_result?;
-        let chunk_len = chunk.len();
-        total_received += chunk_len;
-
-        if !at_capacity {
-            let remaining = MAX_HTTP_ERROR_BODY_BYTES.saturating_sub(collected.len());
-            if chunk_len <= remaining {
-                collected.extend_from_slice(&chunk);
-                if collected.len() == MAX_HTTP_ERROR_BODY_BYTES {
+            if !at_capacity {
+                let remaining = MAX_HTTP_ERROR_BODY_BYTES.saturating_sub(collected.len());
+                if chunk_len <= remaining {
+                    collected.extend_from_slice(&chunk);
+                    if collected.len() == MAX_HTTP_ERROR_BODY_BYTES {
+                        at_capacity = true;
+                    }
+                } else {
+                    collected.extend_from_slice(&chunk[..remaining]);
                     at_capacity = true;
                 }
-            } else {
-                collected.extend_from_slice(&chunk[..remaining]);
-                at_capacity = true;
+            }
+
+            if at_capacity {
+                break;
             }
         }
 
         if at_capacity {
-            break;
+            Ok(format_truncated_error_body(&collected, total_received))
+        } else {
+            Ok(String::from_utf8_lossy(&collected).into_owned())
         }
     }
 
-    if at_capacity {
-        Ok(format_truncated_error_body(&collected, total_received))
-    } else {
-        Ok(String::from_utf8_lossy(&collected).into_owned())
+    fn format_truncated_error_body(collected: &[u8], bytes_read: usize) -> String {
+        let truncated = String::from_utf8_lossy(collected).into_owned();
+        format!("{truncated}... [truncated after reading {bytes_read} bytes]")
     }
 }
 
-fn format_truncated_error_body(collected: &[u8], bytes_read: usize) -> String {
-    let truncated = String::from_utf8_lossy(collected).into_owned();
-    format!("{truncated}... [truncated after reading {bytes_read} bytes]")
+#[cfg(not(target_arch = "wasm32"))]
+pub(crate) use native::ensure_success;
+
+/// Builds a human-readable default error message for a non-success status code.
+///
+/// Transport-independent (no `reqwest` dependency) so it can be shared by the
+/// native and WASI Preview2 status mappers. Falls back to the numeric status when
+/// the reason phrase is unknown or non-standard.
+fn default_error_message(provider: &str, status_code: u16) -> String {
+    let reason = http_reason_phrase(status_code)
+        .map(|phrase| format!("{status_code} {phrase}"))
+        .unwrap_or_else(|| status_code.to_string());
+    format!("{provider} API returned error status: {reason}")
 }
 
-fn map_http_status_error(
+/// Returns the canonical HTTP reason phrase for well-known status codes.
+///
+/// This mirrors the subset of reason phrases that `reqwest::StatusCode` would
+/// render, without requiring the `reqwest` dependency on WASI targets.
+fn http_reason_phrase(status_code: u16) -> Option<&'static str> {
+    match status_code {
+        400 => Some("Bad Request"),
+        401 => Some("Unauthorized"),
+        402 => Some("Payment Required"),
+        403 => Some("Forbidden"),
+        404 => Some("Not Found"),
+        405 => Some("Method Not Allowed"),
+        406 => Some("Not Acceptable"),
+        407 => Some("Proxy Authentication Required"),
+        408 => Some("Request Timeout"),
+        409 => Some("Conflict"),
+        410 => Some("Gone"),
+        411 => Some("Length Required"),
+        412 => Some("Precondition Failed"),
+        413 => Some("Payload Too Large"),
+        414 => Some("URI Too Long"),
+        415 => Some("Unsupported Media Type"),
+        416 => Some("Range Not Satisfiable"),
+        417 => Some("Expectation Failed"),
+        418 => Some("I'm a teapot"),
+        421 => Some("Misdirected Request"),
+        422 => Some("Unprocessable Entity"),
+        423 => Some("Locked"),
+        424 => Some("Failed Dependency"),
+        425 => Some("Too Early"),
+        426 => Some("Upgrade Required"),
+        428 => Some("Precondition Required"),
+        429 => Some("Too Many Requests"),
+        431 => Some("Request Header Fields Too Large"),
+        451 => Some("Unavailable For Legal Reasons"),
+        500 => Some("Internal Server Error"),
+        501 => Some("Not Implemented"),
+        502 => Some("Bad Gateway"),
+        503 => Some("Service Unavailable"),
+        504 => Some("Gateway Timeout"),
+        505 => Some("HTTP Version Not Supported"),
+        506 => Some("Variant Also Negotiates"),
+        507 => Some("Insufficient Storage"),
+        508 => Some("Loop Detected"),
+        510 => Some("Not Extended"),
+        511 => Some("Network Authentication Required"),
+        529 => Some("Site Is Overloaded"),
+        _ => None,
+    }
+}
+
+/// Maps a non-success HTTP status code and response body to a typed
+/// [`LLMError`].
+///
+/// This is the shared, transport-independent status mapper used by both the
+/// native `reqwest` path ([`ensure_success`]) and the WASI Preview2 transport.
+/// It is intended to be called only after the caller has observed a non-2xx
+/// status code, and always returns an [`LLMError`] describing the failure.
+pub(crate) fn map_http_status_to_error(
     provider: &str,
     status_code: u16,
     body: String,
-    details: ProviderErrorDetails,
     retry_after: Option<Duration>,
-) -> Result<Response, LLMError> {
+) -> LLMError {
+    debug_assert!(
+        !(200..300).contains(&status_code),
+        "map_http_status_to_error called on a success status {status_code}"
+    );
+
+    let details = parse_provider_error_body(&body);
     let message = details
         .message
         .unwrap_or_else(|| default_error_message(provider, status_code));
@@ -131,45 +207,71 @@ fn map_http_status_error(
     let response_body = body.into_boxed_str();
 
     match status_code {
-        401 | 403 => Err(LLMError::AuthError {
+        401 | 403 => LLMError::AuthError {
             message,
             status_code: Some(status_code),
             response_body: Some(response_body),
-        }),
-        429 | 529 => Err(LLMError::RateLimitError {
+        },
+        429 | 529 => LLMError::RateLimitError {
             status_code,
             message,
             response_body,
             retry_after,
             provider_code,
-        }),
-        400 | 404 | 413 | 422 => Err(LLMError::InvalidRequest {
+        },
+        400 | 404 | 413 | 422 => LLMError::InvalidRequest {
             message,
             status_code: Some(status_code),
             response_body: Some(response_body),
-        }),
-        _ => Err(http_status_error(
+        },
+        _ => LLMError::HttpStatusError {
             status_code,
             message,
             response_body,
-            provider_code,
             retry_after,
-        )),
+            provider_code,
+        },
     }
 }
 
-fn parse_retry_after(headers: &reqwest::header::HeaderMap) -> Option<Duration> {
-    let value = headers
-        .get(reqwest::header::RETRY_AFTER)?
-        .to_str()
-        .ok()?
-        .trim();
+/// Parses a `Retry-After` header value into a [`Duration`].
+///
+/// Accepts both the delta-seconds form (e.g. `"30"`) and the HTTP-date /
+/// RFC 3339 form (e.g. `"Wed, 21 Oct 2015 07:28:00 GMT"`). Past dates and
+/// unparseable values return `None`. This is shared by the native and WASI
+/// transports.
+pub(crate) fn parse_retry_after_value(value: &str) -> Option<Duration> {
+    let value = value.trim();
 
     if let Ok(seconds) = value.parse::<u64>() {
         return Some(Duration::from_secs(seconds));
     }
 
     parse_retry_after_http_date(value)
+}
+
+/// Looks up the first `Retry-After` header value (case-insensitive) in a
+/// `(name, value)` header list and parses it via [`parse_retry_after_value`].
+///
+/// This is the transport-agnostic counterpart of the native
+/// `parse_retry_after(&reqwest::HeaderMap)`. The WASI Preview2 transport
+/// collects response headers into lower-cased `(String, String)` pairs (see
+/// `crate::wasi_http`); this helper scans them. Its only callers live behind
+/// `#[cfg(wasi_http)]`, so it is gated to that target plus `test` (so the
+/// native `cargo test` suite exercises it) — otherwise it would be dead code on
+/// native non-test builds.
+#[cfg(any(test, wasi_http))]
+pub(crate) fn find_retry_after(headers: &[(String, String)]) -> Option<Duration> {
+    headers
+        .iter()
+        .find(|(name, _)| name.eq_ignore_ascii_case("retry-after"))
+        .and_then(|(_, value)| parse_retry_after_value(value))
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn parse_retry_after(headers: &reqwest::header::HeaderMap) -> Option<Duration> {
+    let value = headers.get(reqwest::header::RETRY_AFTER)?.to_str().ok()?;
+    parse_retry_after_value(value)
 }
 
 fn parse_retry_after_http_date(value: &str) -> Option<Duration> {
@@ -227,6 +329,181 @@ fn parse_provider_error_body(body: &str) -> ProviderErrorDetails {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn find_retry_after_is_case_insensitive() {
+        let headers = vec![
+            ("Retry-After".to_string(), "30".to_string()),
+            ("x-foo".to_string(), "bar".to_string()),
+        ];
+        assert_eq!(find_retry_after(&headers), Some(Duration::from_secs(30)));
+
+        let lower = vec![("retry-after".to_string(), "12".to_string())];
+        assert_eq!(find_retry_after(&lower), Some(Duration::from_secs(12)));
+    }
+
+    #[test]
+    fn find_retry_after_missing_returns_none() {
+        let headers = vec![("content-type".to_string(), "text/plain".to_string())];
+        assert!(find_retry_after(&headers).is_none());
+    }
+
+    #[test]
+    fn parse_provider_error_body_extracts_google_status() {
+        let details = parse_provider_error_body(
+            r#"{"error":{"code":429,"message":"Resource exhausted","status":"RESOURCE_EXHAUSTED"}}"#,
+        );
+        assert_eq!(details.message.as_deref(), Some("Resource exhausted"));
+        assert_eq!(details.provider_code.as_deref(), Some("RESOURCE_EXHAUSTED"));
+    }
+
+    #[test]
+    fn parse_provider_error_body_reads_top_level_fields() {
+        let details = parse_provider_error_body(r#"{"message":"fail","type":"provider_error"}"#);
+        assert_eq!(details.message.as_deref(), Some("fail"));
+        assert_eq!(details.provider_code.as_deref(), Some("provider_error"));
+    }
+
+    #[test]
+    fn parse_provider_error_body_handles_invalid_json() {
+        let details = parse_provider_error_body("not-json");
+        assert!(details.message.is_none());
+        assert!(details.provider_code.is_none());
+    }
+
+    #[test]
+    fn parse_retry_after_value_accepts_delay_seconds() {
+        assert_eq!(parse_retry_after_value("45"), Some(Duration::from_secs(45)));
+        // Surrounding whitespace is tolerated.
+        assert_eq!(
+            parse_retry_after_value("  12 \n"),
+            Some(Duration::from_secs(12))
+        );
+    }
+
+    #[test]
+    fn parse_retry_after_value_accepts_http_date() {
+        let future = (Utc::now() + chrono::Duration::seconds(60))
+            .format("%a, %d %b %Y %H:%M:%S GMT")
+            .to_string();
+        let parsed = parse_retry_after_value(&future).expect("retry-after should parse");
+        assert!(parsed >= Duration::from_secs(55));
+        assert!(parsed <= Duration::from_secs(65));
+    }
+
+    #[test]
+    fn parse_retry_after_value_accepts_rfc3339_date() {
+        let future = (Utc::now() + chrono::Duration::seconds(90)).to_rfc3339();
+        let parsed = parse_retry_after_value(&future).expect("retry-after should parse");
+        assert!(parsed >= Duration::from_secs(85));
+        assert!(parsed <= Duration::from_secs(95));
+    }
+
+    #[test]
+    fn parse_retry_after_value_past_http_date_returns_none() {
+        let past = (Utc::now() - chrono::Duration::seconds(120))
+            .format("%a, %d %b %Y %H:%M:%S GMT")
+            .to_string();
+        assert_eq!(parse_retry_after_value(&past), None);
+    }
+
+    #[test]
+    fn parse_retry_after_value_rejects_garbage() {
+        assert_eq!(parse_retry_after_value("not a date"), None);
+        assert_eq!(parse_retry_after_value(""), None);
+    }
+
+    #[test]
+    fn map_http_status_to_error_401_maps_to_auth_error() {
+        let err = map_http_status_to_error(
+            "OpenAI",
+            401,
+            r#"{"error":{"message":"invalid key"}}"#.to_string(),
+            None,
+        );
+        match err {
+            LLMError::AuthError {
+                status_code,
+                message,
+                response_body,
+            } => {
+                assert_eq!(status_code, Some(401));
+                assert_eq!(message, "invalid key");
+                assert!(response_body.is_some());
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn map_http_status_to_error_429_maps_to_rate_limit_with_retry_after() {
+        let err = map_http_status_to_error(
+            "OpenAI",
+            429,
+            r#"{"error":{"message":"rate limited","code":"rate_limit_exceeded"}}"#.to_string(),
+            Some(Duration::from_secs(30)),
+        );
+        match err {
+            LLMError::RateLimitError {
+                status_code,
+                message,
+                retry_after,
+                provider_code,
+                ..
+            } => {
+                assert_eq!(status_code, 429);
+                assert_eq!(message, "rate limited");
+                assert_eq!(provider_code.as_deref(), Some("rate_limit_exceeded"));
+                assert_eq!(retry_after, Some(Duration::from_secs(30)));
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn map_http_status_to_error_400_maps_to_invalid_request() {
+        let err = map_http_status_to_error(
+            "OpenAI",
+            400,
+            r#"{"error":{"message":"bad request"}}"#.to_string(),
+            None,
+        );
+        match err {
+            LLMError::InvalidRequest {
+                message,
+                status_code,
+                response_body,
+            } => {
+                assert_eq!(message, "bad request");
+                assert_eq!(status_code, Some(400));
+                assert!(response_body.is_some());
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn map_http_status_to_error_500_maps_to_http_status_error() {
+        let err = map_http_status_to_error("OpenAI", 500, "provider exploded".to_string(), None);
+        match err {
+            LLMError::HttpStatusError {
+                status_code,
+                message,
+                response_body,
+                ..
+            } => {
+                assert_eq!(status_code, 500);
+                assert!(message.contains("500"));
+                assert_eq!(response_body.as_ref(), "provider exploded");
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+}
+
+#[cfg(all(test, not(target_arch = "wasm32")))]
+mod native_tests {
+    use super::*;
     use reqwest::Client;
 
     async fn error_for_status(status: u16, body: &str, retry_after: Option<&str>) -> LLMError {
@@ -250,15 +527,6 @@ mod tests {
         ensure_success(response, "TestProvider")
             .await
             .expect_err("expected error")
-    }
-
-    #[test]
-    fn parse_provider_error_body_extracts_google_status() {
-        let details = parse_provider_error_body(
-            r#"{"error":{"code":429,"message":"Resource exhausted","status":"RESOURCE_EXHAUSTED"}}"#,
-        );
-        assert_eq!(details.message.as_deref(), Some("Resource exhausted"));
-        assert_eq!(details.provider_code.as_deref(), Some("RESOURCE_EXHAUSTED"));
     }
 
     #[test]
@@ -307,13 +575,6 @@ mod tests {
             past.parse().expect("valid header value"),
         );
         assert_eq!(parse_retry_after(&headers), None);
-    }
-
-    #[test]
-    fn parse_provider_error_body_reads_top_level_fields() {
-        let details = parse_provider_error_body(r#"{"message":"fail","type":"provider_error"}"#);
-        assert_eq!(details.message.as_deref(), Some("fail"));
-        assert_eq!(details.provider_code.as_deref(), Some("provider_error"));
     }
 
     #[tokio::test]

--- a/crates/autoagents-llm/src/http.rs
+++ b/crates/autoagents-llm/src/http.rs
@@ -124,9 +124,10 @@ pub(crate) use native::ensure_success;
 /// native and WASI Preview2 status mappers. Falls back to the numeric status when
 /// the reason phrase is unknown or non-standard.
 fn default_error_message(provider: &str, status_code: u16) -> String {
-    let reason = http_reason_phrase(status_code)
-        .map(|phrase| format!("{status_code} {phrase}"))
-        .unwrap_or_else(|| status_code.to_string());
+    let reason = http_reason_phrase(status_code).map_or_else(
+        || status_code.to_string(),
+        |phrase| format!("{status_code} {phrase}"),
+    );
     format!("{provider} API returned error status: {reason}")
 }
 
@@ -135,50 +136,55 @@ fn default_error_message(provider: &str, status_code: u16) -> String {
 /// This mirrors the subset of reason phrases that `reqwest::StatusCode` would
 /// render, without requiring the `reqwest` dependency on WASI targets.
 fn http_reason_phrase(status_code: u16) -> Option<&'static str> {
-    match status_code {
-        400 => Some("Bad Request"),
-        401 => Some("Unauthorized"),
-        402 => Some("Payment Required"),
-        403 => Some("Forbidden"),
-        404 => Some("Not Found"),
-        405 => Some("Method Not Allowed"),
-        406 => Some("Not Acceptable"),
-        407 => Some("Proxy Authentication Required"),
-        408 => Some("Request Timeout"),
-        409 => Some("Conflict"),
-        410 => Some("Gone"),
-        411 => Some("Length Required"),
-        412 => Some("Precondition Failed"),
-        413 => Some("Payload Too Large"),
-        414 => Some("URI Too Long"),
-        415 => Some("Unsupported Media Type"),
-        416 => Some("Range Not Satisfiable"),
-        417 => Some("Expectation Failed"),
-        418 => Some("I'm a teapot"),
-        421 => Some("Misdirected Request"),
-        422 => Some("Unprocessable Entity"),
-        423 => Some("Locked"),
-        424 => Some("Failed Dependency"),
-        425 => Some("Too Early"),
-        426 => Some("Upgrade Required"),
-        428 => Some("Precondition Required"),
-        429 => Some("Too Many Requests"),
-        431 => Some("Request Header Fields Too Large"),
-        451 => Some("Unavailable For Legal Reasons"),
-        500 => Some("Internal Server Error"),
-        501 => Some("Not Implemented"),
-        502 => Some("Bad Gateway"),
-        503 => Some("Service Unavailable"),
-        504 => Some("Gateway Timeout"),
-        505 => Some("HTTP Version Not Supported"),
-        506 => Some("Variant Also Negotiates"),
-        507 => Some("Insufficient Storage"),
-        508 => Some("Loop Detected"),
-        510 => Some("Not Extended"),
-        511 => Some("Network Authentication Required"),
-        529 => Some("Site Is Overloaded"),
-        _ => None,
-    }
+    // Sorted by status code; uses a linear scan because the table is small
+    // (41 entries) and the function is called only on error paths.
+    const PHRASES: &[(u16, &str)] = &[
+        (400, "Bad Request"),
+        (401, "Unauthorized"),
+        (402, "Payment Required"),
+        (403, "Forbidden"),
+        (404, "Not Found"),
+        (405, "Method Not Allowed"),
+        (406, "Not Acceptable"),
+        (407, "Proxy Authentication Required"),
+        (408, "Request Timeout"),
+        (409, "Conflict"),
+        (410, "Gone"),
+        (411, "Length Required"),
+        (412, "Precondition Failed"),
+        (413, "Payload Too Large"),
+        (414, "URI Too Long"),
+        (415, "Unsupported Media Type"),
+        (416, "Range Not Satisfiable"),
+        (417, "Expectation Failed"),
+        (418, "I'm a teapot"),
+        (421, "Misdirected Request"),
+        (422, "Unprocessable Entity"),
+        (423, "Locked"),
+        (424, "Failed Dependency"),
+        (425, "Too Early"),
+        (426, "Upgrade Required"),
+        (428, "Precondition Required"),
+        (429, "Too Many Requests"),
+        (431, "Request Header Fields Too Large"),
+        (451, "Unavailable For Legal Reasons"),
+        (500, "Internal Server Error"),
+        (501, "Not Implemented"),
+        (502, "Bad Gateway"),
+        (503, "Service Unavailable"),
+        (504, "Gateway Timeout"),
+        (505, "HTTP Version Not Supported"),
+        (506, "Variant Also Negotiates"),
+        (507, "Insufficient Storage"),
+        (508, "Loop Detected"),
+        (510, "Not Extended"),
+        (511, "Network Authentication Required"),
+        (529, "Site Is Overloaded"),
+    ];
+    PHRASES
+        .iter()
+        .find(|(code, _)| *code == status_code)
+        .map(|(_, phrase)| *phrase)
 }
 
 /// Maps a non-success HTTP status code and response body to a typed

--- a/crates/autoagents-llm/src/lib.rs
+++ b/crates/autoagents-llm/src/lib.rs
@@ -17,8 +17,16 @@ use std::fmt::Display;
 
 use serde::{Deserialize, Serialize};
 
+// The OpenAI Responses backend supports a WASI Preview2 (`wasm32-wasip2`)
+// HTTP transport via the `wasi-http` feature using `golem-wasi-http` over the
+// `wasi:http` host interface. The unsupported combinations below produce
+// precise, actionable compile errors.
+
+// 1. Any HTTP provider feature on non-WASI browser wasm (e.g. `wasm32-unknown-unknown`)
+//    is unsupported: there is no socket/HTTP host interface available there.
 #[cfg(all(
     target_arch = "wasm32",
+    not(target_os = "wasi"),
     any(
         feature = "openai",
         feature = "anthropic",
@@ -34,8 +42,72 @@ use serde::{Deserialize, Serialize};
     )
 ))]
 compile_error!(
-    "autoagents-llm HTTP provider backends are not supported on wasm32 targets yet. \
-Use a native host for provider access, or build for a non-wasm target."
+    "autoagents-llm HTTP provider backends are not supported on non-WASI wasm32 targets \
+(such as wasm32-unknown-unknown). Use a native target, or target wasm32-wasip2 with the \
+`wasi-http` feature for the OpenAI Responses backend."
+);
+
+// 2. WASI Preview1 (`wasm32-wasip1`) has no Preview2 HTTP host interface; the only
+//    WASI HTTP transport shipped by this crate requires Preview2.
+#[cfg(all(
+    target_arch = "wasm32",
+    target_os = "wasi",
+    target_env = "p1",
+    any(
+        feature = "openai",
+        feature = "anthropic",
+        feature = "ollama",
+        feature = "deepseek",
+        feature = "xai",
+        feature = "phind",
+        feature = "google",
+        feature = "groq",
+        feature = "azure_openai",
+        feature = "openrouter",
+        feature = "minimax"
+    )
+))]
+compile_error!(
+    "autoagents-llm HTTP provider backends are not supported on wasm32-wasip1. \
+WASI HTTP requires the Preview2 target (wasm32-wasip2); rebuild with `--target wasm32-wasip2` \
+and the `wasi-http` feature for the OpenAI Responses backend."
+);
+
+// 3. On WASI Preview2 the OpenAI Responses backend requires the `wasi-http` feature
+//    to pull in the `wasip2` HTTP bindings.
+#[cfg(all(
+    target_arch = "wasm32",
+    target_os = "wasi",
+    target_env = "p2",
+    feature = "openai",
+    not(feature = "wasi-http")
+))]
+compile_error!(
+    "autoagents-llm OpenAI Responses backend on wasm32-wasip2 requires the `wasi-http` feature. \
+Rebuild with `--features openai,wasi-http`."
+);
+
+// 4. Other HTTP providers are not yet wired to the WASI Preview2 transport.
+#[cfg(all(
+    target_arch = "wasm32",
+    target_os = "wasi",
+    target_env = "p2",
+    any(
+        feature = "anthropic",
+        feature = "ollama",
+        feature = "deepseek",
+        feature = "xai",
+        feature = "phind",
+        feature = "google",
+        feature = "groq",
+        feature = "azure_openai",
+        feature = "openrouter",
+        feature = "minimax"
+    )
+))]
+compile_error!(
+    "autoagents-llm only supports the OpenAI Responses backend on wasm32-wasip2 in this release. \
+Remove the non-openai HTTP provider features, or build for a native target."
 );
 
 /// Backend implementations for supported LLM providers like OpenAI, Anthropic, etc.
@@ -60,7 +132,15 @@ pub mod error;
 pub mod config;
 
 /// Centralized HTTP response handling for provider backends.
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(any(
+    not(target_arch = "wasm32"),
+    all(
+        target_arch = "wasm32",
+        target_os = "wasi",
+        target_env = "p2",
+        feature = "wasi-http"
+    )
+))]
 pub mod http;
 
 /// Evaluator for LLM providers
@@ -82,6 +162,16 @@ pub mod pipeline;
 /// Built-in optimization passes (cache, etc.). Not available on WASM.
 #[cfg(all(not(target_arch = "wasm32"), feature = "optim"))]
 pub mod optim;
+
+/// Direct WASI Preview2 (`wasm32-wasip2`) HTTP transport used by the OpenAI
+/// Responses backend when the `wasi-http` feature is enabled.
+#[cfg(all(
+    target_arch = "wasm32",
+    target_os = "wasi",
+    target_env = "p2",
+    feature = "wasi-http"
+))]
+mod wasi_http;
 
 //Re-export for convenience
 pub use async_trait::async_trait;

--- a/crates/autoagents-llm/src/providers/mod.rs
+++ b/crates/autoagents-llm/src/providers/mod.rs
@@ -1,3 +1,2 @@
-#[cfg(not(target_arch = "wasm32"))]
 #[allow(dead_code)]
 pub(crate) mod openai_compatible;

--- a/crates/autoagents-llm/src/providers/openai_compatible.rs
+++ b/crates/autoagents-llm/src/providers/openai_compatible.rs
@@ -3,29 +3,48 @@
 //! This module provides a generic base for OpenAI-compatible APIs that can be reused
 //! across multiple providers like OpenAI, Mistral, XAI, Groq, DeepSeek, etc.
 
+// `OpenAICompatibleProvider` is used on every target (native chat-completions
+// backends and the WASI Preview2 OpenAI Responses backend), but most of the
+// chat-completions / streaming types and helpers below are unreachable on
+// `wasm32-wasip2`. The module is annotated `#[allow(dead_code)]` at its
+// declaration in `providers/mod.rs` (covering all targets) rather than with a
+// second, wasm-only attribute here, which would duplicate that lint allow.
+
+#[cfg(not(target_arch = "wasm32"))]
 use crate::FunctionCall;
-use crate::chat::{StreamChoice, StreamChunk as ChatStreamChunk, StreamDelta};
+#[cfg(not(target_arch = "wasm32"))]
+use crate::chat::{ChatMessage, ChatRole, MessageType};
+#[cfg(not(target_arch = "wasm32"))]
+use crate::chat::{
+    ChatProvider, StreamChoice, StreamChunk as ChatStreamChunk, StreamDelta, StreamResponse,
+};
 use crate::config::resolve_request_timeout;
+#[cfg(not(target_arch = "wasm32"))]
 use crate::error::LLMError;
+#[cfg(not(target_arch = "wasm32"))]
 use crate::http::ensure_success;
 use crate::{
     ToolCall,
     chat::ChatResponse,
-    chat::{
-        ChatMessage, ChatProvider, ChatRole, MessageType, StreamResponse, StructuredOutputFormat,
-        Tool, ToolChoice, Usage,
-    },
+    chat::{StructuredOutputFormat, Tool, ToolChoice, Usage},
     default_call_type,
 };
+#[cfg(not(target_arch = "wasm32"))]
 use async_trait::async_trait;
+#[cfg(not(target_arch = "wasm32"))]
 use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64};
 use either::*;
+#[cfg(not(target_arch = "wasm32"))]
 use futures::{StreamExt, stream::Stream};
-use reqwest::{Client, Url};
+#[cfg(not(target_arch = "wasm32"))]
+use reqwest::Client;
 use serde::{Deserialize, Serialize};
+#[cfg(not(target_arch = "wasm32"))]
 use std::collections::HashMap;
 use std::marker::PhantomData;
+#[cfg(not(target_arch = "wasm32"))]
 use std::pin::Pin;
+use url::Url;
 
 /// Generic OpenAI-compatible provider
 ///
@@ -49,6 +68,9 @@ pub struct OpenAICompatibleProvider<T: OpenAIProviderConfig> {
     pub embedding_encoding_format: Option<String>,
     pub embedding_dimensions: Option<u32>,
     pub normalize_response: bool,
+    /// Native HTTP client. Only present on non-wasm32 targets; the WASI Preview2
+    /// transport uses `golem-wasi-http` over the `wasi:http` host interface.
+    #[cfg(not(target_arch = "wasm32"))]
     pub client: Client,
     _phantom: PhantomData<T>,
 }
@@ -328,10 +350,14 @@ impl<T: OpenAIProviderConfig> OpenAICompatibleProvider<T> {
         embedding_dimensions: Option<u32>,
     ) -> Self {
         let timeout_seconds = resolve_request_timeout(timeout_seconds);
-        let client = Client::builder()
-            .timeout(std::time::Duration::from_secs(timeout_seconds))
-            .build()
-            .expect("Failed to build reqwest Client");
+        #[cfg(not(target_arch = "wasm32"))]
+        let client = {
+            let _ = timeout_seconds; // silence unused warnings on wasm32 below
+            Client::builder()
+                .timeout(std::time::Duration::from_secs(timeout_seconds))
+                .build()
+                .expect("Failed to build reqwest Client")
+        };
         let extra_body = match extra_body {
             Some(serde_json::Value::Object(map)) => map,
             _ => serde_json::Map::new(), // Should we panic here?
@@ -359,11 +385,17 @@ impl<T: OpenAIProviderConfig> OpenAICompatibleProvider<T> {
             normalize_response: normalize_response.unwrap_or(true),
             embedding_encoding_format,
             embedding_dimensions,
+            #[cfg(not(target_arch = "wasm32"))]
             client,
             _phantom: PhantomData,
         }
     }
 
+    /// Builds the OpenAI-compatible chat message list for a request.
+    ///
+    /// Only used by the native chat-completions / streaming paths; the WASI
+    /// Preview2 transport only supports the Responses API and does not call this.
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn prepare_messages(
         &self,
         messages: &[ChatMessage],
@@ -386,6 +418,10 @@ impl<T: OpenAIProviderConfig> OpenAICompatibleProvider<T> {
     }
 }
 
+/// Native chat-completions / streaming transport. These impls and helpers go
+/// through `reqwest` and are only compiled on non-wasm32 targets; the WASI
+/// Preview2 transport uses `golem-wasi-http` over the `wasi:http` host interface.
+#[cfg(not(target_arch = "wasm32"))]
 #[async_trait]
 impl<T: OpenAIProviderConfig> ChatProvider for OpenAICompatibleProvider<T> {
     /// Perform a chat request with tool calls
@@ -690,6 +726,7 @@ impl<T: OpenAIProviderConfig> ChatProvider for OpenAICompatibleProvider<T> {
 }
 
 /// State for tracking tool use blocks during OpenAI-compatible streaming
+#[cfg(not(target_arch = "wasm32"))]
 #[derive(Debug, Default)]
 struct OpenAIToolUseState {
     /// Tool ID
@@ -703,6 +740,7 @@ struct OpenAIToolUseState {
 }
 
 /// Creates an SSE stream that parses OpenAI-compatible tool use events into ChatStreamChunk.
+#[cfg(not(target_arch = "wasm32"))]
 fn create_openai_tool_stream(
     response: reqwest::Response,
 ) -> Pin<Box<dyn Stream<Item = Result<ChatStreamChunk, LLMError>> + Send>> {
@@ -749,6 +787,7 @@ fn create_openai_tool_stream(
     Box::pin(stream)
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 fn find_sse_event_boundary(buffer: &[u8]) -> Option<(usize, usize)> {
     let lf = buffer
         .windows(2)
@@ -767,13 +806,7 @@ fn find_sse_event_boundary(buffer: &[u8]) -> Option<(usize, usize)> {
 }
 
 /// Parses OpenAI-compatible SSE chunks with tool use support.
-///
-/// OpenAI streams tool calls as deltas with:
-/// - `tool_calls[].index` - identifies which tool call
-/// - `tool_calls[].id` - tool call ID (first chunk only)
-/// - `tool_calls[].function.name` - function name (first chunk only)
-/// - `tool_calls[].function.arguments` - partial JSON arguments (streamed)
-/// - `finish_reason: "tool_calls"` - signals completion
+#[cfg(not(target_arch = "wasm32"))]
 fn parse_openai_sse_chunk_with_tools(
     event: &str,
     tool_states: &mut HashMap<usize, OpenAIToolUseState>,
@@ -919,6 +952,7 @@ fn parse_openai_sse_chunk_with_tools(
 }
 
 /// OpenAI streaming chunk structure for tool parsing
+#[cfg(not(target_arch = "wasm32"))]
 #[derive(Debug, Deserialize)]
 struct OpenAIToolStreamChunk {
     choices: Vec<OpenAIToolStreamChoice>,
@@ -927,12 +961,14 @@ struct OpenAIToolStreamChunk {
     usage: Option<Usage>,
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 #[derive(Debug, Deserialize)]
 struct OpenAIToolStreamChoice {
     delta: OpenAIToolStreamDelta,
     finish_reason: Option<String>,
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 #[derive(Debug, Deserialize)]
 struct OpenAIToolStreamDelta {
     content: Option<String>,
@@ -941,6 +977,7 @@ struct OpenAIToolStreamDelta {
     tool_calls: Option<Vec<OpenAIToolStreamToolCall>>,
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 #[derive(Debug, Deserialize)]
 struct OpenAIToolStreamToolCall {
     index: Option<usize>,
@@ -948,6 +985,7 @@ struct OpenAIToolStreamToolCall {
     function: OpenAIToolStreamFunction,
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 #[derive(Debug, Deserialize)]
 struct OpenAIToolStreamFunction {
     name: Option<String>,
@@ -956,6 +994,7 @@ struct OpenAIToolStreamFunction {
 }
 
 /// Create OpenAICompatibleChatMessage` that doesn't borrow from any temporary variables
+#[cfg(not(target_arch = "wasm32"))]
 pub fn chat_message_to_openai_message(
     chat_msg: ChatMessage,
 ) -> Result<OpenAIChatMessage<'static>, LLMError> {
@@ -1016,6 +1055,7 @@ pub fn chat_message_to_openai_message(
     Ok(message)
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 struct SSEStreamParser {
     event_buffer: Vec<u8>,
     tool_buffer: ToolCall,
@@ -1024,6 +1064,7 @@ struct SSEStreamParser {
     normalize_response: bool,
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl SSEStreamParser {
     fn new(normalize_response: bool) -> Self {
         Self {
@@ -1183,6 +1224,7 @@ impl SSEStreamParser {
 /// Creates a structured SSE stream that returns `StreamResponse` objects
 ///
 /// Buffer required to accumulate JSON payload lines that are split across multiple SSE chunks
+#[cfg(not(target_arch = "wasm32"))]
 pub fn create_sse_stream(
     response: reqwest::Response,
     normalize_response: bool,
@@ -1200,7 +1242,7 @@ pub fn create_sse_stream(
     Box::pin(stream)
 }
 
-#[cfg(test)]
+#[cfg(all(test, not(target_arch = "wasm32")))]
 mod tests {
     use super::*;
     use crate::chat::FunctionTool;

--- a/crates/autoagents-llm/src/wasi_http.rs
+++ b/crates/autoagents-llm/src/wasi_http.rs
@@ -1,0 +1,364 @@
+//! WASI Preview2 (`wasm32-wasip2`) HTTP client built on `golem-wasi-http`.
+//!
+//! This module is compiled only for `wasm32-wasip2` with the `wasi-http`
+//! feature. It provides a minimal, reqwest-style POST-with-Bearer-auth helper
+//! backed by the [`golem_wasi_http::Client`], which itself wraps the `wasi:http`
+//! / `wasi:io` host interfaces.
+//!
+//! Only the request shape needed by the OpenAI Responses backend is supported:
+//! `POST` with a JSON body authenticated via `Authorization: Bearer <token>`.
+//!
+//! Timeouts are applied through `golem-wasi-http`'s connect / first-byte /
+//! between-bytes configuration when a non-zero `timeout_seconds` is supplied.
+//! A zero timeout leaves the host's defaults in place.
+
+use std::time::Duration;
+
+use golem_wasi_http::header::{CONTENT_TYPE, HeaderMap};
+use golem_wasi_http::{
+    Client, Error as GolemError, IncomingBody, InputStream, Response, StreamError,
+};
+
+use crate::error::LLMError;
+use crate::http::MAX_HTTP_ERROR_BODY_BYTES;
+
+/// A fully buffered HTTP response.
+///
+/// This is our own small abstraction over [`golem_wasi_http::Response`] so the
+/// caller (`crates/autoagents-llm/src/backends/openai.rs`) does not depend on
+/// the crate's response type. The body is read completely into memory by
+/// `golem-wasi-http` before being returned here.
+#[derive(Debug)]
+pub(crate) struct HttpResponseData {
+    /// HTTP response status code (e.g. `200`, `429`).
+    pub status: u16,
+    /// Response headers, lower-cased names paired with their string values.
+    pub headers: Vec<(String, String)>,
+    /// Decoded response body text.
+    pub body: String,
+}
+
+/// Shared request builder for [`post_json_bearer`] (which buffers the whole
+/// body) and [`post_json_bearer_stream`] (which leaves the body for incremental
+/// reading). Returns the underlying [`golem_wasi_http::Response`] unbuffered.
+fn send_post_request(
+    url: &str,
+    bearer_token: &str,
+    json_body: &[u8],
+    timeout_seconds: u64,
+) -> Result<Response, LLMError> {
+    // Parse the URL ourselves for a clearer error than golem's generic builder error.
+    let parsed_url = url::Url::parse(url)
+        .map_err(|e| LLMError::HttpError(format!("invalid request URL: {e}")))?;
+
+    let client = build_client(timeout_seconds)?;
+
+    if log::log_enabled!(log::Level::Trace) {
+        log::trace!("WASI HTTP POST {url} ({} byte body)", json_body.len());
+    }
+
+    client
+        .post(parsed_url)
+        .bearer_auth(bearer_token)
+        .header(CONTENT_TYPE, "application/json")
+        .body(json_body.to_vec())
+        .send()
+        .map_err(golem_error_to_llm)
+}
+
+/// Reads an error (non-2xx) response body up to
+/// [`MAX_HTTP_ERROR_BODY_BYTES`](crate::http::MAX_HTTP_ERROR_BODY_BYTES),
+/// mirroring the native `reqwest` transport's `read_bounded_error_body`.
+///
+/// When `Content-Length` exceeds the cap the body is not read at all and a
+/// placeholder is returned; otherwise the body is streamed through
+/// [`WasiResponseStream`] and accumulation stops at the cap with a truncation
+/// marker. This keeps multi-MB CDN/WAF error pages out of `wasm32-wasip2`'s
+/// constrained linear memory — the same defense the native path applies.
+fn read_bounded_error_body(mut response: Response) -> Result<String, LLMError> {
+    if let Some(content_length) = response.content_length()
+        && content_length > MAX_HTTP_ERROR_BODY_BYTES as u64
+    {
+        return Ok(format!(
+            "... [body omitted, Content-Length: {content_length} bytes]"
+        ));
+    }
+
+    let (input_stream, incoming_body) = response.get_raw_input_stream();
+    let mut reader = WasiResponseStream::new(input_stream, incoming_body);
+    let mut collected: Vec<u8> = Vec::with_capacity(MAX_HTTP_ERROR_BODY_BYTES.min(8192));
+    let mut total_received = 0usize;
+
+    while let Some(chunk) = reader.read_chunk()? {
+        total_received += chunk.len();
+        let remaining = MAX_HTTP_ERROR_BODY_BYTES.saturating_sub(collected.len());
+        if chunk.len() <= remaining {
+            collected.extend_from_slice(&chunk);
+        } else {
+            collected.extend_from_slice(&chunk[..remaining]);
+        }
+
+        if collected.len() >= MAX_HTTP_ERROR_BODY_BYTES {
+            let truncated = String::from_utf8_lossy(&collected).into_owned();
+            return Ok(format!(
+                "{truncated}... [truncated after reading {total_received} bytes]"
+            ));
+        }
+    }
+
+    Ok(String::from_utf8_lossy(&collected).into_owned())
+}
+
+/// Sends a JSON `POST` request authenticated with a bearer token and returns
+/// the fully buffered response.
+///
+/// `timeout_seconds` of `0` leaves the host's default timeouts in place.
+/// Transport failures map to [`LLMError::HttpError`]; non-success status codes
+/// are returned in [`HttpResponseData`] for the caller to pass through
+/// [`map_http_status_to_error`](crate::http::map_http_status_to_error).
+///
+/// On success (2xx) the body is buffered fully via
+/// [`golem_wasi_http::Response::text`] (the Responses API returns the complete
+/// JSON object, matching the native `reqwest` path). On a non-success status
+/// the body is bounded by [`read_bounded_error_body`] so large error pages
+/// cannot exhaust the linear memory.
+pub(crate) fn post_json_bearer(
+    url: &str,
+    bearer_token: &str,
+    json_body: &[u8],
+    timeout_seconds: u64,
+) -> Result<HttpResponseData, LLMError> {
+    let response = send_post_request(url, bearer_token, json_body, timeout_seconds)?;
+
+    let status = response.status().as_u16();
+    let headers = collect_headers(response.headers());
+
+    let is_success = (200..300).contains(&status);
+    let body = if is_success {
+        // Success: the Responses API returns the complete JSON body.
+        response.text().map_err(golem_error_to_llm)?
+    } else {
+        // Error: bound the body to keep large error pages out of memory.
+        read_bounded_error_body(response)?
+    };
+
+    Ok(HttpResponseData {
+        status,
+        headers,
+        body,
+    })
+}
+
+/// Sends a JSON `POST` request and returns the response without buffering the
+/// body, so the caller can consume it incrementally as a stream of chunks.
+///
+/// This is the streaming counterpart of [`post_json_bearer`]. Use
+/// [`StreamingResponse::into_byte_stream`] on the success path (e.g. for SSE
+/// responses) and [`StreamingResponse::into_bounded_error_text`] on the error
+/// path (to surface a meaningful but memory-bounded error body, mirroring the
+/// native `ensure_success` behavior).
+pub(crate) fn post_json_bearer_stream(
+    url: &str,
+    bearer_token: &str,
+    json_body: &[u8],
+    timeout_seconds: u64,
+) -> Result<StreamingResponse, LLMError> {
+    let response = send_post_request(url, bearer_token, json_body, timeout_seconds)?;
+    let status = response.status().as_u16();
+    let headers = collect_headers(response.headers());
+    Ok(StreamingResponse {
+        status,
+        headers,
+        response,
+    })
+}
+
+/// HTTP response whose body can be consumed incrementally as a stream of
+/// chunks (for SSE-style responses) or fully buffered as text (for error
+/// bodies).
+///
+/// Returned by [`post_json_bearer_stream`]. Body-consuming methods take `self`
+/// by value so the body can only be read once, matching the single-consume
+/// semantics of the underlying `wasi:http` incoming body.
+pub(crate) struct StreamingResponse {
+    status: u16,
+    headers: Vec<(String, String)>,
+    response: Response,
+}
+
+impl StreamingResponse {
+    /// HTTP response status code (e.g. `200`, `429`).
+    pub(crate) fn status(&self) -> u16 {
+        self.status
+    }
+
+    /// Response headers (lower-cased names), for `Retry-After` lookup.
+    pub(crate) fn headers(&self) -> &[(String, String)] {
+        &self.headers
+    }
+
+    /// Consumes the response and returns a chunk reader over the body.
+    ///
+    /// Use this on the success path for streaming responses.
+    pub(crate) fn into_byte_stream(mut self) -> Result<WasiResponseStream, LLMError> {
+        let (input_stream, incoming_body) = self.response.get_raw_input_stream();
+        Ok(WasiResponseStream::new(input_stream, incoming_body))
+    }
+
+    /// Buffers the response body up to
+    /// [`MAX_HTTP_ERROR_BODY_BYTES`](crate::http::MAX_HTTP_ERROR_BODY_BYTES) for
+    /// use as an error body (non-success status), mirroring the native
+    /// `read_bounded_error_body`. Use this on the error path to surface a
+    /// meaningful but memory-bounded error body.
+    pub(crate) fn into_bounded_error_text(self) -> Result<String, LLMError> {
+        read_bounded_error_body(self.response)
+    }
+}
+
+/// Bytes requested per `InputStream::blocking_read` call. Bounding reads lets
+/// incremental SSE parsing surface events promptly; `blocking_read` returns at
+/// least one byte (or `Closed`) regardless.
+const WASI_READ_CHUNK_SIZE: u64 = 64 * 1024;
+
+/// Blocking chunk reader over a WASI HTTP response body.
+///
+/// Wraps the raw [`InputStream`] returned by
+/// [`golem_wasi_http::Response::get_raw_input_stream`]. Each
+/// [`WasiResponseStream::read_chunk`] call performs a single blocking read (the
+/// WASI host multiplexes other work while the current thread is blocked) and
+/// returns `Ok(None)` at end of stream.
+///
+/// # Field / drop order
+///
+/// `input_stream` is declared before `incoming_body` so that, on drop, the
+/// child input-stream is released before its parent incoming-body — the
+/// ordering required by the `wasi:http/types` contract.
+pub(crate) struct WasiResponseStream {
+    input_stream: Option<InputStream>,
+    incoming_body: Option<IncomingBody>,
+    done: bool,
+}
+
+impl WasiResponseStream {
+    fn new(input_stream: InputStream, incoming_body: IncomingBody) -> Self {
+        Self {
+            input_stream: Some(input_stream),
+            incoming_body: Some(incoming_body),
+            done: false,
+        }
+    }
+
+    /// Reads up to 64KiB of the response body, blocking until at least one byte
+    /// is available. Returns `Ok(None)` once the stream has ended.
+    pub(crate) fn read_chunk(&mut self) -> Result<Option<Vec<u8>>, LLMError> {
+        if self.done {
+            return Ok(None);
+        }
+        let Some(stream) = self.input_stream.as_ref() else {
+            return Ok(None);
+        };
+
+        match stream.blocking_read(WASI_READ_CHUNK_SIZE) {
+            // `blocking_read` is documented to return at least one byte (or
+            // `StreamError::Closed`); treat an empty result defensively as EOF.
+            Ok(bytes) if bytes.is_empty() => {
+                self.finish();
+                Ok(None)
+            }
+            Ok(bytes) => Ok(Some(bytes)),
+            Err(StreamError::Closed) => {
+                self.finish();
+                Ok(None)
+            }
+            Err(StreamError::LastOperationFailed(err)) => {
+                self.finish();
+                Err(LLMError::HttpError(format!(
+                    "WASI response stream read failed: {err}"
+                )))
+            }
+        }
+    }
+
+    /// Marks the reader as finished and releases both WASI handles in the order
+    /// required by the `wasi:http/types` contract (input-stream first, then the
+    /// parent incoming-body). Idempotent.
+    fn finish(&mut self) {
+        self.done = true;
+        self.input_stream.take();
+        self.incoming_body.take();
+    }
+}
+
+/// Builds a [`Client`] with the requested timeout applied to the connect,
+/// first-byte and between-bytes knobs. A zero `timeout_seconds` leaves the
+/// host's defaults in place.
+fn build_client(timeout_seconds: u64) -> Result<Client, LLMError> {
+    let mut builder = Client::builder();
+    if timeout_seconds > 0 {
+        let duration = Duration::from_secs(timeout_seconds);
+        // `timeout` covers first-byte and between-bytes; `connect_timeout`
+        // covers the connect phase. Setting both applies the same deadline to
+        // all phases the WASI HTTP client exposes.
+        builder = builder.timeout(duration).connect_timeout(duration);
+    }
+    builder.build().map_err(golem_error_to_llm)
+}
+
+/// Collects a [`golem_wasi_http`] response's headers into name/value pairs.
+///
+/// [`http::HeaderName`] already normalizes names to lowercase. Values may be
+/// non-UTF-8 bytes (rare for JSON APIs); such values fall back to an empty
+/// string rather than surfacing the conversion error to the caller.
+fn collect_headers(headers: &HeaderMap) -> Vec<(String, String)> {
+    headers
+        .iter()
+        .map(|(name, value)| {
+            let value_str = value.to_str().unwrap_or_default().to_string();
+            (name.as_str().to_string(), value_str)
+        })
+        .collect()
+}
+
+/// Maps a [`golem_wasi_http::Error`] to an [`LLMError::HttpError`].
+///
+/// Timeouts are reported with a `"request timed out:"` prefix so the shared
+/// retryability classifier
+/// ([`is_transport_retryable_message`](crate::error::is_transport_retryable_message))
+/// treats them as retryable.
+fn golem_error_to_llm(err: GolemError) -> LLMError {
+    if err.is_timeout() {
+        LLMError::HttpError(format!("request timed out: {err}"))
+    } else {
+        LLMError::HttpError(format!("{err}"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+
+    // NOTE: this module only compiles for `wasm32-wasip2` + `wasi-http`, so
+    // these tests run under `cargo test --target wasm32-wasip2` and the
+    // `examples/wasm_smoke` harness, NOT the default native `cargo test` suite.
+    // The transport-agnostic `Retry-After` lookup (`find_retry_after`) is now
+    // shared in `crate::http` and covered natively in `crate::http::tests`.
+
+    #[test]
+    fn http_response_data_roundtrips_fields() {
+        // Exercises the data contract the OpenAI Responses caller relies on:
+        // status, headers and body are preserved verbatim, and `Retry-After`
+        // is discoverable from the buffered headers.
+        let data = HttpResponseData {
+            status: 429,
+            headers: vec![("retry-after".to_string(), "5".to_string())],
+            body: r#"{"error":"rate limited"}"#.to_string(),
+        };
+        assert_eq!(data.status, 429);
+        assert_eq!(
+            crate::http::find_retry_after(&data.headers),
+            Some(Duration::from_secs(5))
+        );
+        assert_eq!(data.body, r#"{"error":"rate limited"}"#);
+    }
+}


### PR DESCRIPTION
Adds WASI Preview2 (wasm32-wasip2) support for the OpenAI Responses backend, so autoagents-llm can be compiled to a WebAssembly component and run under a WASI Preview2 host (e.g. wasmtime) while calling the OpenAI Responses API over the wasi:http host interface.

Scoped to OpenAI only. Other providers, model listing, and embeddings are intentionally deferred to follow-up issues.

What's included

 - New transport crates/autoagents-llm/src/wasi_http.rs — reqwest-style HTTP over golem-wasi-http (wasi:http), supporting buffered and streaming response bodies.
 - OpenAI Responses over WASI: non-streaming chat, SSE streaming (text / reasoning / tool-call / usage deltas), and 429 rate-limit handling with Retry-After parsing. SSE is read via blocking InputStream with correct wasi:http drop ordering.
 - Compile-time guards — build.rs cfg aliases (native / wasi_http) keyed off CARGO_CFG_TARGET_*, plus compile_error!s for unsupported target/feature combinations (non-WASI wasm, wasip1, wasip2 without wasi-http, wasip2 with non-OpenAI providers).
 - Smoke harness examples/wasm_smoke/ — a native mock server + a wasm agent example + run.sh that builds the component and asserts non-stream / stream / 429 paths end-to-end under wasmtime.

Intentionally out of scope (follow-ups)

For v1 these return a typed LLMError (via OpenAI::wasi_unsupported) — no panics, and all LLMProvider trait bounds remain satisfied:

 - list_models / embed on WASI (transport is currently POST + Bearer only; needs GET / header generalization).
 - Non-OpenAI providers on WASI.
 - Legacy complete (already a stub on native).

A transport-trait refactor to generalize auth/methods will unblock these cleanly.

How to verify

 ```bash
   # Native lint (CI gate)
   cargo clippy -p autoagents-llm --features openai,wasi-http --all-targets -- -D warnings

   # End-to-end: builds the wasm component, runs it against a mock server under wasmtime
   bash crates/autoagents-llm/examples/wasm_smoke/run.sh
   # expect: WASM_SMOKE_OK
 ```