### PR TITLE
[REFACTOR]: Harden the LLM secret store and playload logging

### DIFF
--- a/crates/autoagents-llm/src/backends/anthropic.rs
+++ b/crates/autoagents-llm/src/backends/anthropic.rs
@@ -654,10 +654,15 @@ impl ChatProvider for Anthropic {
             .header("anthropic-version", "2023-06-01")
             .json(&req_body);
 
-        if log::log_enabled!(log::Level::Trace)
-            && let Ok(json) = serde_json::to_string(&req_body)
-        {
-            log::trace!("Anthropic request payload: {}", json);
+        if log::log_enabled!(log::Level::Trace) {
+            log::trace!(
+                "{}",
+                crate::request_diagnostics::summarize_json_request(
+                    "Anthropic",
+                    "chat request",
+                    &req_body
+                )
+            );
         }
 
         log::debug!("Anthropic request: POST /v1/messages");
@@ -794,10 +799,15 @@ impl ChatProvider for Anthropic {
             .header("anthropic-version", "2023-06-01")
             .json(&req_body);
 
-        if log::log_enabled!(log::Level::Trace)
-            && let Ok(json) = serde_json::to_string(&req_body)
-        {
-            log::trace!("Anthropic streaming request payload: {}", json);
+        if log::log_enabled!(log::Level::Trace) {
+            log::trace!(
+                "{}",
+                crate::request_diagnostics::summarize_json_request(
+                    "Anthropic",
+                    "streaming tools request",
+                    &req_body
+                )
+            );
         }
 
         log::debug!("Anthropic request: POST /v1/messages (streaming with tools)");

--- a/crates/autoagents-llm/src/backends/azure_openai.rs
+++ b/crates/autoagents-llm/src/backends/azure_openai.rs
@@ -469,10 +469,15 @@ impl ChatProvider for AzureOpenAI {
             response_format,
         };
 
-        if log::log_enabled!(log::Level::Trace)
-            && let Ok(json) = serde_json::to_string(&body)
-        {
-            log::trace!("Azure OpenAI request payload: {}", json);
+        if log::log_enabled!(log::Level::Trace) {
+            log::trace!(
+                "{}",
+                crate::request_diagnostics::summarize_json_request(
+                    "Azure OpenAI",
+                    "chat request",
+                    &body
+                )
+            );
         }
 
         let mut url = self

--- a/crates/autoagents-llm/src/backends/google.rs
+++ b/crates/autoagents-llm/src/backends/google.rs
@@ -30,10 +30,13 @@ use crate::{
 use async_trait::async_trait;
 use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64};
 use futures::stream::Stream;
-use reqwest::Client;
+use reqwest::{Client, Url};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::sync::Arc;
+
+const DEFAULT_GOOGLE_API_BASE_URL: &str = "https://generativelanguage.googleapis.com";
+const GOOGLE_API_KEY_HEADER: &str = "x-goog-api-key";
 
 /// Client for interacting with Google's Gemini API.
 ///
@@ -55,6 +58,8 @@ pub struct Google {
     pub top_p: Option<f32>,
     /// Top-k sampling parameter
     pub top_k: Option<u32>,
+    /// Base URL for the Gemini API.
+    api_base_url: String,
     /// HTTP client for making API requests
     client: Client,
 }
@@ -476,8 +481,17 @@ impl Google {
             timeout_seconds,
             top_p,
             top_k,
+            api_base_url: DEFAULT_GOOGLE_API_BASE_URL.to_string(),
             client,
         }
+    }
+
+    fn model_endpoint_url(&self, model: &str, method: &str) -> Result<Url, LLMError> {
+        let raw_url = format!(
+            "{}/v1beta/models/{model}:{method}",
+            self.api_base_url.trim_end_matches('/')
+        );
+        Url::parse(&raw_url).map_err(|err| LLMError::HttpError(err.to_string()))
     }
 
     /// Sends a chat request to Google's Gemini API with tools.
@@ -518,19 +532,26 @@ impl Google {
             tools: google_tools,
         };
 
-        if log::log_enabled!(log::Level::Trace)
-            && let Ok(json) = serde_json::to_string(&req_body)
-        {
-            log::trace!("Google Gemini request payload (tool): {json}");
+        if log::log_enabled!(log::Level::Trace) {
+            log::trace!(
+                "{}",
+                crate::request_diagnostics::summarize_json_request(
+                    "Google Gemini",
+                    "chat request",
+                    &req_body
+                )
+            );
         }
 
-        let url = format!(
-            "https://generativelanguage.googleapis.com/v1beta/models/{model}:generateContent?key={key}",
-            model = self.model,
-            key = self.api_key
-        );
+        let url = self.model_endpoint_url(&self.model, "generateContent")?;
 
-        let resp = self.client.post(&url).json(&req_body).send().await?;
+        let resp = self
+            .client
+            .post(url)
+            .header(GOOGLE_API_KEY_HEADER, &self.api_key)
+            .json(&req_body)
+            .send()
+            .await?;
 
         log::debug!("Google Gemini HTTP status (tool): {}", resp.status());
 
@@ -621,13 +642,27 @@ impl ChatProvider for Google {
             tools: None,
         };
 
-        let url = format!(
-            "https://generativelanguage.googleapis.com/v1beta/models/{model}:streamGenerateContent?alt=sse&key={key}",
-            model = self.model,
-            key = self.api_key
-        );
+        let mut url = self.model_endpoint_url(&self.model, "streamGenerateContent")?;
+        url.query_pairs_mut().append_pair("alt", "sse");
 
-        let response = self.client.post(&url).json(&req_body).send().await?;
+        if log::log_enabled!(log::Level::Trace) {
+            log::trace!(
+                "{}",
+                crate::request_diagnostics::summarize_json_request(
+                    "Google Gemini",
+                    "stream request",
+                    &req_body
+                )
+            );
+        }
+
+        let response = self
+            .client
+            .post(url)
+            .header(GOOGLE_API_KEY_HEADER, &self.api_key)
+            .json(&req_body)
+            .send()
+            .await?;
 
         let response = ensure_success(response, "Google").await?;
 
@@ -689,12 +724,15 @@ impl EmbeddingProvider for Google {
                 },
             };
 
-            let url = format!(
-                "https://generativelanguage.googleapis.com/v1beta/models/text-embedding-004:embedContent?key={}",
-                self.api_key
-            );
+            let url = self.model_endpoint_url("text-embedding-004", "embedContent")?;
 
-            let resp = self.client.post(&url).json(&req_body).send().await?;
+            let resp = self
+                .client
+                .post(url)
+                .header(GOOGLE_API_KEY_HEADER, &self.api_key)
+                .json(&req_body)
+                .send()
+                .await?;
             let resp = ensure_success(resp, "Google").await?;
 
             let embedding_resp: GoogleEmbeddingResponse = resp.json().await?;
@@ -928,7 +966,23 @@ impl EmbeddingBuilder<Google> {
 mod tests {
     use super::*;
     use crate::chat::{FunctionTool, Tool};
+    use futures::StreamExt;
+    use httpmock::{Method::POST, MockServer};
     use serde_json::json;
+
+    fn test_google_provider(server: &MockServer) -> Google {
+        let mut provider = Google::new(
+            "secret-key",
+            Some("gemini-test".to_string()),
+            None,
+            None,
+            None,
+            None,
+            None,
+        );
+        provider.api_base_url = server.base_url();
+        provider
+    }
 
     #[test]
     fn test_google_function_declaration_from_tool() {
@@ -1281,5 +1335,105 @@ mod tests {
         let response: GoogleChatResponse = serde_json::from_value(payload)
             .expect("response without usageMetadata must still deserialize");
         assert!(response.usage().is_none());
+    }
+
+    #[test]
+    fn test_google_model_endpoint_url_does_not_include_api_key() {
+        let server = MockServer::start();
+        let provider = test_google_provider(&server);
+
+        let url = provider
+            .model_endpoint_url("gemini-test", "generateContent")
+            .expect("url should build");
+
+        assert_eq!(
+            url.as_str(),
+            format!(
+                "{}/v1beta/models/gemini-test:generateContent",
+                server.base_url()
+            )
+        );
+        assert!(url.query().is_none());
+        assert!(!url.as_str().contains("secret-key"));
+        assert!(!url.as_str().contains("key="));
+    }
+
+    #[tokio::test]
+    async fn test_google_chat_sends_api_key_header_not_query_param() {
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(POST)
+                .path("/v1beta/models/gemini-test:generateContent")
+                .header(GOOGLE_API_KEY_HEADER, "secret-key");
+            then.status(200).json_body(json!({
+                "candidates": [{
+                    "content": {
+                        "parts": [{ "text": "ok" }]
+                    }
+                }]
+            }));
+        });
+        let provider = test_google_provider(&server);
+        let messages = [ChatMessage::user().content("hello").build()];
+
+        let response = provider
+            .chat(&messages, None)
+            .await
+            .expect("chat should succeed");
+
+        assert_eq!(response.text().as_deref(), Some("ok"));
+        mock.assert();
+    }
+
+    #[tokio::test]
+    async fn test_google_stream_keeps_alt_query_and_sends_api_key_header() {
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(POST)
+                .path("/v1beta/models/gemini-test:streamGenerateContent")
+                .query_param("alt", "sse")
+                .header(GOOGLE_API_KEY_HEADER, "secret-key");
+            then.status(200)
+                .body("data: {\"candidates\":[{\"content\":{\"parts\":[{\"text\":\"ok\"}]}}]}\n\n");
+        });
+        let provider = test_google_provider(&server);
+        let messages = [ChatMessage::user().content("hello").build()];
+
+        let mut stream = provider
+            .chat_stream(&messages, None)
+            .await
+            .expect("stream should start");
+
+        let first = stream
+            .next()
+            .await
+            .expect("stream should emit")
+            .expect("stream item should decode");
+        assert_eq!(first, "ok");
+        mock.assert();
+    }
+
+    #[tokio::test]
+    async fn test_google_embeddings_send_api_key_header_not_query_param() {
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(POST)
+                .path("/v1beta/models/text-embedding-004:embedContent")
+                .header(GOOGLE_API_KEY_HEADER, "secret-key");
+            then.status(200).json_body(json!({
+                "embedding": {
+                    "values": [0.1, 0.2]
+                }
+            }));
+        });
+        let provider = test_google_provider(&server);
+
+        let embeddings = provider
+            .embed(vec!["hello".to_string()])
+            .await
+            .expect("embedding should succeed");
+
+        assert_eq!(embeddings, vec![vec![0.1, 0.2]]);
+        mock.assert();
     }
 }

