### PR TITLE
[BUG]: Fix CI failures

### DIFF
--- a/crates/autoagents-derive/tests/ui/compile_fail/missing_tool_input_derive.stderr
+++ b/crates/autoagents-derive/tests/ui/compile_fail/missing_tool_input_derive.stderr
@@ -1,10 +1,10 @@
-error[E0277]: the trait bound `ManualArgs: ToolInputSchema` is not satisfied
+error[E0277]: the trait bound `ManualArgs: autoagents_core::tool::ToolInputSchema` is not satisfied
   --> tests/ui/compile_fail/missing_tool_input_derive.rs:14:70
    |
 14 | #[tool(name = "manual", description = "Manual input schema", input = ManualArgs)]
    |                                                                      ^^^^^^^^^^ unsatisfied trait bound
    |
-help: the trait `ToolInputSchema` is not implemented for `ManualArgs`
+help: the trait `autoagents_core::tool::ToolInputSchema` is not implemented for `ManualArgs`
   --> tests/ui/compile_fail/missing_tool_input_derive.rs:6:1
    |
  6 | struct ManualArgs;

--- a/crates/autoagents-speech/Cargo.toml
+++ b/crates/autoagents-speech/Cargo.toml
@@ -24,6 +24,7 @@ audio-capture = ["dep:cpal", "dep:hound", "dep:symphonia"]
 model-hf = ["dep:hf-hub"]
 vad = ["dep:ort", "dep:ndarray", "model-hf"]
 ort-load-dynamic = ["vad", "ort/load-dynamic"]
+parakeet-load-dynamic = ["parakeet", "parakeet-rs/load-dynamic"]
 
 # Forward parakeet-rs execution provider features
 cuda = ["parakeet", "parakeet-rs/cuda", "ort/cuda"]

--- a/examples/speech/Cargo.toml
+++ b/examples/speech/Cargo.toml
@@ -11,7 +11,6 @@ publish = false
 cuda = ["autoagents-speech/cuda"]
 
 [dependencies]
-autoagents-speech = { workspace = true, features = ["audio-capture", "vad", "parakeet", "pocket-tts", "playback"] }
 tokio = { workspace = true }
 hound = { workspace = true }
 env_logger = { workspace = true }
@@ -22,3 +21,9 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 futures = { workspace = true }
 tokio-stream = { workspace = true }
+
+[target.'cfg(target_os = "macos")'.dependencies]
+autoagents-speech = { workspace = true, features = ["audio-capture", "vad", "ort-load-dynamic", "parakeet", "parakeet-load-dynamic", "pocket-tts", "playback"] }
+
+[target.'cfg(not(target_os = "macos"))'.dependencies]
+autoagents-speech = { workspace = true, features = ["audio-capture", "vad", "parakeet", "pocket-tts", "playback"] }


### PR DESCRIPTION
This PR fixes unrelated CI failures that are not caused by the WASI/OpenAI changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates CI-related fixtures and speech example feature selection. The main changes are:

- Updated a compile-fail stderr fixture to use the fully qualified `ToolInputSchema` path.
- Added a `parakeet-load-dynamic` feature in `autoagents-speech`.
- Split the speech example dependency by target OS, with dynamic loading enabled on macOS.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge after checking whether non-macOS speech examples should also use dynamic ONNX Runtime loading.

- No blocking issues found in the changed code.
- The only follow-up is a contained runtime-loading concern in the example manifest.

examples/speech/Cargo.toml

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| crates/autoagents-derive/tests/ui/compile_fail/missing_tool_input_derive.stderr | Updates the expected diagnostic text for the missing tool input derive compile-fail test. |
| crates/autoagents-speech/Cargo.toml | Adds a feature that forwards dynamic loading support to `parakeet-rs`. |
| examples/speech/Cargo.toml | Moves `autoagents-speech` into target-specific dependencies and enables dynamic loading only for macOS. |

