### PR TITLE
[FEATURE] Add WASI support for model listing and embeddings in OpenAI

### DIFF
--- a/crates/autoagents-llm/examples/wasm_smoke/agent.rs
+++ b/crates/autoagents-llm/examples/wasm_smoke/agent.rs
@@ -23,7 +23,9 @@
 
 use autoagents_llm::backends::openai::{OpenAI, OpenAIApiMode};
 use autoagents_llm::chat::{ChatMessage, ChatProvider};
+use autoagents_llm::embedding::EmbeddingProvider;
 use autoagents_llm::error::LLMError;
+use autoagents_llm::models::ModelsProvider;
 use futures::StreamExt;
 use serde_json::{Map, Value, json};
 
@@ -93,6 +95,8 @@ async fn run() -> Result<(), LLMError> {
     )
     .await?;
     run_stream_smoke(&provider, cfg.strict_mock_expectations, &cfg.stream_prompt).await?;
+    run_model_list_smoke(&provider, cfg.strict_mock_expectations).await?;
+    run_embeddings_smoke(&provider, cfg.strict_mock_expectations).await?;
 
     if cfg.run_error_test {
         run_error_smoke(&provider).await?;
@@ -100,6 +104,70 @@ async fn run() -> Result<(), LLMError> {
         println!("PROVIDER_ERROR_429_SKIPPED");
     }
 
+    Ok(())
+}
+
+/// Lists models through the public provider trait and validates the response.
+async fn run_model_list_smoke(
+    provider: &OpenAI,
+    strict_mock_expectations: bool,
+) -> Result<(), LLMError> {
+    let response = provider.list_models(None).await?;
+    let models = response.get_models();
+    if strict_mock_expectations {
+        let expected = vec!["gpt-4.1".to_string(), "gpt-4o-mini".to_string()];
+        if models != expected {
+            return Err(LLMError::ResponseFormatError {
+                message: format!("unexpected model list from mock server: {models:?}"),
+                raw_response: format!("{models:?}"),
+            });
+        }
+    } else if models.is_empty() {
+        return Err(LLMError::ResponseFormatError {
+            message: "real API model list was empty".to_string(),
+            raw_response: String::default(),
+        });
+    }
+
+    println!(
+        "PROVIDER_MODELS_OK count={} first={}",
+        models.len(),
+        models.first().cloned().unwrap_or_default()
+    );
+    Ok(())
+}
+
+/// Runs an embeddings request through the public provider trait and validates the response.
+async fn run_embeddings_smoke(
+    provider: &OpenAI,
+    strict_mock_expectations: bool,
+) -> Result<(), LLMError> {
+    let embeddings = provider
+        .embed(vec!["alpha".to_string(), "beta".to_string()])
+        .await?;
+    if strict_mock_expectations {
+        let expected = vec![vec![0.1_f32, 0.2, 0.3], vec![0.4_f32, 0.5, 0.6]];
+        if embeddings != expected {
+            return Err(LLMError::ResponseFormatError {
+                message: format!("unexpected embeddings from mock server: {embeddings:?}"),
+                raw_response: format!("{embeddings:?}"),
+            });
+        }
+    } else if embeddings.is_empty() || embeddings.iter().any(|embedding| embedding.is_empty()) {
+        return Err(LLMError::ResponseFormatError {
+            message: "real API embeddings response was empty".to_string(),
+            raw_response: format!("{embeddings:?}"),
+        });
+    }
+
+    println!(
+        "PROVIDER_EMBED_OK count={} dims={}",
+        embeddings.len(),
+        embeddings
+            .first()
+            .map(|embedding| embedding.len())
+            .unwrap_or(0)
+    );
     Ok(())
 }
 

--- a/crates/autoagents-llm/examples/wasm_smoke/mock_server.rs
+++ b/crates/autoagents-llm/examples/wasm_smoke/mock_server.rs
@@ -299,6 +299,34 @@ data: [DONE]
                 &[],
             )
         }
