### PR TITLE
[BUG]: Harden MCP process trust model

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -761,6 +761,7 @@ dependencies = [
  "csv",
  "futures",
  "html2text",
+ "http",
  "httpmock",
  "ipnet",
  "log",

--- a/crates/autoagents-toolkit/Cargo.toml
+++ b/crates/autoagents-toolkit/Cargo.toml
@@ -50,6 +50,7 @@ csv = { workspace = true, optional = true }
 url = { workspace = true, optional = true }
 ipnet = { workspace = true, optional = true }
 futures = { workspace = true, optional = true }
+http = "1.2"
 rmcp = { workspace = true, optional = true, features = [
   "client",
   "transport-child-process",

--- a/crates/autoagents-toolkit/src/mcp/adapter.rs
+++ b/crates/autoagents-toolkit/src/mcp/adapter.rs
@@ -9,20 +9,31 @@ use rmcp::{
 use serde_json::{Value, json};
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::Duration;
+
+use super::client::exposed_tool_name;
 
 /// MCP Tool Adapter that bridges MCP tools with AutoAgents tool system
 #[derive(Debug)]
 pub struct McpToolAdapter {
     name: String,
+    mcp_name: String,
     description: String,
     args_schema: Value,
     service: Arc<RunningService<RoleClient, ClientInfo>>,
+    timeout: Duration,
 }
 
 impl McpToolAdapter {
     /// Create a new MCP tool adapter from an MCP tool and service connection
-    pub fn new(tool: McpTool, service: Arc<RunningService<RoleClient, ClientInfo>>) -> Self {
-        let name = tool.name.to_string();
+    pub fn new(
+        server_name: &str,
+        tool: McpTool,
+        service: Arc<RunningService<RoleClient, ClientInfo>>,
+        timeout: Duration,
+    ) -> Self {
+        let mcp_name = tool.name.to_string();
+        let name = exposed_tool_name(server_name, &mcp_name);
         let description = tool.description.unwrap_or_default().to_string();
         let args_schema = serde_json::to_value(&tool.input_schema).unwrap_or_else(|_| {
             json!({
@@ -34,9 +45,11 @@ impl McpToolAdapter {
 
         Self {
             name,
+            mcp_name,
             description,
             args_schema,
             service,
+            timeout,
         }
     }
 
@@ -48,14 +61,11 @@ impl McpToolAdapter {
 
 impl ToolT for McpToolAdapter {
     fn name(&self) -> &str {
-        // We need to use Box::leak to convert String to &'static str
-        // This is safe because tools are typically long-lived
-        Box::leak(self.name.clone().into_boxed_str())
+        &self.name
     }
 
     fn description(&self) -> &str {
-        // Same approach for description
-        Box::leak(self.description.clone().into_boxed_str())
+        &self.description
     }
 
     fn args_schema(&self) -> Value {
@@ -79,22 +89,33 @@ impl ToolRuntime for McpToolAdapter {
         // Prepare the call tool request
         let request = match arguments {
             Some(arguments) => {
-                CallToolRequestParams::new(self.name.clone()).with_arguments(arguments)
+                CallToolRequestParams::new(self.mcp_name.clone()).with_arguments(arguments)
             }
-            None => CallToolRequestParams::new(self.name.clone()),
+            None => CallToolRequestParams::new(self.mcp_name.clone()),
         };
 
         // Execute the tool via MCP
-        match self.service.call_tool(request).await {
+        match tokio::time::timeout(self.timeout, self.service.call_tool(request)).await {
+            Err(_) => Err(ToolCallError::RuntimeError(
+                format!(
+                    "MCP tool execution timed out for {} after {:?}",
+                    self.name, self.timeout
+                )
+                .into(),
+            )),
             Ok(result) => {
-                // Convert MCP result to our format
-                convert_mcp_result(result)
-            }
-            Err(e) => {
-                log::error!("MCP tool execution failed for {}: {:?}", self.name, e);
-                Err(ToolCallError::RuntimeError(
-                    format!("MCP tool execution failed: {}", e).into(),
-                ))
+                match result {
+                    Ok(result) => {
+                        // Convert MCP result to our format
+                        convert_mcp_result(result)
+                    }
+                    Err(e) => {
+                        log::error!("MCP tool execution failed for {}: {:?}", self.name, e);
+                        Err(ToolCallError::RuntimeError(
+                            format!("MCP tool execution failed: {}", e).into(),
+                        ))
+                    }
+                }
             }
         }
     }
@@ -150,6 +171,10 @@ fn convert_mcp_result(result: CallToolResult) -> Result<Value, ToolCallError> {
             }
         }
         result_data.insert("content", json!(contents));
+    }
+
+    if let Some(structured_content) = result.structured_content {
+        result_data.insert("structured_content", json!(structured_content));
     }
 
     // Add success indicator

--- a/crates/autoagents-toolkit/src/mcp/client.rs
+++ b/crates/autoagents-toolkit/src/mcp/client.rs
@@ -1,30 +1,153 @@
 use crate::mcp::{
     adapter::McpToolAdapter,
-    config::{McpConfig, McpServerConfig},
+    config::{
+        McpConfig, McpLocalServerConfig, McpRemoteServerConfig, McpServerConfig, McpServerTransport,
+    },
 };
 use autoagents::core::tool::ToolT;
+use http::{HeaderName, HeaderValue};
 use rmcp::{
-    model::ClientInfo,
+    model::{
+        ClientInfo, PaginatedRequestParams, Prompt, Resource, ResourceTemplate, ServerCapabilities,
+        Tool,
+    },
     service::{RoleClient, RunningService, ServiceExt},
-    transport::{ConfigureCommandExt, TokioChildProcess},
+    transport::{
+        ConfigureCommandExt, StreamableHttpClientTransport, TokioChildProcess,
+        streamable_http_client::StreamableHttpClientTransportConfig,
+    },
 };
-use std::collections::HashMap;
-use std::sync::Arc;
+use std::{
+    collections::{HashMap, HashSet},
+    future::Future,
+    path::{Path, PathBuf},
+    sync::Arc,
+    time::Duration,
+};
 use tokio::process::Command;
 use tokio::sync::RwLock;
 
-/// Represents a connection to an MCP server
+const MAX_LIST_PAGES: usize = 1_000;
+
+type SharedTool = Arc<dyn ToolT>;
+type ToolCache = HashMap<String, Vec<SharedTool>>;
+
+/// Status for a configured MCP server.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum McpServerStatus {
+    Connected,
+    Disabled,
+    Failed { error: String },
+}
+
+/// Server-provided MCP instructions with the exposed AutoAgents tool names.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct McpServerInstructions {
+    pub name: String,
+    pub instructions: String,
+    pub tools: Vec<String>,
+}
+
+/// Policy for approving local stdio MCP process execution.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct McpProcessPolicy {
+    allow_all: bool,
+    paths: HashSet<PathBuf>,
+}
+
+impl McpProcessPolicy {
+    /// Deny every local MCP process.
+    pub fn deny_all() -> Self {
+        Self::default()
+    }
+
+    /// Allow every local MCP process. Use only for trusted local config.
+    pub fn allow_all() -> Self {
+        Self {
+            allow_all: true,
+            paths: HashSet::new(),
+        }
+    }
+
+    /// Resolve bare commands through the current `PATH` and allow those executable paths.
+    pub fn allow_commands<I, S>(commands: I) -> Result<Self, McpError>
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+        let env = HashMap::new();
+        let mut policy = Self::deny_all();
+        for command in commands {
+            policy
+                .paths
+                .insert(resolve_command_on_path(command.as_ref(), &cwd, &env)?);
+        }
+        Ok(policy)
+    }
+
+    /// Allow executable paths. Existing paths are canonicalized.
+    pub fn allow_paths<I, P>(paths: I) -> Result<Self, McpError>
+    where
+        I: IntoIterator<Item = P>,
+        P: AsRef<Path>,
+    {
+        let mut policy = Self::deny_all();
+        for path in paths {
+            policy.paths.insert(canonicalize_existing(path.as_ref())?);
+        }
+        Ok(policy)
+    }
+
+    /// Resolve a bare command through the current `PATH` and allow that executable path.
+    pub fn with_command(mut self, command: impl AsRef<str>) -> Result<Self, McpError> {
+        let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+        let env = HashMap::new();
+        self.paths
+            .insert(resolve_command_on_path(command.as_ref(), &cwd, &env)?);
+        Ok(self)
+    }
+
+    /// Add an executable path. Existing paths are canonicalized.
+    pub fn with_path(mut self, path: impl AsRef<Path>) -> Result<Self, McpError> {
+        self.paths.insert(canonicalize_existing(path.as_ref())?);
+        Ok(self)
+    }
+
+    fn approve(&self, server: &str, resolved: &ResolvedLocalCommand) -> Result<(), McpError> {
+        if self.allow_all {
+            return Ok(());
+        }
+
+        match &resolved.policy_subject {
+            ProcessPolicySubject::Path(path) if self.paths.contains(path) => Ok(()),
+            ProcessPolicySubject::Path(path) => Err(McpError::ProcessNotAllowed {
+                server: server.to_string(),
+                command: path.display().to_string(),
+            }),
+        }
+    }
+}
+
+/// Represents a connection to an MCP server.
 #[derive(Debug)]
 pub struct McpServerConnection {
     pub name: String,
     pub service: Arc<RunningService<RoleClient, ClientInfo>>,
+    pub timeout: Duration,
+    pub instructions: Option<String>,
+    pub capabilities: ServerCapabilities,
 }
 
-/// MCP Tools Manager that handles multiple MCP server connections
+/// MCP Tools Manager that handles multiple MCP server connections.
 #[derive(Debug)]
 pub struct McpToolsManager {
     connections: Arc<RwLock<HashMap<String, McpServerConnection>>>,
-    tools: Arc<RwLock<Vec<Arc<dyn ToolT>>>>,
+    configs: Arc<RwLock<HashMap<String, McpServerConfig>>>,
+    status: Arc<RwLock<HashMap<String, McpServerStatus>>>,
+    tools: Arc<RwLock<ToolCache>>,
+    process_policy: McpProcessPolicy,
+    base_dir: PathBuf,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -37,6 +160,14 @@ pub enum McpError {
     TransportError(String),
     #[error("Configuration error: {0}")]
     ConfigError(String),
+    #[error("Local MCP process for server '{server}' is not allowed by policy: {command}")]
+    ProcessNotAllowed { server: String, command: String },
+    #[error("MCP operation '{operation}' timed out for server '{server}' after {timeout:?}")]
+    Timeout {
+        server: String,
+        operation: &'static str,
+        timeout: Duration,
+    },
     #[error("Tool error: {0}")]
     ToolError(String),
     #[error("Rmcp error: {0}")]
@@ -51,69 +182,111 @@ impl Default for McpToolsManager {
     fn default() -> Self {
         Self {
             connections: Arc::new(RwLock::new(HashMap::new())),
-            tools: Arc::new(RwLock::new(Vec::new())),
+            configs: Arc::new(RwLock::new(HashMap::new())),
+            status: Arc::new(RwLock::new(HashMap::new())),
+            tools: Arc::new(RwLock::new(HashMap::new())),
+            process_policy: McpProcessPolicy::default(),
+            base_dir: std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
         }
     }
 }
 
 impl McpToolsManager {
-    /// Create a new MCP tools manager
+    /// Create a new MCP tools manager. Local process execution is denied by default.
     pub fn new() -> Self {
         Self::default()
     }
 
-    /// Load MCP configuration from a file and connect to all servers
-    pub async fn from_config_file<P: AsRef<std::path::Path>>(path: P) -> Result<Self, McpError> {
-        let config =
-            McpConfig::from_file(path).map_err(|e| McpError::ConfigError(e.to_string()))?;
+    /// Create an MCP tools manager with an explicit process policy.
+    pub fn with_process_policy(process_policy: McpProcessPolicy) -> Self {
+        Self {
+            connections: Arc::new(RwLock::new(HashMap::new())),
+            configs: Arc::new(RwLock::new(HashMap::new())),
+            status: Arc::new(RwLock::new(HashMap::new())),
+            tools: Arc::new(RwLock::new(HashMap::new())),
+            process_policy,
+            base_dir: std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
+        }
+    }
 
-        let manager = Self::new();
+    /// Set the base directory used for resolving relative local MCP process paths.
+    pub fn with_base_dir<P: Into<PathBuf>>(mut self, base_dir: P) -> Self {
+        self.base_dir = base_dir.into();
+        self
+    }
+
+    /// Load MCP configuration from a file and connect to enabled servers.
+    pub async fn from_config_file<P: AsRef<Path>>(path: P) -> Result<Self, McpError> {
+        Self::from_config_file_with_process_policy(path, McpProcessPolicy::deny_all()).await
+    }
+
+    /// Load MCP configuration from a file using an explicit local process policy.
+    pub async fn from_config_file_with_process_policy<P: AsRef<Path>>(
+        path: P,
+        process_policy: McpProcessPolicy,
+    ) -> Result<Self, McpError> {
+        let config =
+            McpConfig::from_file(path).map_err(|error| McpError::ConfigError(error.to_string()))?;
+
+        let mut manager = Self::with_process_policy(process_policy);
+        if let Some(base_dir) = config.base_dir() {
+            manager.base_dir = base_dir.to_path_buf();
+        }
         manager.connect_servers(&config).await?;
         Ok(manager)
     }
 
-    /// Connect to all servers defined in the configuration
+    /// Connect to all servers defined in the configuration.
     pub async fn connect_servers(&self, config: &McpConfig) -> Result<(), McpError> {
-        let mut connections = self.connections.write().await;
-        let mut all_tools = self.tools.write().await;
+        self.connect_servers_inner(config, false).await
+    }
+
+    /// Connect to all servers while preserving partial startup on failures.
+    ///
+    /// Failed enabled servers are recorded in [`Self::status`], but this method
+    /// continues connecting later servers and returns `Ok(())`.
+    pub async fn connect_servers_allow_partial(&self, config: &McpConfig) -> Result<(), McpError> {
+        self.connect_servers_inner(config, true).await
+    }
+
+    async fn connect_servers_inner(
+        &self,
+        config: &McpConfig,
+        allow_partial: bool,
+    ) -> Result<(), McpError> {
+        {
+            let mut configs = self.configs.write().await;
+            for server_config in &config.servers {
+                configs.insert(server_config.name.clone(), server_config.clone());
+            }
+        }
 
         for server_config in &config.servers {
-            match self.connect_server(server_config).await {
-                Ok(connection) => {
-                    let server_name = connection.name.clone();
+            if !server_config.enabled {
+                self.remove_server_connection_and_tools(&server_config.name)
+                    .await;
+                self.set_status(&server_config.name, McpServerStatus::Disabled)
+                    .await;
+                continue;
+            }
 
-                    // Get tools from this server
-                    match self.load_server_tools(&connection).await {
-                        Ok(tools) => {
-                            log::info!(
-                                "Connected to MCP server '{}' with {} tools",
-                                server_name,
-                                tools.len()
-                            );
-
-                            // Add tools to the global collection
-                            all_tools.extend(tools);
-
-                            // Store the connection
-                            connections.insert(server_name.clone(), connection);
-                        }
-                        Err(e) => {
-                            log::error!(
-                                "Failed to load tools from server '{}': {}",
-                                server_name,
-                                e
-                            );
-                            return Err(e);
-                        }
-                    }
-                }
-                Err(e) => {
-                    log::error!(
-                        "Failed to connect to server '{}': {}",
-                        server_config.name,
-                        e
-                    );
-                    return Err(e);
+            if let Err(error) = self.connect_and_store(server_config).await {
+                log::error!(
+                    "Failed to connect to MCP server '{}': {}",
+                    server_config.name,
+                    error
+                );
+                self.remove_server_connection_and_tools(&server_config.name)
+                    .await;
+                self.set_status(
+                    &server_config.name,
+                    McpServerStatus::Failed {
+                        error: error.to_string(),
+                    },
+                )
+                .await;
+                if !allow_partial {
+                    return Err(error);
                 }
             }
         }
@@ -121,161 +294,819 @@ impl McpToolsManager {
         Ok(())
     }
 
-    /// Connect to a single MCP server
+    /// Connect or reconnect one configured server.
+    pub async fn connect(&self, server_name: &str) -> Result<(), McpError> {
+        let config = self
+            .configs
+            .read()
+            .await
+            .get(server_name)
+            .cloned()
+            .ok_or_else(|| McpError::ServerNotFound(server_name.to_string()))?;
+
+        if let Err(error) = self.connect_and_store(&config).await {
+            self.remove_server_connection_and_tools(&config.name).await;
+            self.set_status(
+                &config.name,
+                McpServerStatus::Failed {
+                    error: error.to_string(),
+                },
+            )
+            .await;
+            return Err(error);
+        }
+
+        Ok(())
+    }
+
+    /// Disconnect one server and remove its tools.
+    pub async fn disconnect(&self, server_name: &str) -> Result<(), McpError> {
+        if !self.configs.read().await.contains_key(server_name) {
+            return Err(McpError::ServerNotFound(server_name.to_string()));
+        }
+
+        self.remove_server_connection_and_tools(server_name).await;
+        self.set_status(server_name, McpServerStatus::Disabled)
+            .await;
+        Ok(())
+    }
+
+    async fn connect_and_store(&self, server_config: &McpServerConfig) -> Result<(), McpError> {
+        let connection = self.connect_server(server_config).await?;
+        let server_name = connection.name.clone();
+        let tools = self.load_server_tools(&connection).await?;
+
+        self.connections
+            .write()
+            .await
+            .insert(server_name.clone(), connection);
+        self.replace_server_tools(&server_name, tools).await;
+        self.set_status(&server_name, McpServerStatus::Connected)
+            .await;
+
+        Ok(())
+    }
+
+    /// Connect to a single MCP server.
     async fn connect_server(
         &self,
         server_config: &McpServerConfig,
     ) -> Result<McpServerConnection, McpError> {
-        // Validate configuration
         server_config.validate().map_err(McpError::ConfigError)?;
+        let timeout = Duration::from_millis(server_config.timeout_ms);
 
-        let service = match server_config.protocol.as_str() {
-            "stdio" => self.connect_stdio_server(server_config).await?,
-            _ => {
+        let service = match &server_config.transport {
+            McpServerTransport::Local(local) => {
+                self.connect_stdio_server(server_config, local, timeout)
+                    .await?
+            }
+            McpServerTransport::Remote(remote) => {
+                self.connect_remote_server(server_config, remote, timeout)
+                    .await?
+            }
+            McpServerTransport::Unsupported { protocol } => {
                 return Err(McpError::ConfigError(format!(
-                    "Unsupported protocol: {}. Currently only 'stdio' is supported.",
-                    server_config.protocol
+                    "Unsupported MCP protocol: {protocol}"
                 )));
             }
         };
 
+        let peer_info = service.peer().peer_info().cloned().unwrap_or_default();
+
         Ok(McpServerConnection {
             name: server_config.name.clone(),
             service,
+            timeout,
+            instructions: peer_info
+                .instructions
+                .map(|instructions| instructions.trim().to_string())
+                .filter(|instructions| !instructions.is_empty()),
+            capabilities: peer_info.capabilities,
         })
     }
 
-    /// Connect to a stdio-based MCP server
     async fn connect_stdio_server(
         &self,
-        config: &McpServerConfig,
+        server_config: &McpServerConfig,
+        local: &McpLocalServerConfig,
+        timeout: Duration,
     ) -> Result<Arc<RunningService<RoleClient, ClientInfo>>, McpError> {
-        let mut command = Command::new(&config.command);
+        let resolved = self.resolve_local_command(&server_config.name, local)?;
+        self.process_policy
+            .approve(&server_config.name, &resolved)?;
 
-        // Configure command arguments
-        if !config.args.is_empty() {
-            command.args(&config.args);
-        }
-
-        // Set working directory
-        if let Some(cwd) = &config.cwd {
-            command.current_dir(cwd);
-        }
-
-        // Set environment variables
-        for (key, value) in &config.env {
+        let mut command = Command::new(&resolved.executable);
+        command.args(&resolved.args);
+        command.current_dir(&resolved.cwd);
+        for (key, value) in &local.environment {
             command.env(key, value);
         }
 
-        // Create transport
         let transport = TokioChildProcess::new(command.configure(|_| {}))
-            .map_err(|e| McpError::TransportError(e.to_string()))?;
-
-        // Create client info for AutoAgents using default values
+            .map_err(|error| McpError::TransportError(error.to_string()))?;
         let client_info = ClientInfo::default();
 
-        // Connect to server
-        let service = client_info.serve(transport).await.map_err(|e| {
-            McpError::GenericError(format!("Failed to connect to MCP server: {:?}", e))
-        })?;
+        let service = timeout_result(&server_config.name, "connect", timeout, async move {
+            client_info.serve(transport).await.map_err(|error| {
+                McpError::ConnectionFailed(format!(
+                    "Failed to connect to local MCP server: {error:?}"
+                ))
+            })
+        })
+        .await?;
 
         Ok(Arc::new(service))
     }
 
-    /// Load tools from a connected MCP server
+    async fn connect_remote_server(
+        &self,
+        server_config: &McpServerConfig,
+        remote: &McpRemoteServerConfig,
+        timeout: Duration,
+    ) -> Result<Arc<RunningService<RoleClient, ClientInfo>>, McpError> {
+        let headers = parse_headers(&server_config.name, &remote.headers)?;
+        let transport_config = StreamableHttpClientTransportConfig::with_uri(remote.url.clone())
+            .custom_headers(headers);
+        let transport = StreamableHttpClientTransport::from_config(transport_config);
+        let client_info = ClientInfo::default();
+
+        let service = timeout_result(&server_config.name, "connect", timeout, async move {
+            client_info.serve(transport).await.map_err(|error| {
+                McpError::ConnectionFailed(format!(
+                    "Failed to connect to remote MCP server: {error:?}"
+                ))
+            })
+        })
+        .await?;
+
+        Ok(Arc::new(service))
+    }
+
+    fn resolve_local_command(
+        &self,
+        server_name: &str,
+        local: &McpLocalServerConfig,
+    ) -> Result<ResolvedLocalCommand, McpError> {
+        let executable = local.command.first().ok_or_else(|| {
+            McpError::ConfigError(format!("MCP server '{server_name}' command is empty"))
+        })?;
+
+        let cwd = match &local.cwd {
+            Some(cwd) => resolve_path(&self.base_dir, cwd),
+            None => self.base_dir.clone(),
+        };
+
+        let canonical_executable = if is_path_command(executable) {
+            let path = PathBuf::from(executable);
+            let resolved = if path.is_absolute() {
+                path
+            } else {
+                cwd.join(path)
+            };
+            canonicalize_existing(&resolved)?
+        } else {
+            resolve_command_on_path(executable, &cwd, &local.environment)?
+        };
+
+        Ok(ResolvedLocalCommand {
+            executable: canonical_executable.to_string_lossy().to_string(),
+            args: local.command.iter().skip(1).cloned().collect(),
+            cwd,
+            policy_subject: ProcessPolicySubject::Path(canonical_executable),
+        })
+    }
+
+    /// Load tools from a connected MCP server.
     async fn load_server_tools(
         &self,
         connection: &McpServerConnection,
     ) -> Result<Vec<Arc<dyn ToolT>>, McpError> {
-        let tools_result = connection
-            .service
-            .list_tools(None)
-            .await
-            .map_err(|e| McpError::GenericError(format!("Failed to list tools: {:?}", e)))?;
-
-        let mut adapted_tools = Vec::new();
-
-        for tool in tools_result.tools {
-            let adapter = McpToolAdapter::new(tool, Arc::clone(&connection.service));
-            adapted_tools.push(Arc::new(adapter) as Arc<dyn ToolT>);
+        if connection.capabilities.tools.is_none() {
+            return Ok(Vec::new());
         }
 
-        Ok(adapted_tools)
+        let tools = timeout_result(
+            &connection.name,
+            "list_tools",
+            connection.timeout,
+            list_all_tools(Arc::clone(&connection.service)),
+        )
+        .await?;
+
+        Ok(tools
+            .into_iter()
+            .map(|tool| {
+                Arc::new(McpToolAdapter::new(
+                    &connection.name,
+                    tool,
+                    Arc::clone(&connection.service),
+                    connection.timeout,
+                )) as Arc<dyn ToolT>
+            })
+            .collect())
     }
 
-    /// Get all available tools
+    /// Get all available tools.
     pub async fn get_tools(&self) -> Vec<Arc<dyn ToolT>> {
-        self.tools.read().await.clone()
+        let tools = self.tools.read().await;
+        flatten_tools_by_server_name(&tools)
     }
 
-    /// Get tools from a specific server
+    /// Get tools from a specific server.
     pub async fn get_server_tools(
         &self,
         server_name: &str,
     ) -> Result<Vec<Arc<dyn ToolT>>, McpError> {
-        let connections = self.connections.read().await;
-        let connection = connections
-            .get(server_name)
-            .ok_or_else(|| McpError::ServerNotFound(server_name.to_string()))?;
+        if !self.connections.read().await.contains_key(server_name) {
+            return Err(McpError::ServerNotFound(server_name.to_string()));
+        }
 
-        self.load_server_tools(connection).await
+        Ok(self
+            .tools
+            .read()
+            .await
+            .get(server_name)
+            .cloned()
+            .unwrap_or_default())
     }
 
-    /// Get a tool by name
+    /// Get a tool by its exposed name.
     pub async fn get_tool(&self, tool_name: &str) -> Option<Arc<dyn ToolT>> {
         let tools = self.tools.read().await;
-        tools.iter().find(|tool| tool.name() == tool_name).cloned()
+        tools
+            .values()
+            .flat_map(|tools| tools.iter())
+            .find(|tool| tool.name() == tool_name)
+            .cloned()
     }
 
-    /// Refresh tools from all connected servers
+    /// Refresh tools from all connected servers.
     pub async fn refresh_tools(&self) -> Result<(), McpError> {
         let connections = self.connections.read().await;
-        let mut all_tools = Vec::new();
+        let mut all_tools = HashMap::new();
 
         for connection in connections.values() {
-            let tools = self.load_server_tools(connection).await?;
-            all_tools.extend(tools);
+            match self.load_server_tools(connection).await {
+                Ok(tools) => {
+                    all_tools.insert(connection.name.clone(), tools);
+                }
+                Err(error) => {
+                    self.remove_server_tools(&connection.name).await;
+                    self.set_status(
+                        &connection.name,
+                        McpServerStatus::Failed {
+                            error: error.to_string(),
+                        },
+                    )
+                    .await;
+                    return Err(error);
+                }
+            }
         }
 
         *self.tools.write().await = all_tools;
         Ok(())
     }
 
-    /// Get the names of all connected servers
+    /// Get the names of all connected servers.
     pub async fn connected_servers(&self) -> Vec<String> {
-        self.connections.read().await.keys().cloned().collect()
+        let mut servers = self
+            .connections
+            .read()
+            .await
+            .keys()
+            .cloned()
+            .collect::<Vec<_>>();
+        servers.sort();
+        servers
     }
 
-    /// Check if a server is connected
+    /// Check if a server is connected.
     pub async fn is_server_connected(&self, server_name: &str) -> bool {
         self.connections.read().await.contains_key(server_name)
     }
 
-    /// Get the number of available tools
-    pub async fn tool_count(&self) -> usize {
-        self.tools.read().await.len()
+    /// Get all configured server statuses.
+    pub async fn status(&self) -> HashMap<String, McpServerStatus> {
+        self.status.read().await.clone()
     }
 
-    /// Get tool names
-    pub async fn tool_names(&self) -> Vec<String> {
+    /// Get the number of available tools.
+    pub async fn tool_count(&self) -> usize {
         self.tools
             .read()
             .await
-            .iter()
+            .values()
+            .map(Vec::len)
+            .sum::<usize>()
+    }
+
+    /// Get exposed tool names.
+    pub async fn tool_names(&self) -> Vec<String> {
+        let tools = self.tools.read().await;
+        flatten_tools_by_server_name(&tools)
+            .into_iter()
             .map(|tool| tool.name().to_string())
             .collect()
     }
+
+    /// Get connected server instructions.
+    pub async fn server_instructions(&self) -> Vec<McpServerInstructions> {
+        let connections = self.connections.read().await;
+        let tools = self.tools.read().await;
+
+        let mut instructions = connections
+            .values()
+            .filter_map(|connection| {
+                let instructions = connection.instructions.as_ref()?;
+                Some(McpServerInstructions {
+                    name: connection.name.clone(),
+                    instructions: instructions.clone(),
+                    tools: tools
+                        .get(&connection.name)
+                        .into_iter()
+                        .flat_map(|tools| tools.iter())
+                        .map(|tool| tool.name().to_string())
+                        .collect(),
+                })
+            })
+            .collect::<Vec<_>>();
+        instructions.sort_by(|left, right| left.name.cmp(&right.name));
+        instructions
+    }
+
+    /// List prompts from connected servers, keyed as `server:prompt`.
+    pub async fn prompts(&self) -> Result<HashMap<String, Prompt>, McpError> {
+        let connections = self.connections.read().await;
+        let mut result = HashMap::new();
+        for connection in connections.values() {
+            if connection.capabilities.prompts.is_none() {
+                continue;
+            }
+            let prompts = timeout_result(
+                &connection.name,
+                "list_prompts",
+                connection.timeout,
+                list_all_prompts(Arc::clone(&connection.service)),
+            )
+            .await?;
+            for prompt in prompts {
+                result.insert(format!("{}:{}", connection.name, prompt.name), prompt);
+            }
+        }
+        Ok(result)
+    }
+
+    /// List resources from connected servers, keyed as `server:uri`.
+    pub async fn resources(
+        &self,
+        server_name: Option<&str>,
+    ) -> Result<HashMap<String, Resource>, McpError> {
+        let connections = self.connections.read().await;
+        let mut result = HashMap::new();
+        for connection in connections.values() {
+            if server_name.is_some_and(|name| name != connection.name) {
+                continue;
+            }
+            if connection.capabilities.resources.is_none() {
+                continue;
+            }
+            let resources = timeout_result(
+                &connection.name,
+                "list_resources",
+                connection.timeout,
+                list_all_resources(Arc::clone(&connection.service)),
+            )
+            .await?;
+            for resource in resources {
+                result.insert(
+                    format!("{}:{}", connection.name, resource.raw.uri),
+                    resource,
+                );
+            }
+        }
+        Ok(result)
+    }
+
+    /// List resource templates from connected servers, keyed as `server:uri_template`.
+    pub async fn resource_templates(
+        &self,
+        server_name: Option<&str>,
+    ) -> Result<HashMap<String, ResourceTemplate>, McpError> {
+        let connections = self.connections.read().await;
+        let mut result = HashMap::new();
+        for connection in connections.values() {
+            if server_name.is_some_and(|name| name != connection.name) {
+                continue;
+            }
+            if connection.capabilities.resources.is_none() {
+                continue;
+            }
+            let templates = timeout_result(
+                &connection.name,
+                "list_resource_templates",
+                connection.timeout,
+                list_all_resource_templates(Arc::clone(&connection.service)),
+            )
+            .await?;
+            for template in templates {
+                result.insert(
+                    format!("{}:{}", connection.name, template.raw.uri_template),
+                    template,
+                );
+            }
+        }
+        Ok(result)
+    }
+
+    async fn set_status(&self, server_name: &str, status: McpServerStatus) {
+        self.status
+            .write()
+            .await
+            .insert(server_name.to_string(), status);
+    }
+
+    async fn remove_server_tools(&self, server_name: &str) {
+        self.tools.write().await.remove(server_name);
+    }
+
+    async fn remove_server_connection_and_tools(&self, server_name: &str) {
+        self.connections.write().await.remove(server_name);
+        self.remove_server_tools(server_name).await;
+    }
+
+    async fn replace_server_tools(&self, server_name: &str, tools: Vec<Arc<dyn ToolT>>) {
+        self.tools
+            .write()
+            .await
+            .insert(server_name.to_string(), tools);
+    }
+}
+
+#[derive(Debug)]
+struct ResolvedLocalCommand {
+    executable: String,
+    args: Vec<String>,
+    cwd: PathBuf,
+    policy_subject: ProcessPolicySubject,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum ProcessPolicySubject {
+    Path(PathBuf),
+}
+
+async fn timeout_result<T, F>(
+    server: &str,
+    operation: &'static str,
+    timeout: Duration,
+    future: F,
+) -> Result<T, McpError>
+where
+    F: Future<Output = Result<T, McpError>>,
+{
+    tokio::time::timeout(timeout, future)
+        .await
+        .map_err(|_| McpError::Timeout {
+            server: server.to_string(),
+            operation,
+            timeout,
+        })?
+}
+
+async fn list_all_tools(
+    service: Arc<RunningService<RoleClient, ClientInfo>>,
+) -> Result<Vec<Tool>, McpError> {
+    let mut tools = Vec::new();
+    let mut cursor = None;
+    let mut seen_cursors = HashSet::new();
+
+    for _ in 0..MAX_LIST_PAGES {
+        let result = service
+            .peer()
+            .list_tools(Some(PaginatedRequestParams::default().with_cursor(cursor)))
+            .await
+            .map_err(|error| McpError::GenericError(format!("Failed to list tools: {error:?}")))?;
+        tools.extend(result.tools);
+        match result.next_cursor {
+            Some(next_cursor) => {
+                if !seen_cursors.insert(next_cursor.clone()) {
+                    return Err(McpError::GenericError(format!(
+                        "MCP tools/list returned duplicate cursor: {next_cursor}"
+                    )));
+                }
+                cursor = Some(next_cursor);
+            }
+            None => return Ok(tools),
+        }
+    }
+
+    Err(McpError::GenericError(format!(
+        "MCP tools/list exceeded {MAX_LIST_PAGES} pages"
+    )))
+}
+
+async fn list_all_prompts(
+    service: Arc<RunningService<RoleClient, ClientInfo>>,
+) -> Result<Vec<Prompt>, McpError> {
+    let mut prompts = Vec::new();
+    let mut cursor = None;
+    let mut seen_cursors = HashSet::new();
+
+    for _ in 0..MAX_LIST_PAGES {
+        let result = service
+            .peer()
+            .list_prompts(Some(PaginatedRequestParams::default().with_cursor(cursor)))
+            .await
+            .map_err(|error| {
+                McpError::GenericError(format!("Failed to list prompts: {error:?}"))
+            })?;
+        prompts.extend(result.prompts);
+        match result.next_cursor {
+            Some(next_cursor) => {
+                if !seen_cursors.insert(next_cursor.clone()) {
+                    return Err(McpError::GenericError(format!(
+                        "MCP prompts/list returned duplicate cursor: {next_cursor}"
+                    )));
+                }
+                cursor = Some(next_cursor);
+            }
+            None => return Ok(prompts),
+        }
+    }
+
+    Err(McpError::GenericError(format!(
+        "MCP prompts/list exceeded {MAX_LIST_PAGES} pages"
+    )))
+}
+
+async fn list_all_resources(
+    service: Arc<RunningService<RoleClient, ClientInfo>>,
+) -> Result<Vec<Resource>, McpError> {
+    let mut resources = Vec::new();
+    let mut cursor = None;
+    let mut seen_cursors = HashSet::new();
+
+    for _ in 0..MAX_LIST_PAGES {
+        let result = service
+            .peer()
+            .list_resources(Some(PaginatedRequestParams::default().with_cursor(cursor)))
+            .await
+            .map_err(|error| {
+                McpError::GenericError(format!("Failed to list resources: {error:?}"))
+            })?;
+        resources.extend(result.resources);
+        match result.next_cursor {
+            Some(next_cursor) => {
+                if !seen_cursors.insert(next_cursor.clone()) {
+                    return Err(McpError::GenericError(format!(
+                        "MCP resources/list returned duplicate cursor: {next_cursor}"
+                    )));
+                }
+                cursor = Some(next_cursor);
+            }
+            None => return Ok(resources),
+        }
+    }
+
+    Err(McpError::GenericError(format!(
+        "MCP resources/list exceeded {MAX_LIST_PAGES} pages"
+    )))
+}
+
+async fn list_all_resource_templates(
+    service: Arc<RunningService<RoleClient, ClientInfo>>,
+) -> Result<Vec<ResourceTemplate>, McpError> {
+    let mut templates = Vec::new();
+    let mut cursor = None;
+    let mut seen_cursors = HashSet::new();
+
+    for _ in 0..MAX_LIST_PAGES {
+        let result = service
+            .peer()
+            .list_resource_templates(Some(PaginatedRequestParams::default().with_cursor(cursor)))
+            .await
+            .map_err(|error| {
+                McpError::GenericError(format!("Failed to list resource templates: {error:?}"))
+            })?;
+        templates.extend(result.resource_templates);
+        match result.next_cursor {
+            Some(next_cursor) => {
+                if !seen_cursors.insert(next_cursor.clone()) {
+                    return Err(McpError::GenericError(format!(
+                        "MCP resources/templates/list returned duplicate cursor: {next_cursor}"
+                    )));
+                }
+                cursor = Some(next_cursor);
+            }
+            None => return Ok(templates),
+        }
+    }
+
+    Err(McpError::GenericError(format!(
+        "MCP resources/templates/list exceeded {MAX_LIST_PAGES} pages"
+    )))
+}
+
+fn parse_headers(
+    server_name: &str,
+    headers: &HashMap<String, String>,
+) -> Result<HashMap<HeaderName, HeaderValue>, McpError> {
+    headers
+        .iter()
+        .map(|(key, value)| {
+            let name = HeaderName::from_bytes(key.as_bytes()).map_err(|error| {
+                McpError::ConfigError(format!(
+                    "Invalid header name for MCP server '{server_name}': {error}"
+                ))
+            })?;
+            let value = HeaderValue::from_str(value).map_err(|error| {
+                McpError::ConfigError(format!(
+                    "Invalid header value for MCP server '{server_name}' header '{key}': {error}"
+                ))
+            })?;
+            Ok((name, value))
+        })
+        .collect()
+}
+
+fn resolve_path(base_dir: &Path, path: &str) -> PathBuf {
+    let path = PathBuf::from(path);
+    if path.is_absolute() {
+        path
+    } else {
+        base_dir.join(path)
+    }
+}
+
+fn canonicalize_existing(path: &Path) -> Result<PathBuf, McpError> {
+    path.canonicalize().map_err(|error| {
+        McpError::ConfigError(format!(
+            "Failed to canonicalize MCP process path '{}': {error}",
+            path.display()
+        ))
+    })
+}
+
+fn resolve_command_on_path(
+    command: &str,
+    cwd: &Path,
+    environment: &HashMap<String, String>,
+) -> Result<PathBuf, McpError> {
+    if command.is_empty() {
+        return Err(McpError::ConfigError(
+            "MCP local server command cannot be empty".to_string(),
+        ));
+    }
+    if is_path_command(command) {
+        return canonicalize_existing(Path::new(command));
+    }
+
+    let path_value = environment
+        .get("PATH")
+        .map(|path| path.as_str().into())
+        .or_else(|| std::env::var_os("PATH"));
+
+    let Some(path_value) = path_value else {
+        return Err(McpError::ConfigError(format!(
+            "MCP local server command '{command}' was not found because PATH is not set"
+        )));
+    };
+
+    for dir in std::env::split_paths(&path_value) {
+        let dir = if dir.as_os_str().is_empty() {
+            cwd.to_path_buf()
+        } else {
+            dir
+        };
+        for candidate in command_candidates(&dir, command) {
+            if candidate.is_file() {
+                return canonicalize_existing(&candidate);
+            }
+        }
+    }
+
+    Err(McpError::ConfigError(format!(
+        "MCP local server command '{command}' was not found on PATH"
+    )))
+}
+
+fn command_candidates(dir: &Path, command: &str) -> Vec<PathBuf> {
+    let command_path = Path::new(command);
+    #[cfg(windows)]
+    {
+        if command_path.extension().is_some() {
+            return vec![dir.join(command_path)];
+        }
+        let path_ext = std::env::var_os("PATHEXT")
+            .unwrap_or_else(|| ".COM;.EXE;.BAT;.CMD".into())
+            .to_string_lossy()
+            .to_string();
+        path_ext
+            .split(';')
+            .filter(|ext| !ext.is_empty())
+            .map(|ext| dir.join(format!("{command}{ext}")))
+            .chain(std::iter::once(dir.join(command_path)))
+            .collect()
+    }
+    #[cfg(not(windows))]
+    {
+        vec![dir.join(command_path)]
+    }
+}
+
+fn flatten_tools_by_server_name(tools: &ToolCache) -> Vec<Arc<dyn ToolT>> {
+    let mut server_names = tools.keys().collect::<Vec<_>>();
+    server_names.sort();
+    server_names
+        .into_iter()
+        .flat_map(|server_name| tools[server_name].iter().cloned())
+        .collect()
+}
+
+fn is_path_command(command: &str) -> bool {
+    command.contains('/') || command.contains('\\') || Path::new(command).is_absolute()
+}
+
+fn sanitize_tool_segment(value: &str) -> String {
+    value
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || ch == '_' || ch == '-' {
+                ch
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+fn hex_encode(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut result = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        result.push(HEX[(byte >> 4) as usize] as char);
+        result.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    result
+}
+
+pub(crate) fn tool_prefix(server_name: &str) -> String {
+    format!(
+        "{}_{}_",
+        sanitize_tool_segment(server_name),
+        hex_encode(server_name.as_bytes())
+    )
+}
+
+pub(crate) fn exposed_tool_name(server_name: &str, tool_name: &str) -> String {
+    format!(
+        "{}{}",
+        tool_prefix(server_name),
+        sanitize_tool_segment(tool_name)
+    )
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::mcp::config::McpServerTransport;
+    use autoagents::core::tool::ToolCallError;
+    use tempfile::tempdir;
+
+    #[derive(Debug)]
+    struct DummyTool {
+        name: String,
+    }
+
+    #[autoagents::async_trait]
+    impl autoagents::core::tool::ToolRuntime for DummyTool {
+        async fn execute(
+            &self,
+            _args: serde_json::Value,
+        ) -> Result<serde_json::Value, ToolCallError> {
+            Ok(serde_json::Value::Null)
+        }
+    }
+
+    impl ToolT for DummyTool {
+        fn name(&self) -> &str {
+            &self.name
+        }
+
+        fn description(&self) -> &str {
+            "dummy tool"
+        }
+
+        fn args_schema(&self) -> serde_json::Value {
+            serde_json::json!({})
+        }
+    }
 
     #[tokio::test]
-    async fn test_manager_basic_operations() {
+    async fn manager_basic_operations() {
         let manager = McpToolsManager::default();
 
-        // Test initial state
         assert_eq!(manager.tool_count().await, 0);
         assert!(manager.tool_names().await.is_empty());
         assert!(manager.connected_servers().await.is_empty());
@@ -283,44 +1114,329 @@ mod tests {
         assert!(manager.get_tool("nonexistent").await.is_none());
     }
 
-    fn invalid_protocol_config() -> McpServerConfig {
-        McpServerConfig::new(
-            "bad_server".to_string(),
-            "http".to_string(),
-            "noop".to_string(),
-        )
-    }
-
     #[tokio::test]
-    async fn test_get_server_tools_missing() {
+    async fn get_server_tools_missing() {
         let manager = McpToolsManager::default();
         let err = manager.get_server_tools("missing").await.unwrap_err();
         assert!(matches!(err, McpError::ServerNotFound(_)));
     }
 
     #[tokio::test]
-    async fn test_connect_server_rejects_unsupported_protocol() {
-        let manager = McpToolsManager::default();
-        let config = invalid_protocol_config();
-        let err = manager.connect_server(&config).await.unwrap_err();
-        assert!(matches!(err, McpError::ConfigError(_)));
-        assert!(err.to_string().contains("Unsupported protocol"));
-    }
-
-    #[tokio::test]
-    async fn test_connect_servers_returns_error_on_invalid_protocol() {
+    async fn connect_servers_records_invalid_protocol_as_failed_status() {
         let manager = McpToolsManager::default();
         let mut config = McpConfig::new();
-        config.add_server(invalid_protocol_config());
+        config.add_server(McpServerConfig::new(
+            "bad_server".to_string(),
+            "sse".to_string(),
+            "noop".to_string(),
+        ));
+
         let err = manager.connect_servers(&config).await.unwrap_err();
-        assert!(err.to_string().contains("Unsupported protocol"));
+        assert!(err.to_string().contains("Unsupported"));
+        let status = manager.status().await;
+        assert!(matches!(
+            status.get("bad_server"),
+            Some(McpServerStatus::Failed { error }) if error.contains("Unsupported")
+        ));
     }
 
     #[tokio::test]
-    async fn test_refresh_tools_on_empty_manager() {
+    async fn connect_servers_allow_partial_records_failures_without_error() {
         let manager = McpToolsManager::default();
-        manager.refresh_tools().await.unwrap();
-        let tools = manager.get_tools().await;
-        assert!(tools.is_empty());
+        let mut config = McpConfig::new();
+        config.add_server(McpServerConfig::new(
+            "bad_server".to_string(),
+            "sse".to_string(),
+            "noop".to_string(),
+        ));
+
+        manager
+            .connect_servers_allow_partial(&config)
+            .await
+            .unwrap();
+        let status = manager.status().await;
+        assert!(matches!(
+            status.get("bad_server"),
+            Some(McpServerStatus::Failed { error }) if error.contains("Unsupported")
+        ));
+    }
+
+    #[tokio::test]
+    async fn connect_servers_marks_disabled_without_connecting() {
+        let manager = McpToolsManager::default();
+        let mut config = McpConfig::new();
+        config.add_server(
+            McpServerConfig::local("disabled", vec!["echo".to_string()]).with_enabled(false),
+        );
+
+        manager.connect_servers(&config).await.unwrap();
+        let status = manager.status().await;
+        assert_eq!(status.get("disabled"), Some(&McpServerStatus::Disabled));
+    }
+
+    #[tokio::test]
+    async fn connect_servers_removes_existing_tools_when_server_is_disabled() {
+        let manager = McpToolsManager::default();
+        manager.tools.write().await.insert(
+            "disabled".to_string(),
+            vec![Arc::new(DummyTool {
+                name: exposed_tool_name("disabled", "stale"),
+            })],
+        );
+        assert_eq!(manager.tool_count().await, 1);
+
+        let mut config = McpConfig::new();
+        config.add_server(
+            McpServerConfig::local("disabled", vec!["echo".to_string()]).with_enabled(false),
+        );
+
+        manager.connect_servers(&config).await.unwrap();
+
+        assert_eq!(manager.tool_count().await, 0);
+        assert!(
+            manager
+                .get_tool(&exposed_tool_name("disabled", "stale"))
+                .await
+                .is_none()
+        );
+        assert!(!manager.is_server_connected("disabled").await);
+        let status = manager.status().await;
+        assert_eq!(status.get("disabled"), Some(&McpServerStatus::Disabled));
+    }
+
+    #[tokio::test]
+    async fn remove_server_tools_does_not_remove_sibling_prefix_tools() {
+        let manager = McpToolsManager::default();
+        manager.tools.write().await.extend([
+            (
+                "my".to_string(),
+                vec![Arc::new(DummyTool {
+                    name: exposed_tool_name("my", "search"),
+                }) as Arc<dyn ToolT>],
+            ),
+            (
+                "my_team".to_string(),
+                vec![Arc::new(DummyTool {
+                    name: exposed_tool_name("my_team", "search"),
+                }) as Arc<dyn ToolT>],
+            ),
+        ]);
+
+        manager.remove_server_tools("my").await;
+
+        assert!(
+            manager
+                .get_tool(&exposed_tool_name("my", "search"))
+                .await
+                .is_none()
+        );
+        assert!(
+            manager
+                .get_tool(&exposed_tool_name("my_team", "search"))
+                .await
+                .is_some()
+        );
+        assert_eq!(manager.tool_count().await, 1);
+    }
+
+    #[test]
+    fn exposed_tool_names_do_not_collide_for_sanitized_server_name_matches() {
+        assert_ne!(
+            exposed_tool_name("github.tools", "search"),
+            exposed_tool_name("github_tools", "search")
+        );
+    }
+
+    #[tokio::test]
+    async fn public_tool_lists_are_sorted_by_server_name() {
+        let manager = McpToolsManager::default();
+        manager.tools.write().await.extend([
+            (
+                "z_server".to_string(),
+                vec![Arc::new(DummyTool {
+                    name: exposed_tool_name("z_server", "search"),
+                }) as Arc<dyn ToolT>],
+            ),
+            (
+                "a_server".to_string(),
+                vec![Arc::new(DummyTool {
+                    name: exposed_tool_name("a_server", "lookup"),
+                }) as Arc<dyn ToolT>],
+            ),
+        ]);
+
+        assert_eq!(
+            manager.tool_names().await,
+            vec![
+                exposed_tool_name("a_server", "lookup"),
+                exposed_tool_name("z_server", "search")
+            ]
+        );
+        assert_eq!(
+            manager
+                .get_tools()
+                .await
+                .iter()
+                .map(|tool| tool.name().to_string())
+                .collect::<Vec<_>>(),
+            vec![
+                exposed_tool_name("a_server", "lookup"),
+                exposed_tool_name("z_server", "search")
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn failed_reconnect_removes_existing_tools() {
+        let manager = McpToolsManager::default();
+        manager.tools.write().await.insert(
+            "local".to_string(),
+            vec![Arc::new(DummyTool {
+                name: exposed_tool_name("local", "stale"),
+            })],
+        );
+
+        let mut config = McpConfig::new();
+        config.add_server(McpServerConfig::local(
+            "local",
+            vec!["definitely-missing-autoagents-mcp-server".to_string()],
+        ));
+
+        let err = manager.connect_servers(&config).await.unwrap_err();
+        assert!(err.to_string().contains("not found") || err.to_string().contains("not allowed"));
+        assert!(
+            manager
+                .get_tool(&exposed_tool_name("local", "stale"))
+                .await
+                .is_none()
+        );
+        assert_eq!(manager.tool_count().await, 0);
+        let status = manager.status().await;
+        assert!(matches!(
+            status.get("local"),
+            Some(McpServerStatus::Failed { .. })
+        ));
+    }
+
+    #[tokio::test]
+    async fn default_policy_denies_local_processes() {
+        let manager = McpToolsManager::default();
+        let mut config = McpConfig::new();
+        config.add_server(McpServerConfig::local("local", vec!["echo".to_string()]));
+
+        let err = manager.connect_servers(&config).await.unwrap_err();
+        assert!(err.to_string().contains("not allowed"));
+        let status = manager.status().await;
+        assert!(matches!(
+            status.get("local"),
+            Some(McpServerStatus::Failed { error }) if error.contains("not allowed")
+        ));
+    }
+
+    #[test]
+    fn policy_allows_canonical_paths() {
+        let dir = tempdir().unwrap();
+        let executable = dir.path().join("server");
+        std::fs::write(&executable, "").unwrap();
+        let executable = executable.canonicalize().unwrap();
+
+        let policy = McpProcessPolicy::allow_paths([&executable]).unwrap();
+        let resolved = ResolvedLocalCommand {
+            executable: executable.to_string_lossy().to_string(),
+            args: Vec::new(),
+            cwd: PathBuf::from("."),
+            policy_subject: ProcessPolicySubject::Path(executable),
+        };
+
+        assert!(policy.approve("server", &resolved).is_ok());
+    }
+
+    #[test]
+    fn bare_command_resolves_through_child_path_before_policy_approval() {
+        let dir = tempdir().unwrap();
+        let trusted_bin = dir.path().join("trusted");
+        let shadow_bin = dir.path().join("shadow");
+        std::fs::create_dir_all(&trusted_bin).unwrap();
+        std::fs::create_dir_all(&shadow_bin).unwrap();
+        let trusted = trusted_bin.join("server");
+        let shadow = shadow_bin.join("server");
+        std::fs::write(&trusted, "").unwrap();
+        std::fs::write(&shadow, "").unwrap();
+
+        let manager = McpToolsManager {
+            base_dir: dir.path().to_path_buf(),
+            process_policy: McpProcessPolicy::allow_paths([&trusted]).unwrap(),
+            ..McpToolsManager::default()
+        };
+        let local = McpLocalServerConfig {
+            command: vec!["server".to_string()],
+            cwd: None,
+            environment: HashMap::from([(
+                "PATH".to_string(),
+                shadow_bin.to_string_lossy().to_string(),
+            )]),
+        };
+
+        let resolved = manager.resolve_local_command("server", &local).unwrap();
+        assert!(matches!(
+            resolved.policy_subject,
+            ProcessPolicySubject::Path(ref path) if path == &shadow.canonicalize().unwrap()
+        ));
+        assert!(manager.process_policy.approve("server", &resolved).is_err());
+    }
+
+    #[test]
+    fn relative_cwd_and_path_commands_resolve_from_base_dir() {
+        let dir = tempdir().unwrap();
+        let bin_dir = dir.path().join("bin");
+        std::fs::create_dir_all(&bin_dir).unwrap();
+        let executable = bin_dir.join("server");
+        std::fs::write(&executable, "").unwrap();
+
+        let manager = McpToolsManager {
+            base_dir: dir.path().to_path_buf(),
+            ..McpToolsManager::default()
+        };
+        let local = McpLocalServerConfig {
+            command: vec!["./server".to_string()],
+            cwd: Some("bin".to_string()),
+            environment: HashMap::new(),
+        };
+
+        let resolved = manager.resolve_local_command("server", &local).unwrap();
+        assert_eq!(resolved.cwd, bin_dir);
+        assert!(matches!(
+            resolved.policy_subject,
+            ProcessPolicySubject::Path(path) if path == executable.canonicalize().unwrap()
+        ));
+    }
+
+    #[test]
+    fn tool_names_are_prefixed_and_sanitized() {
+        assert_eq!(
+            exposed_tool_name("my.special-server", "tool.name"),
+            "my_special-server_6d792e7370656369616c2d736572766572_tool_name"
+        );
+    }
+
+    #[test]
+    fn remote_header_parsing_rejects_invalid_names() {
+        let mut headers = HashMap::new();
+        headers.insert("bad header".to_string(), "value".to_string());
+        assert!(parse_headers("server", &headers).is_err());
+    }
+
+    #[test]
+    fn validate_remote_config_from_transport() {
+        let config = McpServerConfig {
+            name: "remote".to_string(),
+            enabled: true,
+            timeout_ms: crate::mcp::config::default_timeout_ms(),
+            transport: McpServerTransport::Remote(McpRemoteServerConfig {
+                url: "https://example.com/mcp".to_string(),
+                headers: HashMap::new(),
+            }),
+        };
+        assert!(config.validate().is_ok());
     }
 }

--- a/crates/autoagents-toolkit/src/mcp/config.rs
+++ b/crates/autoagents-toolkit/src/mcp/config.rs
@@ -1,140 +1,439 @@
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::collections::HashMap;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
-/// MCP Server configuration
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct McpServerConfig {
-    /// Server name
-    pub name: String,
-    /// Protocol type (stdio, sse, etc.)
-    pub protocol: String,
-    /// Command to execute
-    pub command: String,
-    /// Arguments for the command
-    #[serde(default)]
-    pub args: Vec<String>,
-    /// Environment variables
-    #[serde(default)]
-    pub env: HashMap<String, String>,
-    /// Working directory
-    #[serde(default)]
-    pub cwd: Option<String>,
-    /// Connection timeout in seconds
-    #[serde(default = "default_timeout")]
-    pub timeout: u64,
-}
+const DEFAULT_TIMEOUT_MS: u64 = 30_000;
 
-/// MCP configuration containing all servers
+/// MCP configuration containing all servers.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct McpConfig {
     #[serde(rename = "server")]
     pub servers: Vec<McpServerConfig>,
+    #[serde(skip)]
+    base_dir: Option<PathBuf>,
 }
 
-/// Top-level configuration structure
+/// Top-level configuration structure.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Config {
     pub mcp: McpConfig,
 }
 
-fn default_timeout() -> u64 {
-    30
+/// MCP server configuration.
+#[derive(Debug, Clone)]
+pub struct McpServerConfig {
+    pub name: String,
+    pub enabled: bool,
+    pub timeout_ms: u64,
+    pub transport: McpServerTransport,
+}
+
+/// Supported MCP transports.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum McpServerTransport {
+    Local(McpLocalServerConfig),
+    Remote(McpRemoteServerConfig),
+    Unsupported { protocol: String },
+}
+
+/// Local stdio MCP server configuration.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct McpLocalServerConfig {
+    pub command: Vec<String>,
+    pub cwd: Option<String>,
+    pub environment: HashMap<String, String>,
+}
+
+/// Remote Streamable HTTP MCP server configuration.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct McpRemoteServerConfig {
+    pub url: String,
+    pub headers: HashMap<String, String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawMcpServerConfig {
+    name: String,
+    #[serde(rename = "type")]
+    transport_type: Option<String>,
+    protocol: Option<String>,
+    command: Option<CommandValue>,
+    #[serde(default)]
+    args: Vec<String>,
+    #[serde(default, alias = "environment")]
+    env: HashMap<String, String>,
+    cwd: Option<String>,
+    url: Option<String>,
+    #[serde(default)]
+    headers: HashMap<String, String>,
+    #[serde(default = "default_enabled")]
+    enabled: bool,
+    #[serde(default)]
+    timeout_ms: Option<u64>,
+    #[serde(default)]
+    timeout: Option<u64>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum CommandValue {
+    String(String),
+    Vec(Vec<String>),
+}
+
+fn default_enabled() -> bool {
+    true
+}
+
+pub fn default_timeout_ms() -> u64 {
+    DEFAULT_TIMEOUT_MS
 }
 
 impl McpConfig {
-    /// Load MCP configuration from a TOML file
+    /// Load MCP configuration from a TOML file.
     pub fn from_file<P: AsRef<Path>>(path: P) -> Result<Self, Box<dyn std::error::Error>> {
+        let path = path.as_ref();
         let content = std::fs::read_to_string(path)?;
-        let config: Config = toml::from_str(&content)?;
+        let mut config: Config = toml::from_str(&content)?;
+        config.mcp.base_dir = path.parent().map(Path::to_path_buf);
         Ok(config.mcp)
     }
 
-    /// Create a new empty MCP configuration
+    /// Create a new empty MCP configuration.
     pub fn new() -> Self {
         Self::default()
     }
 
-    /// Add a server to the configuration
+    /// Add a server to the configuration.
     pub fn add_server(&mut self, server: McpServerConfig) {
         self.servers.push(server);
     }
 
-    /// Get a server by name
+    /// Get a server by name.
     pub fn get_server(&self, name: &str) -> Option<&McpServerConfig> {
-        self.servers.iter().find(|s| s.name == name)
+        self.servers.iter().find(|server| server.name == name)
     }
 
-    /// List all server names
+    /// List all server names.
     pub fn server_names(&self) -> Vec<&str> {
-        self.servers.iter().map(|s| s.name.as_str()).collect()
+        self.servers
+            .iter()
+            .map(|server| server.name.as_str())
+            .collect()
+    }
+
+    /// Base directory used for resolving relative MCP process paths.
+    pub fn base_dir(&self) -> Option<&Path> {
+        self.base_dir.as_deref()
+    }
+
+    /// Set the base directory used for resolving relative process paths.
+    pub fn with_base_dir<P: Into<PathBuf>>(mut self, base_dir: P) -> Self {
+        self.base_dir = Some(base_dir.into());
+        self
     }
 }
 
 impl McpServerConfig {
-    /// Create a new server configuration
+    /// Create a backward-compatible local stdio server configuration.
     pub fn new(name: String, protocol: String, command: String) -> Self {
+        let transport = if protocol == "stdio" {
+            McpServerTransport::Local(McpLocalServerConfig {
+                command: vec![command],
+                cwd: None,
+                environment: HashMap::new(),
+            })
+        } else {
+            McpServerTransport::Unsupported { protocol }
+        };
+
         Self {
             name,
-            protocol,
-            command,
-            args: Vec::new(),
-            env: HashMap::new(),
-            cwd: None,
-            timeout: default_timeout(),
+            enabled: true,
+            timeout_ms: default_timeout_ms(),
+            transport,
         }
     }
 
-    /// Set command arguments
+    /// Create a local stdio MCP server configuration.
+    pub fn local(name: impl Into<String>, command: Vec<String>) -> Self {
+        Self {
+            name: name.into(),
+            enabled: true,
+            timeout_ms: default_timeout_ms(),
+            transport: McpServerTransport::Local(McpLocalServerConfig {
+                command,
+                cwd: None,
+                environment: HashMap::new(),
+            }),
+        }
+    }
+
+    /// Create a remote Streamable HTTP MCP server configuration.
+    pub fn remote(name: impl Into<String>, url: impl Into<String>) -> Self {
+        Self {
+            name: name.into(),
+            enabled: true,
+            timeout_ms: default_timeout_ms(),
+            transport: McpServerTransport::Remote(McpRemoteServerConfig {
+                url: url.into(),
+                headers: HashMap::new(),
+            }),
+        }
+    }
+
+    /// Set local command arguments for backward-compatible callers.
     pub fn with_args(mut self, args: Vec<String>) -> Self {
-        self.args = args;
+        if let McpServerTransport::Local(local) = &mut self.transport {
+            local.command.extend(args);
+        }
         self
     }
 
-    /// Set environment variables
+    /// Set local environment variables.
     pub fn with_env(mut self, env: HashMap<String, String>) -> Self {
-        self.env = env;
+        if let McpServerTransport::Local(local) = &mut self.transport {
+            local.environment = env;
+        }
         self
     }
 
-    /// Set working directory
+    /// Set local working directory.
     pub fn with_cwd<P: AsRef<Path>>(mut self, cwd: P) -> Self {
-        self.cwd = Some(cwd.as_ref().to_string_lossy().to_string());
+        if let McpServerTransport::Local(local) = &mut self.transport {
+            local.cwd = Some(cwd.as_ref().to_string_lossy().to_string());
+        }
         self
     }
 
-    /// Set timeout
-    pub fn with_timeout(mut self, timeout: u64) -> Self {
-        self.timeout = timeout;
+    /// Set timeout in seconds.
+    ///
+    /// This preserves the pre-typed-config builder API semantics. Use
+    /// [`Self::with_timeout_ms`] when configuring millisecond values.
+    pub fn with_timeout(mut self, timeout_secs: u64) -> Self {
+        self.timeout_ms = timeout_secs.saturating_mul(1_000);
         self
     }
 
-    /// Validate the server configuration
+    /// Set timeout in milliseconds.
+    pub fn with_timeout_ms(mut self, timeout_ms: u64) -> Self {
+        self.timeout_ms = timeout_ms;
+        self
+    }
+
+    /// Set whether this server is enabled.
+    pub fn with_enabled(mut self, enabled: bool) -> Self {
+        self.enabled = enabled;
+        self
+    }
+
+    /// Set remote HTTP headers.
+    pub fn with_headers(mut self, headers: HashMap<String, String>) -> Self {
+        if let McpServerTransport::Remote(remote) = &mut self.transport {
+            remote.headers = headers;
+        }
+        self
+    }
+
+    /// Validate the server configuration.
     pub fn validate(&self) -> Result<(), String> {
-        if self.name.is_empty() {
-            return Err("Server name cannot be empty".to_string());
+        if self.name.trim().is_empty() {
+            return Err("MCP server name cannot be empty".to_string());
         }
 
-        if self.command.is_empty() {
-            return Err("Server command cannot be empty".to_string());
+        if self.timeout_ms == 0 {
+            return Err(format!(
+                "MCP server '{}' timeout_ms must be greater than zero",
+                self.name
+            ));
         }
 
-        match self.protocol.as_str() {
-            "stdio" | "sse" | "http" => Ok(()),
-            _ => Err(format!("Unsupported protocol: {}", self.protocol)),
+        match &self.transport {
+            McpServerTransport::Local(local) => {
+                if local.command.is_empty() || local.command[0].trim().is_empty() {
+                    return Err(format!(
+                        "MCP local server '{}' command cannot be empty",
+                        self.name
+                    ));
+                }
+                Ok(())
+            }
+            McpServerTransport::Remote(remote) => {
+                if remote.url.trim().is_empty() {
+                    return Err(format!(
+                        "MCP remote server '{}' url cannot be empty",
+                        self.name
+                    ));
+                }
+                remote
+                    .url
+                    .parse::<http::Uri>()
+                    .map_err(|error| {
+                        format!("MCP remote server '{}' url is invalid: {error}", self.name)
+                    })
+                    .and_then(|uri| match uri.scheme_str() {
+                        Some("http" | "https") => Ok(()),
+                        Some(scheme) => Err(format!(
+                            "MCP remote server '{}' url scheme '{}' is unsupported",
+                            self.name, scheme
+                        )),
+                        None => Err(format!(
+                            "MCP remote server '{}' url must include http or https scheme",
+                            self.name
+                        )),
+                    })
+            }
+            McpServerTransport::Unsupported { protocol } => Err(format!(
+                "Unsupported MCP protocol '{}'. Use type = 'local' for stdio or type = 'remote' for Streamable HTTP.",
+                protocol
+            )),
         }
     }
+
+    pub fn local_config(&self) -> Option<&McpLocalServerConfig> {
+        match &self.transport {
+            McpServerTransport::Local(local) => Some(local),
+            _ => None,
+        }
+    }
+
+    pub fn remote_config(&self) -> Option<&McpRemoteServerConfig> {
+        match &self.transport {
+            McpServerTransport::Remote(remote) => Some(remote),
+            _ => None,
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for McpServerConfig {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let raw = RawMcpServerConfig::deserialize(deserializer)?;
+        let timeout_ms = raw
+            .timeout_ms
+            .or_else(|| {
+                raw.timeout
+                    .map(|timeout_secs| timeout_secs.saturating_mul(1_000))
+            })
+            .unwrap_or_else(default_timeout_ms);
+
+        let transport = match raw.transport_type.as_deref() {
+            Some("local") => {
+                let command = command_vec(raw.command, raw.args)
+                    .map_err(<D::Error as serde::de::Error>::custom)?;
+                McpServerTransport::Local(McpLocalServerConfig {
+                    command,
+                    cwd: raw.cwd,
+                    environment: raw.env,
+                })
+            }
+            Some("remote") => McpServerTransport::Remote(McpRemoteServerConfig {
+                url: raw.url.ok_or_else(|| {
+                    <D::Error as serde::de::Error>::custom("remote MCP server requires url")
+                })?,
+                headers: raw.headers,
+            }),
+            Some(other) => McpServerTransport::Unsupported {
+                protocol: other.to_string(),
+            },
+            None => match raw.protocol.as_deref() {
+                Some("stdio") => {
+                    let command = command_vec(raw.command, raw.args)
+                        .map_err(<D::Error as serde::de::Error>::custom)?;
+                    McpServerTransport::Local(McpLocalServerConfig {
+                        command,
+                        cwd: raw.cwd,
+                        environment: raw.env,
+                    })
+                }
+                Some(protocol @ ("http" | "https" | "streamable_http")) => {
+                    let url = raw.url.ok_or_else(|| {
+                        <D::Error as serde::de::Error>::custom(format!(
+                            "remote MCP protocol '{protocol}' requires url"
+                        ))
+                    })?;
+                    McpServerTransport::Remote(McpRemoteServerConfig {
+                        url,
+                        headers: raw.headers,
+                    })
+                }
+                Some(protocol) => McpServerTransport::Unsupported {
+                    protocol: protocol.to_string(),
+                },
+                None => {
+                    return Err(<D::Error as serde::de::Error>::custom(
+                        "MCP server requires type or protocol",
+                    ));
+                }
+            },
+        };
+
+        Ok(Self {
+            name: raw.name,
+            enabled: raw.enabled,
+            timeout_ms,
+            transport,
+        })
+    }
+}
+
+impl Serialize for McpServerConfig {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        use serde::ser::SerializeStruct;
+
+        let mut fields = match &self.transport {
+            McpServerTransport::Local(_) => serializer.serialize_struct("McpServerConfig", 7)?,
+            McpServerTransport::Remote(_) => serializer.serialize_struct("McpServerConfig", 6)?,
+            McpServerTransport::Unsupported { .. } => {
+                serializer.serialize_struct("McpServerConfig", 4)?
+            }
+        };
+        fields.serialize_field("name", &self.name)?;
+        fields.serialize_field("enabled", &self.enabled)?;
+        fields.serialize_field("timeout_ms", &self.timeout_ms)?;
+        match &self.transport {
+            McpServerTransport::Local(local) => {
+                fields.serialize_field("type", "local")?;
+                fields.serialize_field("command", &local.command)?;
+                fields.serialize_field("cwd", &local.cwd)?;
+                fields.serialize_field("environment", &local.environment)?;
+            }
+            McpServerTransport::Remote(remote) => {
+                fields.serialize_field("type", "remote")?;
+                fields.serialize_field("url", &remote.url)?;
+                fields.serialize_field("headers", &remote.headers)?;
+            }
+            McpServerTransport::Unsupported { protocol } => {
+                fields.serialize_field("protocol", protocol)?;
+            }
+        }
+        fields.end()
+    }
+}
+
+fn command_vec(command: Option<CommandValue>, args: Vec<String>) -> Result<Vec<String>, String> {
+    let mut command = match command {
+        Some(CommandValue::String(command)) => vec![command],
+        Some(CommandValue::Vec(command)) => command,
+        None => return Err("local MCP server requires command".to_string()),
+    };
+    command.extend(args);
+    Ok(command)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::io::Write;
-    use tempfile::NamedTempFile;
-    use tempfile::tempdir;
+    use tempfile::{NamedTempFile, tempdir};
 
     #[test]
-    fn test_mcp_server_config_creation() {
+    fn creates_local_config_with_legacy_constructor() {
         let config = McpServerConfig::new(
             "test_server".to_string(),
             "stdio".to_string(),
@@ -142,15 +441,14 @@ mod tests {
         );
 
         assert_eq!(config.name, "test_server");
-        assert_eq!(config.protocol, "stdio");
-        assert_eq!(config.command, "python");
-        assert!(config.args.is_empty());
-        assert!(config.env.is_empty());
-        assert_eq!(config.timeout, 30);
+        assert_eq!(config.timeout_ms, 30_000);
+        let local = config.local_config().expect("local config");
+        assert_eq!(local.command, vec!["python"]);
+        assert!(local.environment.is_empty());
     }
 
     #[test]
-    fn test_mcp_server_config_builder() -> std::io::Result<()> {
+    fn local_builder_sets_options() -> std::io::Result<()> {
         let dir = tempdir()?;
         let cwd = dir.path().to_str().unwrap().to_string();
         let mut env = HashMap::new();
@@ -166,51 +464,61 @@ mod tests {
         .with_cwd(cwd.clone())
         .with_timeout(60);
 
-        assert_eq!(config.name, "builder_test");
-        assert_eq!(config.args, vec!["-m", "my_server"]);
-        assert_eq!(config.env, env);
-        assert_eq!(config.cwd, Some(cwd));
-        assert_eq!(config.timeout, 60);
+        let local = config.local_config().expect("local config");
+        assert_eq!(local.command, vec!["python", "-m", "my_server"]);
+        assert_eq!(local.environment, env);
+        assert_eq!(local.cwd, Some(cwd));
+        assert_eq!(config.timeout_ms, 60_000);
         Ok(())
     }
 
     #[test]
-    fn test_mcp_server_config_validation() {
-        let valid_config = McpServerConfig::new(
-            "valid".to_string(),
-            "stdio".to_string(),
-            "python".to_string(),
+    fn validates_config() {
+        assert!(
+            McpServerConfig::new(
+                "valid".to_string(),
+                "stdio".to_string(),
+                "python".to_string()
+            )
+            .validate()
+            .is_ok()
         );
-        assert!(valid_config.validate().is_ok());
 
-        let empty_name =
-            McpServerConfig::new("".to_string(), "stdio".to_string(), "python".to_string());
-        assert!(empty_name.validate().is_err());
-
-        let empty_command =
-            McpServerConfig::new("test".to_string(), "stdio".to_string(), "".to_string());
-        assert!(empty_command.validate().is_err());
-
-        let invalid_protocol = McpServerConfig::new(
-            "test".to_string(),
-            "invalid".to_string(),
-            "python".to_string(),
+        assert!(
+            McpServerConfig::new("".to_string(), "stdio".to_string(), "python".to_string())
+                .validate()
+                .is_err()
         );
-        assert!(invalid_protocol.validate().is_err());
+
+        assert!(
+            McpServerConfig::new("test".to_string(), "stdio".to_string(), "".to_string())
+                .validate()
+                .is_err()
+        );
+
+        assert!(
+            McpServerConfig::new("test".to_string(), "sse".to_string(), "node".to_string())
+                .validate()
+                .is_err()
+        );
+
+        assert!(
+            McpServerConfig::remote("remote", "https://example.com/mcp")
+                .validate()
+                .is_ok()
+        );
     }
 
     #[test]
-    fn test_mcp_config_operations() {
+    fn config_operations_work() {
         let mut config = McpConfig::default();
         assert!(config.servers.is_empty());
         assert!(config.server_names().is_empty());
 
-        let server = McpServerConfig::new(
-            "test_server".to_string(),
-            "stdio".to_string(),
-            "python".to_string(),
-        );
-        config.add_server(server);
+        config.add_server(McpServerConfig::local(
+            "test_server",
+            vec!["python".to_string()],
+        ));
 
         assert_eq!(config.servers.len(), 1);
         assert_eq!(config.server_names(), vec!["test_server"]);
@@ -219,7 +527,7 @@ mod tests {
     }
 
     #[test]
-    fn test_config_from_toml() {
+    fn parses_new_and_legacy_toml() {
         let toml_content = r#"
 [mcp]
 [[mcp.server]]
@@ -230,10 +538,13 @@ args = ["-m", "test_module"]
 timeout = 45
 
 [[mcp.server]]
-name = "another_server"
-protocol = "sse"
-command = "node"
-args = ["server.js"]
+name = "remote_server"
+type = "remote"
+url = "https://example.com/mcp"
+timeout_ms = 5000
+
+[mcp.server.headers]
+Authorization = "Bearer token"
         "#;
 
         let mut temp_file = NamedTempFile::new().unwrap();
@@ -242,26 +553,28 @@ args = ["server.js"]
 
         let config = McpConfig::from_file(temp_file.path()).unwrap();
         assert_eq!(config.servers.len(), 2);
+        assert_eq!(config.base_dir(), temp_file.path().parent());
 
         let first_server = config.get_server("test_server").unwrap();
-        assert_eq!(first_server.protocol, "stdio");
-        assert_eq!(first_server.command, "python");
-        assert_eq!(first_server.args, vec!["-m", "test_module"]);
-        assert_eq!(first_server.timeout, 45);
+        let first_local = first_server.local_config().unwrap();
+        assert_eq!(first_local.command, vec!["python", "-m", "test_module"]);
+        assert_eq!(first_server.timeout_ms, 45_000);
 
-        let second_server = config.get_server("another_server").unwrap();
-        assert_eq!(second_server.protocol, "sse");
-        assert_eq!(second_server.command, "node");
-        assert_eq!(second_server.args, vec!["server.js"]);
+        let second_server = config.get_server("remote_server").unwrap();
+        let remote = second_server.remote_config().unwrap();
+        assert_eq!(remote.url, "https://example.com/mcp");
+        assert_eq!(
+            remote.headers.get("Authorization"),
+            Some(&"Bearer token".to_string())
+        );
     }
 
     #[test]
-    fn test_config_from_invalid_toml() {
+    fn rejects_invalid_toml() {
         let invalid_toml = r#"
 [mcp]
 [[mcp.server]]
 name = "incomplete"
-# Missing required fields
         "#;
 
         let mut temp_file = NamedTempFile::new().unwrap();
@@ -273,7 +586,7 @@ name = "incomplete"
     }
 
     #[test]
-    fn test_config_with_env_vars() {
+    fn parses_environment_aliases() {
         let dir = tempdir().unwrap();
         let cwd_str = dir.path().to_str().unwrap();
 
@@ -282,11 +595,11 @@ name = "incomplete"
 [mcp]
 [[mcp.server]]
 name = "env_server"
-protocol = "stdio"
-command = "python"
+type = "local"
+command = ["python", "-m", "server"]
 cwd = "{cwd}"
 
-[mcp.server.env]
+[mcp.server.environment]
 PYTHONPATH = "/path/to/modules"
 DEBUG = "1"
         "#,
@@ -298,41 +611,29 @@ DEBUG = "1"
         temp_file.flush().unwrap();
 
         let config = McpConfig::from_file(temp_file.path()).unwrap();
-        let server = config.get_server("env_server").unwrap();
+        let local = config
+            .get_server("env_server")
+            .unwrap()
+            .local_config()
+            .unwrap();
 
-        assert_eq!(server.cwd, Some(cwd_str.to_string()));
+        assert_eq!(local.cwd, Some(cwd_str.to_string()));
         assert_eq!(
-            server.env.get("PYTHONPATH"),
+            local.environment.get("PYTHONPATH"),
             Some(&"/path/to/modules".to_string())
         );
-        assert_eq!(server.env.get("DEBUG"), Some(&"1".to_string()));
+        assert_eq!(local.environment.get("DEBUG"), Some(&"1".to_string()));
     }
 
     #[test]
-    fn test_default_values() {
-        let server = McpServerConfig::new(
-            "default_test".to_string(),
-            "stdio".to_string(),
-            "command".to_string(),
-        );
-
-        assert_eq!(server.timeout, 30);
-        assert!(server.args.is_empty());
-        assert!(server.env.is_empty());
-        assert!(server.cwd.is_none());
-    }
-
-    #[test]
-    fn test_config_serialization() {
+    fn serializes_config() {
         let mut env = HashMap::default();
         env.insert("TEST_VAR".to_string(), "test_value".to_string());
 
-        let server = McpServerConfig::new(
-            "serialize_test".to_string(),
-            "stdio".to_string(),
-            "python".to_string(),
+        let server = McpServerConfig::local(
+            "serialize_test",
+            vec!["python".to_string(), "-m".to_string(), "server".to_string()],
         )
-        .with_args(vec!["-m".to_string(), "server".to_string()])
         .with_env(env);
 
         let mut config = McpConfig::default();
@@ -345,13 +646,10 @@ DEBUG = "1"
         let deserialized: Config = toml::from_str(&serialized).unwrap();
 
         assert_eq!(config.servers.len(), deserialized.mcp.servers.len());
-        let original = &config.servers[0];
-        let parsed = &deserialized.mcp.servers[0];
+        let original = config.servers[0].local_config().unwrap();
+        let parsed = deserialized.mcp.servers[0].local_config().unwrap();
 
-        assert_eq!(original.name, parsed.name);
-        assert_eq!(original.protocol, parsed.protocol);
         assert_eq!(original.command, parsed.command);
-        assert_eq!(original.args, parsed.args);
-        assert_eq!(original.env, parsed.env);
+        assert_eq!(original.environment, parsed.environment);
     }
 }

--- a/crates/autoagents-toolkit/src/mcp/mod.rs
+++ b/crates/autoagents-toolkit/src/mcp/mod.rs
@@ -9,6 +9,12 @@ pub mod config;
 pub mod tools;
 
 pub use adapter::{McpToolAdapter, McpToolWrapper};
-pub use client::{McpError, McpServerConnection, McpToolsManager};
-pub use config::{Config, McpConfig, McpServerConfig};
+pub use client::{
+    McpError, McpProcessPolicy, McpServerConnection, McpServerInstructions, McpServerStatus,
+    McpToolsManager,
+};
+pub use config::{
+    Config, McpConfig, McpLocalServerConfig, McpRemoteServerConfig, McpServerConfig,
+    McpServerTransport,
+};
 pub use tools::McpTools;

--- a/crates/autoagents-toolkit/src/mcp/tools.rs
+++ b/crates/autoagents-toolkit/src/mcp/tools.rs
@@ -1,5 +1,9 @@
-use crate::mcp::{McpConfig, McpError, McpToolsManager};
+use crate::mcp::{
+    McpConfig, McpError, McpProcessPolicy, McpServerInstructions, McpServerStatus, McpToolsManager,
+};
 use autoagents::core::tool::ToolT;
+use rmcp::model::{Prompt, Resource, ResourceTemplate};
+use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Arc;
 
@@ -21,9 +25,39 @@ impl McpTools {
         Ok(Self { manager })
     }
 
+    /// Create MCP tools from a configuration file with an explicit local process policy.
+    pub async fn from_config_with_process_policy<P: AsRef<Path>>(
+        config_path: P,
+        process_policy: McpProcessPolicy,
+    ) -> Result<Self, McpError> {
+        let manager = Arc::new(
+            McpToolsManager::from_config_file_with_process_policy(config_path, process_policy)
+                .await?,
+        );
+        Ok(Self { manager })
+    }
+
     /// Create MCP tools from a configuration object
     pub async fn from_config_object(config: &McpConfig) -> Result<Self, McpError> {
-        let manager = Arc::new(McpToolsManager::new());
+        let mut manager = McpToolsManager::new();
+        if let Some(base_dir) = config.base_dir() {
+            manager = manager.with_base_dir(base_dir.to_path_buf());
+        }
+        let manager = Arc::new(manager);
+        manager.connect_servers(config).await?;
+        Ok(Self { manager })
+    }
+
+    /// Create MCP tools from a configuration object with an explicit local process policy.
+    pub async fn from_config_object_with_process_policy(
+        config: &McpConfig,
+        process_policy: McpProcessPolicy,
+    ) -> Result<Self, McpError> {
+        let mut manager = McpToolsManager::with_process_policy(process_policy);
+        if let Some(base_dir) = config.base_dir() {
+            manager = manager.with_base_dir(base_dir.to_path_buf());
+        }
+        let manager = Arc::new(manager);
         manager.connect_servers(config).await?;
         Ok(Self { manager })
     }
@@ -51,6 +85,47 @@ impl McpTools {
     /// Refresh tools from all connected servers
     pub async fn refresh(&self) -> Result<(), McpError> {
         self.manager.refresh_tools().await
+    }
+
+    /// Get configured server statuses.
+    pub async fn status(&self) -> HashMap<String, McpServerStatus> {
+        self.manager.status().await
+    }
+
+    /// Connect a configured server.
+    pub async fn connect(&self, name: &str) -> Result<(), McpError> {
+        self.manager.connect(name).await
+    }
+
+    /// Disconnect a configured server.
+    pub async fn disconnect(&self, name: &str) -> Result<(), McpError> {
+        self.manager.disconnect(name).await
+    }
+
+    /// Get server-provided instructions for connected servers.
+    pub async fn server_instructions(&self) -> Vec<McpServerInstructions> {
+        self.manager.server_instructions().await
+    }
+
+    /// List prompts from connected servers.
+    pub async fn prompts(&self) -> Result<HashMap<String, Prompt>, McpError> {
+        self.manager.prompts().await
+    }
+
+    /// List resources from connected servers.
+    pub async fn resources(
+        &self,
+        server_name: Option<&str>,
+    ) -> Result<HashMap<String, Resource>, McpError> {
+        self.manager.resources(server_name).await
+    }
+
+    /// List resource templates from connected servers.
+    pub async fn resource_templates(
+        &self,
+        server_name: Option<&str>,
+    ) -> Result<HashMap<String, ResourceTemplate>, McpError> {
+        self.manager.resource_templates(server_name).await
     }
 
     /// Get connected server names
@@ -123,6 +198,8 @@ impl autoagents::core::tool::ToolRuntime for McpToolWrapper {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::mcp::{McpProcessPolicy, McpServerConfig};
+    use tempfile::tempdir;
 
     #[tokio::test]
     async fn test_empty_mcp_tools() {
@@ -137,5 +214,27 @@ mod tests {
         let tools = McpTools::default();
         let boxed_tools = tools.to_boxed_tools().await;
         assert!(boxed_tools.is_empty());
+    }
+
+    #[tokio::test]
+    async fn from_config_object_honors_config_base_dir_for_relative_commands() {
+        let dir = tempdir().unwrap();
+        let bin_dir = dir.path().join("node_modules").join(".bin");
+        std::fs::create_dir_all(&bin_dir).unwrap();
+        let server_bin = bin_dir.join("server");
+        std::fs::write(&server_bin, "").unwrap();
+
+        let mut config = McpConfig::new().with_base_dir(dir.path().to_path_buf());
+        config.add_server(McpServerConfig::local(
+            "local",
+            vec!["./node_modules/.bin/server".to_string()],
+        ));
+
+        let err =
+            McpTools::from_config_object_with_process_policy(&config, McpProcessPolicy::deny_all())
+                .await
+                .unwrap_err();
+
+        assert!(err.to_string().contains(&server_bin.display().to_string()));
     }
 }

--- a/crates/autoagents-toolkit/src/utils/path_sandbox.rs
+++ b/crates/autoagents-toolkit/src/utils/path_sandbox.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(not(feature = "filesystem"), allow(dead_code))]
+
 use std::path::{Component, Path, PathBuf};
 
 /// Normalize a path by resolving `.` and `..` components without touching the filesystem.

--- a/docs/content/core-concepts/tools.md
+++ b/docs/content/core-concepts/tools.md
@@ -59,4 +59,28 @@ The filesystem constructors named `new()` are also sandboxed to the process curr
 
 ## MCP
 
-Model Context Protocol (MCP) integrations are available via `autoagents-toolkit::mcp` — load tool definitions from MCP servers and expose them as `ToolT`. See `McpTools` for managing connections and wrapping MCP tools for use by agents.
+Model Context Protocol (MCP) integrations are available via `autoagents-toolkit::mcp` — load tool definitions from MCP servers and expose them as `ToolT`. AutoAgents supports local stdio servers and remote Streamable HTTP servers.
+
+Local MCP servers execute host processes. Treat MCP config as trusted code and pass an explicit `McpProcessPolicy` before local servers can run:
+
+```rust
+use autoagents_toolkit::mcp::{McpProcessPolicy, McpTools};
+
+let server_bin = std::fs::canonicalize("./mcp-servers/my-server")?;
+let process_policy = McpProcessPolicy::allow_paths([server_bin])?;
+let mcp_tools = McpTools::from_config_with_process_policy("mcp.toml", process_policy).await?;
+```
+
+Remote MCP servers use `type = "remote"` and may include HTTP headers for API-key style authentication. OAuth is intentionally not handled by the toolkit MCP client yet; store and inject credentials from your application boundary.
+
+```toml
+[mcp]
+[[mcp.server]]
+name = "docs"
+type = "remote"
+url = "https://example.com/mcp"
+timeout_ms = 30000
+
+[mcp.server.headers]
+Authorization = "Bearer ${TOKEN}"
+```

--- a/examples/mcp/README.md
+++ b/examples/mcp/README.md
@@ -2,10 +2,13 @@
 
 This example demonstrates how to integrate MCP servers with AutoAgents, allowing your agents to use tools from external MCP-compatible servers.
 
+MCP local servers execute host processes. This example uses the globally installed Brave Search MCP server binary and explicitly allowlists that command name in code; do not load MCP configs from untrusted sources, and keep your `PATH` trusted.
+
 ### Setup
 
 ```sh
 export OPENAI_API_KEY=your_openai_api_key_here
 export BRAVE_API_KEY=your_brave_api_key_here
+npm install -g @modelcontextprotocol/server-brave-search
 cargo run --package mcp-example
 ```

--- a/examples/mcp/config.toml
+++ b/examples/mcp/config.toml
@@ -1,6 +1,6 @@
 # Brave Search MCP Server - provides web search capabilities
 [[mcp.server]]
 name = "brave_search"
-protocol = "stdio"
-command = "npx"
-args = ["-y", "@modelcontextprotocol/server-brave-search"]
+type = "local"
+command = ["mcp-server-brave-search"]
+timeout_ms = 30000

--- a/examples/mcp/src/main.rs
+++ b/examples/mcp/src/main.rs
@@ -6,7 +6,7 @@ use autoagents::core::error::Error;
 use autoagents::core::tool::ToolT;
 use autoagents::llm::{backends::openai::OpenAI, builder::LLMBuilder};
 use autoagents_derive::AgentHooks;
-use autoagents_toolkit::mcp::{McpToolWrapper, McpTools};
+use autoagents_toolkit::mcp::{McpProcessPolicy, McpToolWrapper, McpTools};
 use std::env;
 use std::sync::Arc;
 
@@ -18,7 +18,10 @@ pub struct McpAgent {
 impl McpAgent {
     pub async fn new() -> Result<Self, Box<dyn std::error::Error>> {
         // Load MCP tools from config
-        let mcp_tools = McpTools::from_config("./examples/mcp/config.toml").await?;
+        let process_policy = McpProcessPolicy::allow_commands(["mcp-server-brave-search"])?;
+        let mcp_tools =
+            McpTools::from_config_with_process_policy("./examples/mcp/config.toml", process_policy)
+                .await?;
         let tools = mcp_tools.get_tools().await;
 
         Ok(Self { tools })


### PR DESCRIPTION
Fixes #250.

## Summary
- Add typed MCP local/remote transport config with strict validation and backwards-compatible legacy parsing.
- Deny local stdio MCP process execution by default and require explicit process policy allowlisting.
- Add strict connection startup by default, explicit partial-startup opt-in, per-server timeouts, prefixed tool names, and cleanup on disabled server reconfiguration.
- Update MCP docs and example to use a globally installed Brave MCP server command.

## Verification
- cargo test -p autoagents-toolkit --features mcp --no-default-features
- cargo clippy -p autoagents-toolkit --features mcp --all-targets -- -D warnings
- cargo check --package mcp-example
- pre-commit hooks: fmt, check, test, clippy

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens MCP configuration and connection handling. The main changes are:

- Typed local and remote MCP transport configuration.
- Default-deny policy for local stdio process execution.
- Per-server startup and tool execution timeouts.
- Prefixed MCP tool names with exact server-keyed cache ownership.
- Cleanup for disabled servers and failed reconnect or refresh paths.
- Updated MCP docs and example configuration.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.
- The local process path is resolved before policy approval and the same resolved path is executed.
- Tool cache ownership now uses exact server keys instead of prefix matching.



<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| crates/autoagents-toolkit/src/mcp/client.rs | Adds MCP process policy checks, remote/local connection setup, server status tracking, exact server-keyed tool caches, unique exposed names, timeouts, and cleanup paths. |
| crates/autoagents-toolkit/src/mcp/config.rs | Replaces the legacy flat server config with typed local and remote transport configs while preserving legacy parsing. |
| crates/autoagents-toolkit/src/mcp/adapter.rs | Uses exposed prefixed names for AutoAgents while preserving original MCP names for tool calls and adding execution timeouts. |
| crates/autoagents-toolkit/src/mcp/tools.rs | Adds process-policy-aware constructors and public accessors for MCP status, instructions, prompts, resources, and templates. |


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `crates/autoagents-toolkit/src/mcp/client.rs`, line 1176-1186 ([link](https://github.com/liquidos-ai/autoagents/blob/c4c5f64ca59f1077132aed33328a4fcabf0bffea/crates/autoagents-toolkit/src/mcp/client.rs#L1176-L1186)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Sanitized Tool Prefix Collisions**

   When two server names sanitize to the same prefix, such as `github.tools` and `github_tools`, both servers expose tools under the same `github_tools_` namespace. Since the manager later removes and looks up tools only by that derived prefix, disabling or reconnecting one server can remove the other server's tools or route a tool call to the wrong MCP server.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: crates/autoagents-toolkit/src/mcp/client.rs
   Line: 1176-1186

   Comment:
   **Sanitized Tool Prefix Collisions**

   When two server names sanitize to the same prefix, such as `github.tools` and `github_tools`, both servers expose tools under the same `github_tools_` namespace. Since the manager later removes and looks up tools only by that derived prefix, disabling or reconnecting one server can remove the other server's tools or route a tool call to the wrong MCP server.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Fautoagents-toolkit%2Fsrc%2Fmcp%2Fclient.rs%0ALine%3A%201176-1186%0A%0AComment%3A%0A**Sanitized%20Tool%20Prefix%20Collisions**%0A%0AWhen%20two%20server%20names%20sanitize%20to%20the%20same%20prefix%2C%20such%20as%20%60github.tools%60%20and%20%60github_tools%60%2C%20both%20servers%20expose%20tools%20under%20the%20same%20%60github_tools_%60%20namespace.%20Since%20the%20manager%20later%20removes%20and%20looks%20up%20tools%20only%20by%20that%20derived%20prefix%2C%20disabling%20or%20reconnecting%20one%20server%20can%20remove%20the%20other%20server's%20tools%20or%20route%20a%20tool%20call%20to%20the%20wrong%20MCP%20server.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=275&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22liquidos-ai%2Fautoagents%22%20on%20the%20existing%20branch%20%22issue-250-mcp-trust-model%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22issue-250-mcp-trust-model%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Fautoagents-toolkit%2Fsrc%2Fmcp%2Fclient.rs%0ALine%3A%201176-1186%0A%0AComment%3A%0A**Sanitized%20Tool%20Prefix%20Collisions**%0A%0AWhen%20two%20server%20names%20sanitize%20to%20the%20same%20prefix%2C%20such%20as%20%60github.tools%60%20and%20%60github_tools%60%2C%20both%20servers%20expose%20tools%20under%20the%20same%20%60github_tools_%60%20namespace.%20Since%20the%20manager%20later%20removes%20and%20looks%20up%20tools%20only%20by%20that%20derived%20prefix%2C%20disabling%20or%20reconnecting%20one%20server%20can%20remove%20the%20other%20server's%20tools%20or%20route%20a%20tool%20call%20to%20the%20wrong%20MCP%20server.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=liquidos-ai%2Fautoagents&pr=275&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a>

2. `crates/autoagents-toolkit/src/mcp/config.rs`, line 1767-1783 ([link](https://github.com/liquidos-ai/autoagents/blob/c4c5f64ca59f1077132aed33328a4fcabf0bffea/crates/autoagents-toolkit/src/mcp/config.rs#L1767-L1783)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> <a href="#"><img alt="security" src="https://greptile-static-assets.s3.amazonaws.com/badges/Security.svg?v=2" align="top"></a> **Remote Hosts Are Unrestricted**

   Remote MCP validation accepts any `http` or `https` URI and does not require a host allowlist. If MCP config is user-controlled or tenant-controlled, it can point the client at loopback, private-network, or metadata endpoints such as `http://127.0.0.1:...` or `http://169.254.169.254/...`, causing the new remote transport to make internal requests.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: crates/autoagents-toolkit/src/mcp/config.rs
   Line: 1767-1783

   Comment:
   **Remote Hosts Are Unrestricted**

   Remote MCP validation accepts any `http` or `https` URI and does not require a host allowlist. If MCP config is user-controlled or tenant-controlled, it can point the client at loopback, private-network, or metadata endpoints such as `http://127.0.0.1:...` or `http://169.254.169.254/...`, causing the new remote transport to make internal requests.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/api/ide/cursor?prompt=This%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Fautoagents-toolkit%2Fsrc%2Fmcp%2Fconfig.rs%0ALine%3A%201767-1783%0A%0AComment%3A%0A**Remote%20Hosts%20Are%20Unrestricted**%0A%0ARemote%20MCP%20validation%20accepts%20any%20%60http%60%20or%20%60https%60%20URI%20and%20does%20not%20require%20a%20host%20allowlist.%20If%20MCP%20config%20is%20user-controlled%20or%20tenant-controlled%2C%20it%20can%20point%20the%20client%20at%20loopback%2C%20private-network%2C%20or%20metadata%20endpoints%20such%20as%20%60http%3A%2F%2F127.0.0.1%3A...%60%20or%20%60http%3A%2F%2F169.254.169.254%2F...%60%2C%20causing%20the%20new%20remote%20transport%20to%20make%20internal%20requests.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&pr=275&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"><img alt="Fix in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22liquidos-ai%2Fautoagents%22%20on%20the%20existing%20branch%20%22issue-250-mcp-trust-model%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22issue-250-mcp-trust-model%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20crates%2Fautoagents-toolkit%2Fsrc%2Fmcp%2Fconfig.rs%0ALine%3A%201767-1783%0A%0AComment%3A%0A**Remote%20Hosts%20Are%20Unrestricted**%0A%0ARemote%20MCP%20validation%20accepts%20any%20%60http%60%20or%20%60https%60%20URI%20and%20does%20not%20require%20a%20host%20allowlist.%20If%20MCP%20config%20is%20user-controlled%20or%20tenant-controlled%2C%20it%20can%20point%20the%20client%20at%20loopback%2C%20private-network%2C%20or%20metadata%20endpoints%20such%20as%20%60http%3A%2F%2F127.0.0.1%3A...%60%20or%20%60http%3A%2F%2F169.254.169.254%2F...%60%2C%20causing%20the%20new%20remote%20transport%20to%20make%20internal%20requests.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=liquidos-ai%2Fautoagents&pr=275&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["\[BUG\]: Harden MCP process trust model"](https://github.com/liquidos-ai/autoagents/commit/cdea061e785d9632e333b89c1830eb83cf43f2d8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42305488)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - AGENTS.md ([source](https://app.greptile.com/liquidos/github/liquidos-ai/autoagents/-/custom-context?memory=3016560d-8393-46c9-8b28-32dd4efbbe2e))
- Context used - CLAUDE.md ([source](https://app.greptile.com/liquidos/github/liquidos-ai/autoagents/-/custom-context?memory=b47666cb-3593-419b-8e94-f613c4c4a23c))
- Context used - docs/content/core-concepts/agents.md ([source](https://app.greptile.com/liquidos/github/liquidos-ai/autoagents/-/custom-context?memory=ee5ee7f3-1bae-40fc-ab9a-3cfb1dc16d60))
</details>


<!-- /greptile_comment -->