<a href="https://app.greptile.com/api/ide/cursor?prompt=Fix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aexamples%2Fspeech%2FCargo.toml%3A29%0A**Non-macOS%20VAD%20Loads%20Statically**%0A%0AWhen%20%60vad_stt%60%20runs%20on%20Linux%20or%20Windows%2C%20this%20target%20branch%20enables%20%60vad%60%20without%20%60ort-load-dynamic%60.%20The%20VAD%20path%20uses%20the%20crate's%20direct%20%60ort%60%20session%20builder%2C%20so%20deployments%20that%20do%20not%20have%20ONNX%20Runtime%20linked%20or%20available%20through%20the%20default%20binary-copy%20path%20can%20fail%20while%20macOS%20uses%20the%20new%20dynamic-loading%20feature.%0A%0A%23%23%23%20Issue%202%20of%202%0Aexamples%2Fspeech%2FCargo.toml%3A29%0A**Non-macOS%20Parakeet%20Loads%20Statically**%0A%0AWhen%20the%20Parakeet%20example%20runs%20on%20Linux%20or%20Windows%2C%20this%20target%20branch%20enables%20%60parakeet%60%20without%20%60parakeet-load-dynamic%60.%20If%20the%20runtime%20environment%20lacks%20the%20ONNX%20Runtime%20library%20expected%20by%20Parakeet's%20default%20loading%20mode%2C%20model%20initialization%20can%20fail%20even%20though%20the%20macOS%20branch%20now%20opts%20into%20dynamic%20loading.%0A%0A&pr=273&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22liquidos-ai%2Fautoagents%22%20on%20the%20existing%20branch%20%22fix%2Fci-unrelated-failures%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Fci-unrelated-failures%22.%0A%0AFix%20the%20following%202%20code%20review%20issues.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%202%0Aexamples%2Fspeech%2FCargo.toml%3A29%0A**Non-macOS%20VAD%20Loads%20Statically**%0A%0AWhen%20%60vad_stt%60%20runs%20on%20Linux%20or%20Windows%2C%20this%20target%20branch%20enables%20%60vad%60%20without%20%60ort-load-dynamic%60.%20The%20VAD%20path%20uses%20the%20crate's%20direct%20%60ort%60%20session%20builder%2C%20so%20deployments%20that%20do%20not%20have%20ONNX%20Runtime%20linked%20or%20available%20through%20the%20default%20binary-copy%20path%20can%20fail%20while%20macOS%20uses%20the%20new%20dynamic-loading%20feature.%0A%0A%23%23%23%20Issue%202%20of%202%0Aexamples%2Fspeech%2FCargo.toml%3A29%0A**Non-macOS%20Parakeet%20Loads%20Statically**%0A%0AWhen%20the%20Parakeet%20example%20runs%20on%20Linux%20or%20Windows%2C%20this%20target%20branch%20enables%20%60parakeet%60%20without%20%60parakeet-load-dynamic%60.%20If%20the%20runtime%20environment%20lacks%20the%20ONNX%20Runtime%20library%20expected%20by%20Parakeet's%20default%20loading%20mode%2C%20model%20initialization%20can%20fail%20even%20though%20the%20macOS%20branch%20now%20opts%20into%20dynamic%20loading.%0A%0A&repo=liquidos-ai%2Fautoagents&pr=273&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
examples/speech/Cargo.toml:29
**Non-macOS VAD Loads Statically**

When `vad_stt` runs on Linux or Windows, this target branch enables `vad` without `ort-load-dynamic`. The VAD path uses the crate's direct `ort` session builder, so deployments that do not have ONNX Runtime linked or available through the default binary-copy path can fail while macOS uses the new dynamic-loading feature.

### Issue 2 of 2
examples/speech/Cargo.toml:29
**Non-macOS Parakeet Loads Statically**

When the Parakeet example runs on Linux or Windows, this target branch enables `parakeet` without `parakeet-load-dynamic`. If the runtime environment lacks the ONNX Runtime library expected by Parakeet's default loading mode, model initialization can fail even though the macOS branch now opts into dynamic loading.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["\[BUG\]: Fix unrelated CI failures"](https://github.com/liquidos-ai/autoagents/commit/da5bca965c5cb4c5f1f4f3c83607e605fca7fa28) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41914558)</sub>

> Greptile also left **2 inline comments** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Context used - AGENTS.md ([source](https://app.greptile.com/liquidos/github/liquidos-ai/autoagents/-/custom-context?memory=3016560d-8393-46c9-8b28-32dd4efbbe2e))
- Context used - CLAUDE.md ([source](https://app.greptile.com/liquidos/github/liquidos-ai/autoagents/-/custom-context?memory=b47666cb-3593-419b-8e94-f613c4c4a23c))
- Context used - docs/content/core-concepts/agents.md ([source](https://app.greptile.com/liquidos/github/liquidos-ai/autoagents/-/custom-context?memory=ee5ee7f3-1bae-40fc-ab9a-3cfb1dc16d60))
</details>

<!-- /greptile_comment -->