--- a/crates/autoagents-llm/src/backends/ollama.rs
+++ b/crates/autoagents-llm/src/backends/ollama.rs
@@ -545,10 +545,15 @@ impl Ollama {
             think: self.think,
         };
 
-        if log::log_enabled!(log::Level::Trace)
-            && let Ok(json) = serde_json::to_string(&req_body)
-        {
-            log::trace!("Ollama request payload (tools): {json}");
+        if log::log_enabled!(log::Level::Trace) {
+            log::trace!(
+                "{}",
+                crate::request_diagnostics::summarize_json_request(
+                    "Ollama",
+                    "tools request",
+                    &req_body
+                )
+            );
         }
 
         let url = format!("{}/api/chat", self.base_url);

--- a/crates/autoagents-llm/src/backends/openai.rs
+++ b/crates/autoagents-llm/src/backends/openai.rs
@@ -1252,10 +1252,15 @@ impl OpenAI {
             .bearer_auth(&self.provider.api_key)
             .json(body);
 
-        if log::log_enabled!(log::Level::Trace)
-            && let Ok(json) = serde_json::to_string(body)
-        {
-            log::trace!("OpenAI Responses payload: {}", json);
+        if log::log_enabled!(log::Level::Trace) {
+            log::trace!(
+                "{}",
+                crate::request_diagnostics::summarize_json_request(
+                    "OpenAI",
+                    "responses request",
+                    body
+                )
+            );
         }
 
         let response = request.send().await?;
@@ -1275,10 +1280,15 @@ impl OpenAI {
         &self,
         body: &OpenAIResponsesRequest,
     ) -> Result<String, LLMError> {
-        if log::log_enabled!(log::Level::Trace)
-            && let Ok(json) = serde_json::to_string(body)
-        {
-            log::trace!("OpenAI Responses payload: {}", json);
+        if log::log_enabled!(log::Level::Trace) {
+            log::trace!(
+                "{}",
+                crate::request_diagnostics::summarize_json_request(
+                    "OpenAI",
+                    "responses request",
+                    body
+                )
+            );
         }
 
         #[cfg(native)]
@@ -1382,10 +1392,11 @@ impl OpenAI {
             .post(url)
             .bearer_auth(&self.provider.api_key)
             .json(&body);
-        if log::log_enabled!(log::Level::Trace)
-            && let Ok(json) = serde_json::to_string(&body)
-        {
-            log::trace!("OpenAI request payload: {}", json);
+        if log::log_enabled!(log::Level::Trace) {
+            log::trace!(
+                "{}",
+                crate::request_diagnostics::summarize_json_request("OpenAI", "chat request", &body)
+            );
         }
         let response = request.send().await?;
         log::debug!("OpenAI HTTP status: {}", response.status());
@@ -1481,10 +1492,15 @@ impl OpenAI {
     ) -> Result<Pin<Box<dyn Stream<Item = Result<StreamChunk, LLMError>> + Send>>, LLMError> {
         let body = self.build_responses_request(messages, tools, json_schema, true)?;
 
-        if log::log_enabled!(log::Level::Trace)
-            && let Ok(json) = serde_json::to_string(&body)
-        {
-            log::trace!("OpenAI Responses payload: {}", json);
+        if log::log_enabled!(log::Level::Trace) {
+            log::trace!(
+                "{}",
+                crate::request_diagnostics::summarize_json_request(
+                    "OpenAI",
+                    "responses stream request",
+                    &body
+                )
+            );
         }
 
         let url = self.responses_url()?;

--- a/crates/autoagents-llm/src/backends/phind.rs
+++ b/crates/autoagents-llm/src/backends/phind.rs
@@ -191,7 +191,10 @@ impl ChatProvider for Phind {
         });
 
         if log::log_enabled!(log::Level::Trace) {
-            log::trace!("Phind request payload: {payload}");
+            log::trace!(
+                "{}",
+                crate::request_diagnostics::summarize_value("Phind", "chat request", &payload)
+            );
         }
 
         let headers = Self::create_headers()?;

--- a/crates/autoagents-llm/src/backends/xai.rs
+++ b/crates/autoagents-llm/src/backends/xai.rs
@@ -425,10 +425,11 @@ impl ChatProvider for XAI {
             search_parameters: Some(&search_parameters),
         };
 
-        if log::log_enabled!(log::Level::Trace)
-            && let Ok(json) = serde_json::to_string(&body)
-        {
-            log::trace!("XAI request payload: {json}");
+        if log::log_enabled!(log::Level::Trace) {
+            log::trace!(
+                "{}",
+                crate::request_diagnostics::summarize_json_request("XAI", "chat request", &body)
+            );
         }
 
         let resp = self

--- a/crates/autoagents-llm/src/lib.rs
+++ b/crates/autoagents-llm/src/lib.rs
@@ -155,6 +155,7 @@ pub mod models;
 
 mod protocol;
 pub mod providers;
+mod request_diagnostics;
 
 /// Composable optimization pipeline for LLM providers.
 pub mod pipeline;

--- a/crates/autoagents-llm/src/providers/openai_compatible.rs
+++ b/crates/autoagents-llm/src/providers/openai_compatible.rs
@@ -486,10 +486,15 @@ impl<T: OpenAIProviderConfig> ChatProvider for OpenAICompatibleProvider<T> {
                 request = request.header(key, value);
             }
         }
-        if log::log_enabled!(log::Level::Trace)
-            && let Ok(json) = serde_json::to_string(&body)
-        {
-            log::trace!("{} request payload: {}", T::PROVIDER_NAME, json);
+        if log::log_enabled!(log::Level::Trace) {
+            log::trace!(
+                "{}",
+                crate::request_diagnostics::summarize_json_request(
+                    T::PROVIDER_NAME,
+                    "chat request",
+                    &body
+                )
+            );
         }
         let response = request.send().await?;
         log::debug!("{} HTTP status: {}", T::PROVIDER_NAME, response.status());
@@ -605,10 +610,15 @@ impl<T: OpenAIProviderConfig> ChatProvider for OpenAICompatibleProvider<T> {
                 request = request.header(key, value);
             }
         }
-        if log::log_enabled!(log::Level::Trace)
-            && let Ok(json) = serde_json::to_string(&body)
-        {
-            log::trace!("{} request payload: {}", T::PROVIDER_NAME, json);
+        if log::log_enabled!(log::Level::Trace) {
+            log::trace!(
+                "{}",
+                crate::request_diagnostics::summarize_json_request(
+                    T::PROVIDER_NAME,
+                    "stream request",
+                    &body
+                )
+            );
         }
         let response = request.send().await?;
         log::debug!("{} HTTP status: {}", T::PROVIDER_NAME, response.status());
@@ -698,13 +708,14 @@ impl<T: OpenAIProviderConfig> ChatProvider for OpenAICompatibleProvider<T> {
             }
         }
 
-        if log::log_enabled!(log::Level::Trace)
-            && let Ok(json) = serde_json::to_string(&body)
-        {
+        if log::log_enabled!(log::Level::Trace) {
             log::trace!(
-                "{} streaming with tools request: {}",
-                T::PROVIDER_NAME,
-                json
+                "{}",
+                crate::request_diagnostics::summarize_json_request(
+                    T::PROVIDER_NAME,
+                    "streaming tools request",
+                    &body
+                )
             );
         }
 

--- a/crates/autoagents-llm/src/request_diagnostics.rs
+++ b/crates/autoagents-llm/src/request_diagnostics.rs
@@ -1,0 +1,235 @@
+use serde::Serialize;
+use serde_json::Value;
+
+const REDACTED: &str = "[redacted request payload]";
+
+pub(crate) fn summarize_json_request<T: Serialize>(
+    provider: &str,
+    operation: &str,
+    body: &T,
+) -> String {
+    match serde_json::to_value(body) {
+        Ok(value) => summarize_value(provider, operation, &value),
+        Err(_) => format!("{provider} {operation}: {REDACTED}; serialization=failed"),
+    }
+}
+
+pub(crate) fn summarize_value(provider: &str, operation: &str, value: &Value) -> String {
+    let model = get_string(value, &["model"])
+        .or_else(|| get_string(value, &["requested_model"]))
+        .unwrap_or("<unknown>");
+    let stream = get_bool(value, &["stream"]);
+    let message_count =
+        count_first_array(value, &["messages", "input", "contents", "message_history"])
+            .unwrap_or(0);
+    let tool_count = count_tools(value);
+    let schema = has_schema(value);
+    let extra_keys = extra_top_level_keys(value);
+
+    let mut parts = vec![
+        format!("model={model}"),
+        format!("messages={message_count}"),
+        format!("tools={tool_count}"),
+        format!("schema={schema}"),
+    ];
+
+    if let Some(stream) = stream {
+        parts.push(format!("stream={stream}"));
+    }
+
+    if !extra_keys.is_empty() {
+        parts.push(format!("extra_keys={}", extra_keys.join(",")));
+    }
+
+    format!("{provider} {operation}: {REDACTED}; {}", parts.join(" "))
+}
+
+fn get_string<'a>(value: &'a Value, path: &[&str]) -> Option<&'a str> {
+    let mut current = value;
+    for key in path {
+        current = current.get(*key)?;
+    }
+    current.as_str()
+}
+
+fn get_bool(value: &Value, path: &[&str]) -> Option<bool> {
+    let mut current = value;
+    for key in path {
+        current = current.get(*key)?;
+    }
+    current.as_bool()
+}
+
+fn count_first_array(value: &Value, keys: &[&str]) -> Option<usize> {
+    keys.iter()
+        .filter_map(|key| value.get(*key).and_then(Value::as_array))
+        .map(Vec::len)
+        .next()
+}
+
+fn count_tools(value: &Value) -> usize {
+    let Some(tools) = value.get("tools").and_then(Value::as_array) else {
+        return 0;
+    };
+
+    let declarations = tools
+        .iter()
+        .filter_map(|tool| tool.get("functionDeclarations").and_then(Value::as_array))
+        .map(Vec::len)
+        .sum::<usize>();
+
+    if declarations > 0 {
+        declarations
+    } else {
+        tools.len()
+    }
+}
+
+fn has_schema(value: &Value) -> bool {
+    has_key_recursive(
+        value,
+        &[
+            "response_format",
+            "response_schema",
+            "output_config",
+            "json_schema",
+        ],
+    )
+}
+
+fn has_key_recursive(value: &Value, keys: &[&str]) -> bool {
+    match value {
+        Value::Object(map) => map
+            .iter()
+            .any(|(key, value)| keys.contains(&key.as_str()) || has_key_recursive(value, keys)),
+        Value::Array(values) => values.iter().any(|value| has_key_recursive(value, keys)),
+        _ => false,
+    }
+}
+
+fn extra_top_level_keys(value: &Value) -> Vec<String> {
+    let Some(map) = value.as_object() else {
+        return Vec::new();
+    };
+
+    let known = [
+        "additional_extension_context",
+        "allow_magic_buttons",
+        "contents",
+        "format",
+        "generationConfig",
+        "input",
+        "is_vscode_extension",
+        "keep_alive",
+        "max_completion_tokens",
+        "max_tokens",
+        "max_output_tokens",
+        "message_history",
+        "messages",
+        "model",
+        "options",
+        "output_config",
+        "parallel_tool_calls",
+        "requested_model",
+        "reasoning_effort",
+        "response_format",
+        "search_parameters",
+        "stream",
+        "stream_options",
+        "system",
+        "temperature",
+        "think",
+        "tool_choice",
+        "tools",
+        "top_k",
+        "top_p",
+        "user_input",
+    ];
+
+    let mut keys = map
+        .keys()
+        .filter(|key| !known.contains(&key.as_str()) && !is_sensitive_key(key))
+        .cloned()
+        .collect::<Vec<_>>();
+    keys.sort();
+    keys
+}
+
+fn is_sensitive_key(key: &str) -> bool {
+    let key = key.to_ascii_lowercase();
+    [
+        "api_key",
+        "auth",
+        "authorization",
+        "content",
+        "input",
+        "key",
+        "message",
+        "output",
+        "password",
+        "prompt",
+        "secret",
+        "token",
+    ]
+    .iter()
+    .any(|needle| key.contains(needle))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn request_summary_excludes_sensitive_values() {
+        let body = json!({
+            "model": "test-model",
+            "messages": [
+                {"role": "user", "content": "my password is hunter2"}
+            ],
+            "tools": [
+                {"function": {"name": "lookup", "parameters": {"type": "object"}}}
+            ],
+            "response_format": {"type": "json_schema", "json_schema": {"name": "Secret"}},
+            "seed": 7,
+            "api_key": "sk-secret",
+            "prompt_cache_key": "secret-cache"
+        });
+
+        let summary = summarize_value("Test", "request", &body);
+
+        assert!(summary.contains("[redacted request payload]"));
+        assert!(summary.contains("model=test-model"));
+        assert!(summary.contains("messages=1"));
+        assert!(summary.contains("tools=1"));
+        assert!(summary.contains("schema=true"));
+        assert!(summary.contains("extra_keys=seed"));
+        assert!(!summary.contains("hunter2"));
+        assert!(!summary.contains("sk-secret"));
+        assert!(!summary.contains("prompt_cache_key"));
+        assert!(!summary.contains("\"messages\""));
+    }
+
+    #[test]
+    fn google_tool_count_uses_function_declarations() {
+        let body = json!({
+            "contents": [{"role": "user", "parts": [{"text": "secret"}]}],
+            "tools": [{
+                "functionDeclarations": [
+                    {"name": "one"},
+                    {"name": "two"}
+                ]
+            }],
+            "generationConfig": {
+                "response_schema": {"type": "object"}
+            }
+        });
+
+        let summary = summarize_value("Google", "request", &body);
+
+        assert!(summary.contains("messages=1"));
+        assert!(summary.contains("tools=2"));
+        assert!(summary.contains("schema=true"));
+        assert!(!summary.contains("secret"));
+    }
+}

--- a/crates/autoagents-llm/src/secret_store.rs
+++ b/crates/autoagents-llm/src/secret_store.rs
@@ -5,7 +5,7 @@ use std::fs::{self, File, OpenOptions};
 use std::io::{self, Read, Write};
 #[cfg(unix)]
 use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 /// Key used to store the default provider in the secret store
 const DEFAULT_PROVIDER_KEY: &str = "default";
@@ -41,25 +41,45 @@ impl SecretStore {
     ///
     /// * `io::Result<Self>` - A new SecretStore instance or an IO error
     pub fn new() -> io::Result<Self> {
+        let mut store = Self::new_empty()?;
+        store.load()?;
+        Ok(store)
+    }
+
+    /// Creates an empty SecretStore at the default path without loading the existing file.
+    ///
+    /// This is intended for explicit recovery flows when the on-disk JSON is corrupt and
+    /// callers want to overwrite it by setting new values or calling [`SecretStore::reset`].
+    pub fn new_empty() -> io::Result<Self> {
+        let file_path = Self::default_file_path()?;
+
+        if let Some(parent) = file_path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+
+        Ok(SecretStore {
+            secrets: HashMap::new(),
+            file_path,
+        })
+    }
+
+    /// Replaces the default secret store file with an empty valid store.
+    ///
+    /// Use this for deliberate recovery from corrupt or unwanted local secret files.
+    pub fn reset() -> io::Result<Self> {
+        let store = Self::new_empty()?;
+        store.save()?;
+        Ok(store)
+    }
+
+    fn default_file_path() -> io::Result<PathBuf> {
         let home_dir = dirs::home_dir().ok_or_else(|| {
             io::Error::new(
                 io::ErrorKind::NotFound,
                 "could not find home directory for SecretStore",
             )
         })?;
-        let file_path = home_dir.join(".llm").join("secrets.json");
-
-        if let Some(parent) = file_path.parent() {
-            fs::create_dir_all(parent)?;
-        }
-
-        let mut store = SecretStore {
-            secrets: HashMap::new(),
-            file_path,
-        };
-
-        store.load()?;
-        Ok(store)
+        Ok(home_dir.join(".llm").join("secrets.json"))
     }
 
     /// Loads secrets from the file system
@@ -100,21 +120,82 @@ impl SecretStore {
         }
 
         let contents = serde_json::to_string_pretty(&self.secrets)?;
+        let temp_path = self.temp_file_path()?;
         let mut options = OpenOptions::new();
-        options.create(true).write(true).truncate(true);
+        options.create_new(true).write(true);
         #[cfg(unix)]
         options.mode(0o600);
 
-        let mut file = options.open(&self.file_path)?;
-        file.write_all(contents.as_bytes())?;
-        file.sync_all()?;
+        let mut file = options.open(&temp_path)?;
+
+        if let Err(error) = file.write_all(contents.as_bytes()) {
+            drop(file);
+            let _ = fs::remove_file(&temp_path);
+            return Err(error);
+        }
+
+        if let Err(error) = file.sync_all() {
+            drop(file);
+            let _ = fs::remove_file(&temp_path);
+            return Err(error);
+        }
+
+        drop(file);
 
         #[cfg(unix)]
-        {
-            fs::set_permissions(&self.file_path, fs::Permissions::from_mode(0o600))?;
+        if let Err(error) = fs::set_permissions(&temp_path, fs::Permissions::from_mode(0o600)) {
+            let _ = fs::remove_file(&temp_path);
+            return Err(error);
+        }
+
+        if let Err(error) = fs::rename(&temp_path, &self.file_path) {
+            let _ = fs::remove_file(&temp_path);
+            return Err(error);
+        }
+
+        if let Some(parent) = self.file_path.parent() {
+            sync_directory(parent)?;
         }
 
         Ok(())
+    }
+
+    fn temp_file_path(&self) -> io::Result<PathBuf> {
+        let parent = self.file_path.parent().ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!(
+                    "secret store path has no parent directory: {}",
+                    self.file_path.display()
+                ),
+            )
+        })?;
+        let file_name = self.file_path.file_name().ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!(
+                    "secret store path has no file name: {}",
+                    self.file_path.display()
+                ),
+            )
+        })?;
+        let file_name = file_name.to_string_lossy();
+        let process_id = std::process::id();
+
+        for attempt in 0..100 {
+            let candidate = parent.join(format!(".{file_name}.tmp.{process_id}.{attempt}"));
+            if !candidate.exists() {
+                return Ok(candidate);
+            }
+        }
+
+        Err(io::Error::new(
+            io::ErrorKind::AlreadyExists,
+            format!(
+                "could not allocate temporary secret store path near {}",
+                self.file_path.display()
+            ),
+        ))
     }
 
     /// Sets a secret value for the given key
@@ -192,6 +273,16 @@ impl SecretStore {
         self.secrets.remove(DEFAULT_PROVIDER_KEY);
         self.save()
     }
+}
+
+#[cfg(unix)]
+fn sync_directory(path: &Path) -> io::Result<()> {
+    File::open(path)?.sync_all()
+}
+
+#[cfg(not(unix))]
+fn sync_directory(_path: &Path) -> io::Result<()> {
+    Ok(())
 }
 
 #[cfg(test)]
@@ -448,6 +539,42 @@ mod tests {
     }
 
     #[test]
+    fn test_secret_store_can_recover_from_invalid_json_with_empty_store() {
+        let temp_dir = tempdir().unwrap();
+        let file_path = temp_dir.path().join("invalid.json");
+        fs::write(&file_path, "invalid json content").unwrap();
+
+        let mut store = SecretStore {
+            secrets: HashMap::new(),
+            file_path: file_path.clone(),
+        };
+
+        let result = store.load();
+        assert!(matches!(
+            result,
+            Err(ref err) if err.kind() == io::ErrorKind::InvalidData
+        ));
+
+        let mut recovery_store = SecretStore {
+            secrets: HashMap::new(),
+            file_path: file_path.clone(),
+        };
+        recovery_store
+            .set("replacement_key", "replacement_value")
+            .unwrap();
+
+        let mut reloaded = SecretStore {
+            secrets: HashMap::new(),
+            file_path,
+        };
+        reloaded.load().unwrap();
+        assert_eq!(
+            reloaded.get("replacement_key"),
+            Some(&"replacement_value".to_string())
+        );
+    }
+
+    #[test]
     fn test_secret_store_load_empty_json() {
         let temp_dir = tempdir().unwrap();
         let file_path = temp_dir.path().join("empty.json");
@@ -554,6 +681,30 @@ mod tests {
 
         let permissions = fs::metadata(&file_path).unwrap().permissions();
         assert_eq!(permissions.mode() & 0o777, 0o600);
+    }
+
+    #[test]
+    fn test_secret_store_save_failure_keeps_existing_file() {
+        let temp_dir = tempdir().unwrap();
+        let file_path = temp_dir.path().join("secrets.json");
+        fs::write(&file_path, r#"{"old_key":"old_value"}"#).unwrap();
+
+        for attempt in 0..100 {
+            let temp_path = temp_dir.path().join(format!(
+                ".secrets.json.tmp.{}.{attempt}",
+                std::process::id()
+            ));
+            fs::write(temp_path, "occupied").unwrap();
+        }
+
+        let mut store = SecretStore {
+            secrets: HashMap::new(),
+            file_path: file_path.clone(),
+        };
+        store.set("new_key", "new_value").unwrap_err();
+
+        let contents = fs::read_to_string(file_path).unwrap();
+        assert_eq!(contents, r#"{"old_key":"old_value"}"#);
     }
 
     #[test]

--- a/crates/autoagents-llm/src/secret_store.rs
+++ b/crates/autoagents-llm/src/secret_store.rs
@@ -126,21 +126,16 @@ impl SecretStore {
         #[cfg(unix)]
         options.mode(0o600);
 
-        let mut file = options.open(&temp_path)?;
+        let write_result = (|| -> io::Result<()> {
+            let mut file = options.open(&temp_path)?;
+            file.write_all(contents.as_bytes())?;
+            file.sync_all()
+        })();
 
-        if let Err(error) = file.write_all(contents.as_bytes()) {
-            drop(file);
+        if let Err(error) = write_result {
             let _ = fs::remove_file(&temp_path);
             return Err(error);
         }
-
-        if let Err(error) = file.sync_all() {
-            drop(file);
-            let _ = fs::remove_file(&temp_path);
-            return Err(error);
-        }
-
-        drop(file);
 
         #[cfg(unix)]
         if let Err(error) = fs::set_permissions(&temp_path, fs::Permissions::from_mode(0o600)) {

--- a/crates/autoagents-llm/src/secret_store.rs
+++ b/crates/autoagents-llm/src/secret_store.rs
@@ -1,7 +1,10 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::fs::{self, File};
+use std::fmt;
+use std::fs::{self, File, OpenOptions};
 use std::io::{self, Read, Write};
+#[cfg(unix)]
+use std::os::unix::fs::{OpenOptionsExt, PermissionsExt};
 use std::path::PathBuf;
 
 /// Key used to store the default provider in the secret store
@@ -11,12 +14,21 @@ const DEFAULT_PROVIDER_KEY: &str = "default";
 ///
 /// Provides functionality to store, retrieve, and manage secrets
 /// in a JSON file located in the user's home directory.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct SecretStore {
     /// Map of secret keys to their values
     secrets: HashMap<String, String>,
     /// Path to the secrets file
     file_path: PathBuf,
+}
+
+impl fmt::Debug for SecretStore {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("SecretStore")
+            .field("secret_count", &self.secrets.len())
+            .field("file_path", &self.file_path)
+            .finish()
+    }
 }
 
 impl SecretStore {
@@ -29,7 +41,12 @@ impl SecretStore {
     ///
     /// * `io::Result<Self>` - A new SecretStore instance or an IO error
     pub fn new() -> io::Result<Self> {
-        let home_dir = dirs::home_dir().expect("Could not find home directory");
+        let home_dir = dirs::home_dir().ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::NotFound,
+                "could not find home directory for SecretStore",
+            )
+        })?;
         let file_path = home_dir.join(".llm").join("secrets.json");
 
         if let Some(parent) = file_path.parent() {
@@ -55,7 +72,15 @@ impl SecretStore {
             Ok(mut file) => {
                 let mut contents = String::default();
                 file.read_to_string(&mut contents)?;
-                self.secrets = serde_json::from_str(&contents).unwrap_or_default();
+                self.secrets = serde_json::from_str(&contents).map_err(|err| {
+                    io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        format!(
+                            "failed to parse secret store JSON at {}: {err}",
+                            self.file_path.display()
+                        ),
+                    )
+                })?;
                 Ok(())
             }
             Err(ref e) if e.kind() == io::ErrorKind::NotFound => Ok(()),
@@ -75,8 +100,20 @@ impl SecretStore {
         }
 
         let contents = serde_json::to_string_pretty(&self.secrets)?;
-        let mut file = File::create(&self.file_path)?;
+        let mut options = OpenOptions::new();
+        options.create(true).write(true).truncate(true);
+        #[cfg(unix)]
+        options.mode(0o600);
+
+        let mut file = options.open(&self.file_path)?;
         file.write_all(contents.as_bytes())?;
+        file.sync_all()?;
+
+        #[cfg(unix)]
+        {
+            fs::set_permissions(&self.file_path, fs::Permissions::from_mode(0o600))?;
+        }
+
         Ok(())
     }
 
@@ -161,6 +198,8 @@ impl SecretStore {
 mod tests {
     use super::*;
     use std::fs;
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
     use std::path::PathBuf;
     use tempfile::tempdir;
 
@@ -401,8 +440,11 @@ mod tests {
         };
 
         let result = store.load();
-        assert!(result.is_ok());
-        assert!(store.secrets.is_empty()); // Should default to empty HashMap
+        assert!(matches!(
+            result,
+            Err(ref err) if err.kind() == io::ErrorKind::InvalidData
+        ));
+        assert!(store.secrets.is_empty());
     }
 
     #[test]
@@ -472,9 +514,13 @@ mod tests {
 
     #[test]
     fn test_secret_store_debug_impl() {
-        let (store, _) = create_temp_secret_store();
+        let (mut store, _) = create_temp_secret_store();
+        store.set("api_key", "secret123").unwrap();
         let debug_str = format!("{store:?}");
         assert!(debug_str.contains("SecretStore"));
+        assert!(debug_str.contains("secret_count"));
+        assert!(!debug_str.contains("api_key"));
+        assert!(!debug_str.contains("secret123"));
     }
 
     #[test]
@@ -497,6 +543,17 @@ mod tests {
         assert!(file_path.exists());
         let file_content = fs::read_to_string(&file_path).unwrap();
         let _parsed: serde_json::Value = serde_json::from_str(&file_content).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_secret_store_save_uses_user_only_permissions() {
+        let (mut store, file_path) = create_temp_secret_store();
+
+        store.set("api_key", "secret123").unwrap();
+
+        let permissions = fs::metadata(&file_path).unwrap().permissions();
+        assert_eq!(permissions.mode() & 0o777, 0o600);
     }
 
     #[test]


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens LLM request diagnostics and local secret storage. The main changes are:

- Redacted request summaries replace raw trace payload logs across providers.
- Google API keys move from query strings to the `x-goog-api-key` header.
- `SecretStore` saves through a temp file and atomic rename.
- Secret-store debug output now reports metadata instead of secret values.
- Explicit empty-store and reset flows support recovery from corrupt local JSON.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| crates/autoagents-llm/src/secret_store.rs | Adds redacted debug output, explicit recovery constructors, and atomic temp-file saves for the local secret store. |
| crates/autoagents-llm/src/request_diagnostics.rs | Adds shared helpers that summarize request metadata without logging full request bodies. |
| crates/autoagents-llm/src/backends/google.rs | Moves Gemini authentication to a header and updates trace logging to use redacted summaries. |
| crates/autoagents-llm/src/backends/openai.rs | Updates OpenAI request logging paths to use redacted summaries. |
| crates/autoagents-llm/src/providers/openai_compatible.rs | Updates OpenAI-compatible request logging paths to use redacted summaries. |

<sub>Reviews (3): Last reviewed commit: ["\[REFACTOR\]: Harden the LLM secret store ..."](https://github.com/liquidos-ai/autoagents/commit/bd6ebc855b37bba4b4eb35e84ee5a28f02aee357) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42312505)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - AGENTS.md ([source](https://app.greptile.com/liquidos/github/liquidos-ai/autoagents/-/custom-context?memory=3016560d-8393-46c9-8b28-32dd4efbbe2e))
- Context used - CLAUDE.md ([source](https://app.greptile.com/liquidos/github/liquidos-ai/autoagents/-/custom-context?memory=b47666cb-3593-419b-8e94-f613c4c4a23c))
- Context used - docs/content/core-concepts/agents.md ([source](https://app.greptile.com/liquidos/github/liquidos-ai/autoagents/-/custom-context?memory=ee5ee7f3-1bae-40fc-ab9a-3cfb1dc16d60))
</details>

<!-- /greptile_comment -->