+    } else if method == "GET" && path == "/v1/models" {
+        send_response(
+            stream,
+            200,
+            "application/json",
+            br#"{
+  "data": [
+    { "id": "gpt-4.1", "created": 1 },
+    { "id": "gpt-4o-mini", "created": 2 }
+  ]
+}
+"#,
+            &[],
+        )
+    } else if method == "POST" && path == "/v1/embeddings" {
+        send_response(
+            stream,
+            200,
+            "application/json",
+            br#"{
+  "data": [
+    { "embedding": [0.1, 0.2, 0.3] },
+    { "embedding": [0.4, 0.5, 0.6] }
+  ]
+}
+"#,
+            &[],
+        )
     } else {
         send_response(
             stream,

--- a/crates/autoagents-llm/examples/wasm_smoke/run.sh
+++ b/crates/autoagents-llm/examples/wasm_smoke/run.sh
@@ -72,5 +72,7 @@ fi
 grep -q 'PROVIDER_NON_STREAM_OK' "$stdout_log"
 grep -q 'PROVIDER_STREAM_OK text_delta=true reasoning_delta=true tool_call=true usage=true' "$stdout_log"
 grep -q 'PROVIDER_ERROR_429_OK' "$stdout_log"
+grep -q 'PROVIDER_MODELS_OK count=2 first=gpt-4.1' "$stdout_log"
+grep -q 'PROVIDER_EMBED_OK count=2 dims=3' "$stdout_log"
 
 printf 'WASM_SMOKE_OK\n'

--- a/crates/autoagents-llm/src/backends/openai.rs
+++ b/crates/autoagents-llm/src/backends/openai.rs
@@ -2,7 +2,7 @@
 //!
 //! This module provides integration with OpenAI's GPT models through their API.
 
-#[cfg(native)]
+#[cfg(any(native, wasi_http))]
 use crate::builder::LLMBackend;
 use crate::builder::LLMBuilder;
 use crate::chat::Usage;
@@ -15,7 +15,7 @@ use crate::embedding::EmbeddingBuilder;
 use crate::http::ensure_success;
 #[cfg(wasi_http)]
 use crate::http::map_http_status_to_error;
-#[cfg(native)]
+#[cfg(any(native, wasi_http))]
 use crate::models::StandardModelListResponse;
 #[cfg(native)]
 use crate::providers::openai_compatible::{
@@ -627,7 +627,7 @@ impl OpenAI {
     }
 }
 
-#[cfg(native)]
+#[cfg(any(native, wasi_http))]
 #[derive(Serialize)]
 struct OpenAIEmbeddingRequest {
     model: String,
@@ -638,13 +638,13 @@ struct OpenAIEmbeddingRequest {
     dimensions: Option<u32>,
 }
 
-#[cfg(native)]
+#[cfg(any(native, wasi_http))]
 #[derive(Deserialize, Debug)]
 struct OpenAIEmbeddingData {
     embedding: Vec<f32>,
 }
 
-#[cfg(native)]
+#[cfg(any(native, wasi_http))]
 #[derive(Deserialize, Debug)]
 struct OpenAIEmbeddingResponse {
     data: Vec<OpenAIEmbeddingData>,
@@ -837,9 +837,8 @@ impl CompletionProvider for OpenAI {
     }
 }
 
-// Model listing goes through `reqwest`; gate the override native-only so that
-// on WASI Preview2 the trait's default `list_models` ("List Models not
-// supported") applies.
+// Model listing uses the same `/models` endpoint on both native and WASI;
+// only the transport changes.
 #[cfg(native)]
 #[async_trait]
 impl ModelsProvider for OpenAI {
@@ -847,10 +846,7 @@ impl ModelsProvider for OpenAI {
         &self,
         _request: Option<&ModelListRequest>,
     ) -> Result<Box<dyn ModelListResponse>, LLMError> {
-        let url = self
-            .base_url()
-            .join("models")
-            .map_err(|e| LLMError::HttpError(e.to_string()))?;
+        let url = self.models_url()?;
 
         let resp = self
             .client()
@@ -868,9 +864,6 @@ impl ModelsProvider for OpenAI {
     }
 }
 
-// On WASI Preview2 model listing is not implemented yet; return a clear error
-// so the `LLMProvider` trait bound (which requires `ModelsProvider`) is
-// satisfied.
 #[cfg(wasi_http)]
 #[async_trait]
 impl ModelsProvider for OpenAI {
@@ -878,7 +871,33 @@ impl ModelsProvider for OpenAI {
         &self,
         _request: Option<&ModelListRequest>,
     ) -> Result<Box<dyn ModelListResponse>, LLMError> {
-        Err(Self::wasi_unsupported("OpenAI model listing"))
+        let response = crate::wasi_http::get_bearer(
+            self.models_url()?.as_str(),
+            &self.provider.api_key,
+            self.provider.timeout_seconds,
+        )?;
+        log::debug!("OpenAI model-list HTTP status: {}", response.status);
+
+        if !(200..300).contains(&response.status) {
+            let retry_after = crate::http::find_retry_after(&response.headers);
+            return Err(map_http_status_to_error(
+                "OpenAI",
+                response.status,
+                response.body,
+                retry_after,
+            ));
+        }
+
+        let inner: crate::models::StandardModelListResponseInner =
+            serde_json::from_str(&response.body).map_err(|e| LLMError::ResponseFormatError {
+                message: format!("Failed to decode OpenAI model list response: {e}"),
+                raw_response: response.body.clone(),
+            })?;
+
+        Ok(Box::new(StandardModelListResponse {
+            inner,
+            backend: LLMBackend::OpenAI,
+        }))
     }
 }
 
@@ -912,6 +931,22 @@ impl OpenAI {
     #[cfg(native)]
     pub fn client(&self) -> &reqwest::Client {
         &self.provider.client
+    }
+
+    #[cfg(any(native, wasi_http))]
+    fn models_url(&self) -> Result<url::Url, LLMError> {
+        self.provider
+            .base_url
+            .join("models")
+            .map_err(|e| LLMError::HttpError(e.to_string()))
+    }
+
+    #[cfg(any(native, wasi_http))]
+    fn embeddings_url(&self) -> Result<url::Url, LLMError> {
+        self.provider
+            .base_url
+            .join("embeddings")
+            .map_err(|e| LLMError::HttpError(e.to_string()))
     }
 
     #[cfg(native)]
@@ -1922,13 +1957,12 @@ impl OpenAI {
 /// the stream reaches EOF without a trailing `\n\n` delimiter.
 #[cfg(wasi_http)]
 fn responses_eof_flush(
-    buffer: &mut Vec<u8>,
+    event_bytes: Vec<u8>,
     state: &mut ResponsesStreamState,
 ) -> Result<Vec<StreamChunk>, LLMError> {
-    if buffer.is_empty() {
+    if event_bytes.is_empty() {
         return Ok(Vec::new());
     }
-    let event_bytes = std::mem::take(buffer);
     let event = String::from_utf8_lossy(&event_bytes).into_owned();
     parse_responses_sse_event(event.trim(), state)
 }
@@ -2020,7 +2054,8 @@ impl Stream for WasiResponsesStream {
                     // candidate so that a last SSE event without a trailing
                     // `\n\n` delimiter is still parsed.
                     self.finished = true;
-                    match responses_eof_flush(&mut self.buffer, &mut self.state) {
+                    let event_bytes = std::mem::take(&mut self.buffer);
+                    match responses_eof_flush(event_bytes, &mut self.state) {
                         Ok(chunks) if chunks.is_empty() => {
                             return std::task::Poll::Ready(None);
                         }
@@ -2105,9 +2140,8 @@ impl LLMBuilder<OpenAI> {
     }
 }
 
-// Embeddings go over `reqwest`; the WASI Preview2 transport does not implement
-// them in this first pass. Split into a native impl and a WASI stub so the
-// `EmbeddingProvider` trait (which has no default `embed`) is always satisfied.
+// Embeddings use the same `/embeddings` endpoint on both native and WASI;
+// only the transport changes.
 #[cfg(all(feature = "openai", not(target_arch = "wasm32")))]
 #[async_trait]
 impl EmbeddingProvider for OpenAI {
@@ -2131,11 +2165,7 @@ impl EmbeddingProvider for OpenAI {
             dimensions: self.provider.embedding_dimensions,
         };
 
-        let url = self
-            .provider
-            .base_url
-            .join("embeddings")
-            .map_err(|e| LLMError::HttpError(e.to_string()))?;
+        let url = self.embeddings_url()?;
 
         let resp = self
             .provider
@@ -2157,8 +2187,51 @@ impl EmbeddingProvider for OpenAI {
 #[cfg(all(feature = "openai", wasi_http))]
 #[async_trait]
 impl EmbeddingProvider for OpenAI {
-    async fn embed(&self, _input: Vec<String>) -> Result<Vec<Vec<f32>>, LLMError> {
-        Err(Self::wasi_unsupported("OpenAI embeddings"))
+    async fn embed(&self, input: Vec<String>) -> Result<Vec<Vec<f32>>, LLMError> {
+        if self.provider.api_key.is_empty() {
+            return Err(LLMError::missing_api_key(
+                "Missing OpenAI API key".to_string(),
+            ));
+        }
+
+        let emb_format = self
+            .provider
+            .embedding_encoding_format
+            .clone()
+            .unwrap_or_else(|| "float".to_string());
+
+        let body = OpenAIEmbeddingRequest {
+            model: self.provider.model.to_string(),
+            input,
+            encoding_format: Some(emb_format),
+            dimensions: self.provider.embedding_dimensions,
+        };
+
+        let response = crate::wasi_http::post_json_bearer(
+            self.embeddings_url()?.as_str(),
+            &self.provider.api_key,
+            &serde_json::to_vec(&body).map_err(LLMError::from)?,
+            self.provider.timeout_seconds,
+        )?;
+        log::debug!("OpenAI embeddings HTTP status: {}", response.status);
+
+        if !(200..300).contains(&response.status) {
+            let retry_after = crate::http::find_retry_after(&response.headers);
+            return Err(map_http_status_to_error(
+                "OpenAI",
+                response.status,
+                response.body,
+                retry_after,
+            ));
+        }
+
+        let json_resp: OpenAIEmbeddingResponse =
+            serde_json::from_str(&response.body).map_err(|e| LLMError::ResponseFormatError {
+                message: format!("Failed to decode OpenAI embeddings response: {e}"),
+                raw_response: response.body.clone(),
+            })?;
+
+        Ok(json_resp.data.into_iter().map(|d| d.embedding).collect())
     }
 }
 

--- a/crates/autoagents-llm/src/backends/openai.rs
+++ b/crates/autoagents-llm/src/backends/openai.rs
@@ -3327,57 +3327,49 @@ data: [DONE]
     #[cfg(wasi_http)]
     #[test]
     fn test_responses_eof_flush_valid_event() {
-        let mut buffer =
+        let buffer =
             b"data: {\"type\":\"response.output_text.delta\",\"delta\":\"Hello\"}".to_vec();
         let mut state = ResponsesStreamState::default();
 
-        let chunks =
-            responses_eof_flush(&mut buffer, &mut state).expect("eof flush should succeed");
+        let chunks = responses_eof_flush(buffer, &mut state).expect("eof flush should succeed");
         assert_eq!(chunks.len(), 1);
         assert!(matches!(&chunks[0], StreamChunk::Text(text) if text == "Hello"));
-        assert!(buffer.is_empty(), "buffer should be cleared after flush");
     }
 
     #[cfg(wasi_http)]
     #[test]
     fn test_responses_eof_flush_done_with_usage() {
-        let mut buffer =
+        let buffer =
             br#"data: {"type":"response.done","response":{"usage":{"input_tokens":2,"output_tokens":3,"total_tokens":5}}}"#
                 .to_vec();
         let mut state = ResponsesStreamState::default();
 
-        let chunks =
-            responses_eof_flush(&mut buffer, &mut state).expect("eof flush should succeed");
+        let chunks = responses_eof_flush(buffer, &mut state).expect("eof flush should succeed");
         assert_eq!(chunks.len(), 2);
         assert!(matches!(&chunks[0], StreamChunk::Usage(usage) if usage.total_tokens == 5));
         assert!(
             matches!(&chunks[1], StreamChunk::Done { stop_reason } if stop_reason == "end_turn")
         );
-        assert!(buffer.is_empty(), "buffer should be cleared after flush");
     }
 
     #[cfg(wasi_http)]
     #[test]
     fn test_responses_eof_flush_garbage_event() {
-        let mut buffer = b"data: not-valid-json-trailing-garbage".to_vec();
+        let buffer = b"data: not-valid-json-trailing-garbage".to_vec();
         let mut state = ResponsesStreamState::default();
 
-        let err = responses_eof_flush(&mut buffer, &mut state)
-            .expect_err("eof flush should fail on garbage");
+        let err =
+            responses_eof_flush(buffer, &mut state).expect_err("eof flush should fail on garbage");
         assert!(err.to_string().contains("not-valid-json-trailing-garbage"));
-        assert!(
-            buffer.is_empty(),
-            "buffer should be cleared after failed flush"
-        );
     }
 
     #[cfg(wasi_http)]
     #[test]
     fn test_responses_eof_flush_empty_buffer() {
-        let mut buffer = Vec::new();
+        let buffer = Vec::new();
         let mut state = ResponsesStreamState::default();
 
-        let chunks = responses_eof_flush(&mut buffer, &mut state)
+        let chunks = responses_eof_flush(buffer, &mut state)
             .expect("eof flush on empty buffer should succeed");
         assert!(chunks.is_empty());
     }

--- a/crates/autoagents-llm/src/wasi_http.rs
+++ b/crates/autoagents-llm/src/wasi_http.rs
@@ -66,6 +66,29 @@ fn send_post_request(
         .map_err(golem_error_to_llm)
 }
 
+/// Issues a bearer-authenticated `GET` request and returns the underlying
+/// [`golem_wasi_http::Response`] unbuffered.
+fn send_get_request(
+    url: &str,
+    bearer_token: &str,
+    timeout_seconds: u64,
+) -> Result<Response, LLMError> {
+    let parsed_url = url::Url::parse(url)
+        .map_err(|e| LLMError::HttpError(format!("invalid request URL: {e}")))?;
+
+    let client = build_client(timeout_seconds)?;
+
+    if log::log_enabled!(log::Level::Trace) {
+        log::trace!("WASI HTTP GET {url}");
+    }
+
+    client
+        .get(parsed_url)
+        .bearer_auth(bearer_token)
+        .send()
+        .map_err(golem_error_to_llm)
+}
+
 /// Reads an error (non-2xx) response body up to
 /// [`MAX_HTTP_ERROR_BODY_BYTES`](crate::http::MAX_HTTP_ERROR_BODY_BYTES),
 /// mirroring the native `reqwest` transport's `read_bounded_error_body`.
@@ -109,6 +132,26 @@ fn read_bounded_error_body(mut response: Response) -> Result<String, LLMError> {
     Ok(String::from_utf8_lossy(&collected).into_owned())
 }
 
+/// Buffers a response into [`HttpResponseData`], using full-body reads for
+/// success statuses and bounded reads for non-success statuses.
+fn buffer_response(response: Response) -> Result<HttpResponseData, LLMError> {
+    let status = response.status().as_u16();
+    let headers = collect_headers(response.headers());
+
+    let is_success = (200..300).contains(&status);
+    let body = if is_success {
+        response.text().map_err(golem_error_to_llm)?
+    } else {
+        read_bounded_error_body(response)?
+    };
+
+    Ok(HttpResponseData {
+        status,
+        headers,
+        body,
+    })
+}
+
 /// Sends a JSON `POST` request authenticated with a bearer token and returns
 /// the fully buffered response.
 ///
@@ -129,24 +172,18 @@ pub(crate) fn post_json_bearer(
     timeout_seconds: u64,
 ) -> Result<HttpResponseData, LLMError> {
     let response = send_post_request(url, bearer_token, json_body, timeout_seconds)?;
+    buffer_response(response)
+}
 
-    let status = response.status().as_u16();
-    let headers = collect_headers(response.headers());
-
-    let is_success = (200..300).contains(&status);
-    let body = if is_success {
-        // Success: the Responses API returns the complete JSON body.
-        response.text().map_err(golem_error_to_llm)?
-    } else {
-        // Error: bound the body to keep large error pages out of memory.
-        read_bounded_error_body(response)?
-    };
-
-    Ok(HttpResponseData {
-        status,
-        headers,
-        body,
-    })
+/// Sends a bearer-authenticated `GET` request and returns the fully buffered
+/// response.
+pub(crate) fn get_bearer(
+    url: &str,
+    bearer_token: &str,
+    timeout_seconds: u64,
+) -> Result<HttpResponseData, LLMError> {
+    let response = send_get_request(url, bearer_token, timeout_seconds)?;
+    buffer_response(response)
 }
 
 /// Sends a JSON `POST` request and returns the response without buffering the


### PR DESCRIPTION
## Summary
This PR extends the WASI HTTP OpenAI transport to cover the remaining provider paths that still differed from the native implementation, and tightens the EOF handling for the Responses SSE stream.

### What changed
- Added a shared buffered-response path for WASI HTTP requests
- Added bearer-authenticated `GET` support in `wasi_http.rs`
- Enabled OpenAI `list_models()` on WASI via the `/models` endpoint
- Enabled OpenAI embeddings on WASI via the `/embeddings` endpoint
- Fixed the EOF flush path so the final SSE event is still parsed even if the stream ends without a trailing blank-line delimiter
- Extended the WASM smoke test + mock server to verify:
  - non-stream chat
  - streaming responses
  - model listing
  - embeddings
  - error mapping (`429` / `Retry-After`)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds more WASI HTTP coverage for OpenAI provider operations. The main changes are:

- Shared buffered response handling for WASI HTTP requests.
- Bearer-authenticated WASI `GET` support.
- WASI model listing through `/models`.
- WASI embeddings through `/embeddings`.
- EOF flushing for final Responses SSE events.
- Expanded WASM smoke coverage for models, embeddings, streaming, and rate-limit errors.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- The previously broken WASI EOF-flush test calls now pass an owned buffer.
- The new WASI provider paths use the same status mapping and JSON decoding shape as the existing transport paths.
- No blocking issues were found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| crates/autoagents-llm/src/backends/openai.rs | Adds WASI implementations for model listing and embeddings, reuses URL helpers, and updates the EOF flush helper and tests. |
| crates/autoagents-llm/src/wasi_http.rs | Adds authenticated GET support and factors response buffering into a shared helper. |
| crates/autoagents-llm/examples/wasm_smoke/agent.rs | Extends the smoke example to validate model listing and embeddings. |
| crates/autoagents-llm/examples/wasm_smoke/mock_server.rs | Adds mock `/v1/models` and `/v1/embeddings` responses for WASM smoke coverage. |
| crates/autoagents-llm/examples/wasm_smoke/run.sh | Checks the new model-list and embeddings smoke-test success markers. |

<sub>Reviews (4): Last reviewed commit: ["\[MAINT\] Update tests for responses\_eof\_f..."](https://github.com/liquidos-ai/autoagents/commit/072084453a02d71c7aed809d425eedc4f3ed0902) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41876819)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - AGENTS.md ([source](https://app.greptile.com/liquidos/github/liquidos-ai/autoagents/-/custom-context?memory=3016560d-8393-46c9-8b28-32dd4efbbe2e))
- Context used - CLAUDE.md ([source](https://app.greptile.com/liquidos/github/liquidos-ai/autoagents/-/custom-context?memory=b47666cb-3593-419b-8e94-f613c4c4a23c))
- Context used - docs/content/core-concepts/agents.md ([source](https://app.greptile.com/liquidos/github/liquidos-ai/autoagents/-/custom-context?memory=ee5ee7f3-1bae-40fc-ab9a-3cfb1dc16d60))
</details>

<!-- /greptile_comment -->