### PR TITLE
[FIX]: Fix dependabot issues

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1894,6 +1894,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-hex"
+version = "1.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33e2a781ebdf4467d1428dc4593067825fb646f6871475098d8577421af73558"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "proptest",
+ "serde_core",
+]
+
+[[package]]
 name = "convert_case"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6327,9 +6339,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
+checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -6341,9 +6353,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-appender-tracing"
-version = "0.31.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef6a1ac5ca3accf562b8c306fa8483c85f4390f768185ab775f242f7fe8fdcc2"
+checksum = "2c0080f0dc1d7c786f467cd85a4e395fcab11ee852004f39a29a18ab7c25d837"
 dependencies = [
  "opentelemetry",
  "tracing",
@@ -6353,22 +6365,22 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-http"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a6d09a73194e6b66df7c8f1b680f156d916a1a942abf2de06823dd02b7855d"
+checksum = "5683015d09e2df236ef005b17f6f196f0d5f6313c4fa43a7b6a53b52776e4331"
 dependencies = [
  "async-trait",
  "bytes",
  "http",
  "opentelemetry",
- "reqwest 0.12.28",
+ "reqwest 0.13.4",
 ]
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.31.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f69cd6acbb9af919df949cd1ec9e5e7fdc2ef15d234b6b795aaa525cc02f71f"
+checksum = "9966929966d17620d7c316c643ba62631826e10021409357772d5eea84f62c35"
 dependencies = [
  "http",
  "opentelemetry",
@@ -6376,35 +6388,37 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost 0.14.3",
- "reqwest 0.12.28",
+ "reqwest 0.13.4",
+ "serde_json",
  "thiserror 2.0.18",
- "tracing",
 ]
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
+checksum = "56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638"
 dependencies = [
+ "base64 0.22.1",
+ "const-hex",
  "opentelemetry",
  "opentelemetry_sdk",
  "prost 0.14.3",
- "tonic 0.14.6",
- "tonic-prost",
+ "serde",
 ]
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.31.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14ae4f5991976fd48df6d843de219ca6d31b01daaab2dad5af2badeded372bd"
+checksum = "9b59f80e1ac4d5ff7a2db8fb6c80badb7f0f3f858211fba08dd9aaec750894f9"
 dependencies = [
  "futures-channel",
  "futures-executor",
  "futures-util",
  "opentelemetry",
  "percent-encoding",
+ "portable-atomic",
  "rand 0.9.4",
  "thiserror 2.0.18",
  "tokio",
@@ -7009,6 +7023,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bitflags 2.12.1",
+ "num-traits",
+ "rand 0.9.4",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "unarray",
+]
+
+[[package]]
 name = "prost"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7164,9 +7193,9 @@ checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
 
 [[package]]
 name = "pyo3"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91fd8e38a3b50ed1167fb981cd6fd60147e091784c427b8f7183a7ee32c31c12"
+checksum = "cd274650b21d4bfc26a0a47587962c1edb425f69287324355cd040c3ea66071c"
 dependencies = [
  "libc",
  "once_cell",
@@ -7178,9 +7207,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-async-runtimes"
-version = "0.28.0"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e7364a95bf00e8377bbf9b0f09d7ff9715a29d8fcf93b47d1a967363b973178"
+checksum = "b3ef68daa7316a3fac65e5e18b2203f010346de1c1c53456811a2624673ab046"
 dependencies = [
  "futures-channel",
  "futures-util",
@@ -7192,18 +7221,18 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e368e7ddfdeb98c9bca7f8383be1648fd84ab466bf2bc015e94008db6d35611e"
+checksum = "c5e2a7d2f0d013342f295c048ad19237add5154a55b1c5a254c0ec93d4109078"
 dependencies = [
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f29e10af80b1f7ccaf7f69eace800a03ecd13e883acfacc1e5d0988605f651e"
+checksum = "ca85c467da1bbc8d866eea5deff9cf29ea5f7785054a17da36e65bda9c05845b"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -7211,9 +7240,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-log"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26c2ec80932c5c3b2d4fbc578c9b56b2d4502098587edb8bef5b6bfcad43682e"
+checksum = "f64083bd3a16a353d9d62335808e8e13d0552d2a2b83fdb084496192dcfa9fcd"
 dependencies = [
  "arc-swap",
  "log",
@@ -7222,9 +7251,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df6e520eff47c45997d2fc7dd8214b25dd1310918bbb2642156ef66a67f29813"
+checksum = "9ac53762fd065daa3194dd09337a38bd793a188100fd1a9304c4ab312d901771"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -7234,13 +7263,12 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4cdc218d835738f81c2338f822078af45b4afdf8b2e33cbb5916f108b813acb"
+checksum = "4ca3a1557399783172dc5bf39cfca835157732532cba56b71d2292161e53b362"
 dependencies = [
  "heck",
  "proc-macro2",
- "pyo3-build-config",
  "quote",
  "syn 2.0.117",
 ]
@@ -7529,6 +7557,15 @@ name = "rand_isaac"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3382fc9f0aad4f2e2a56b53d9133c8c810b4dbf21e7e370e24346161a5b2c7bd"
+dependencies = [
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
  "rand_core 0.9.5",
 ]
@@ -10582,9 +10619,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.32.1"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ac28f2d093c6c477eaa76b23525478f38de514fa9aeb1285738d4b97a9552fc"
+checksum = "adbc64cba7137545b8044cb1fe9814f7aacf3c6b5f9b45be8bb5db538befdb26"
 dependencies = [
  "js-sys",
  "opentelemetry",
@@ -10746,6 +10783,12 @@ dependencies = [
  "thiserror 1.0.69",
  "ug",
 ]
+
+[[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unchecked-index"

--- a/bindings/python/autoagents-guardrails/Cargo.toml
+++ b/bindings/python/autoagents-guardrails/Cargo.toml
@@ -22,4 +22,4 @@ extension-module = ["pyo3/extension-module"]
 autoagents-py = { path = "../autoagents", default-features = false }
 autoagents-guardrails = { workspace = true }
 autoagents-llm = { workspace = true }
-pyo3 = { version = "0.28.2", features = ["abi3-py39"] }
+pyo3 = { version = "0.29.0", features = ["abi3-py39"] }

--- a/bindings/python/autoagents-llamacpp-core/Cargo.toml
+++ b/bindings/python/autoagents-llamacpp-core/Cargo.toml
@@ -24,6 +24,6 @@ vulkan = ["autoagents-llamacpp/vulkan"]
 autoagents-py = { path = "../autoagents", default-features = false }
 autoagents-llm = { workspace = true }
 autoagents-llamacpp = { workspace = true, features = ["mtmd"] }
-pyo3 = { version = "0.28.2", features = ["abi3-py39"] }
-pyo3-async-runtimes = { version = "0.28", features = ["tokio-runtime"] }
+pyo3 = { version = "0.29.0", features = ["abi3-py39"] }
+pyo3-async-runtimes = { version = "0.29.0", features = ["tokio-runtime"] }
 serde_json = { workspace = true }

--- a/bindings/python/autoagents-llamacpp-cuda/Cargo.toml
+++ b/bindings/python/autoagents-llamacpp-cuda/Cargo.toml
@@ -22,4 +22,4 @@ cuda-no-vmm = ["autoagents-llamacpp-py-core/cuda-no-vmm"]
 
 [dependencies]
 autoagents-llamacpp-py-core = { path = "../autoagents-llamacpp-core" }
-pyo3 = { version = "0.28.2", features = ["abi3-py39"] }
+pyo3 = { version = "0.29.0", features = ["abi3-py39"] }

--- a/bindings/python/autoagents-llamacpp-metal/Cargo.toml
+++ b/bindings/python/autoagents-llamacpp-metal/Cargo.toml
@@ -21,4 +21,4 @@ metal = ["autoagents-llamacpp-py-core/metal"]
 
 [dependencies]
 autoagents-llamacpp-py-core = { path = "../autoagents-llamacpp-core" }
-pyo3 = { version = "0.28.2", features = ["abi3-py39"] }
+pyo3 = { version = "0.29.0", features = ["abi3-py39"] }

--- a/bindings/python/autoagents-llamacpp-vulkan/Cargo.toml
+++ b/bindings/python/autoagents-llamacpp-vulkan/Cargo.toml
@@ -21,4 +21,4 @@ vulkan = ["autoagents-llamacpp-py-core/vulkan"]
 
 [dependencies]
 autoagents-llamacpp-py-core = { path = "../autoagents-llamacpp-core" }
-pyo3 = { version = "0.28.2", features = ["abi3-py39"] }
+pyo3 = { version = "0.29.0", features = ["abi3-py39"] }

--- a/bindings/python/autoagents-llamacpp/Cargo.toml
+++ b/bindings/python/autoagents-llamacpp/Cargo.toml
@@ -20,4 +20,4 @@ extension-module = ["pyo3/extension-module"]
 
 [dependencies]
 autoagents-llamacpp-py-core = { path = "../autoagents-llamacpp-core" }
-pyo3 = { version = "0.28.2", features = ["abi3-py39"] }
+pyo3 = { version = "0.29.0", features = ["abi3-py39"] }

--- a/bindings/python/autoagents-mistralrs-core/Cargo.toml
+++ b/bindings/python/autoagents-mistralrs-core/Cargo.toml
@@ -28,6 +28,6 @@ ring = ["autoagents-mistral-rs/ring"]
 autoagents-py = { path = "../autoagents", default-features = false }
 autoagents-llm = { workspace = true }
 autoagents-mistral-rs = { workspace = true }
-pyo3 = { version = "0.28.2", features = ["abi3-py39"] }
-pyo3-async-runtimes = { version = "0.28", features = ["tokio-runtime"] }
+pyo3 = { version = "0.29.0", features = ["abi3-py39"] }
+pyo3-async-runtimes = { version = "0.29.0", features = ["tokio-runtime"] }
 serde_json = { workspace = true }

--- a/bindings/python/autoagents-mistralrs-cuda/Cargo.toml
+++ b/bindings/python/autoagents-mistralrs-cuda/Cargo.toml
@@ -22,4 +22,4 @@ cudnn = ["autoagents-mistral-rs-py-core/cudnn"]
 
 [dependencies]
 autoagents-mistral-rs-py-core = { path = "../autoagents-mistralrs-core" }
-pyo3 = { version = "0.28.2", features = ["abi3-py39"] }
+pyo3 = { version = "0.29.0", features = ["abi3-py39"] }

--- a/bindings/python/autoagents-mistralrs-metal/Cargo.toml
+++ b/bindings/python/autoagents-mistralrs-metal/Cargo.toml
@@ -21,4 +21,4 @@ metal = ["autoagents-mistral-rs-py-core/metal"]
 
 [dependencies]
 autoagents-mistral-rs-py-core = { path = "../autoagents-mistralrs-core" }
-pyo3 = { version = "0.28.2", features = ["abi3-py39"] }
+pyo3 = { version = "0.29.0", features = ["abi3-py39"] }

--- a/bindings/python/autoagents-mistralrs/Cargo.toml
+++ b/bindings/python/autoagents-mistralrs/Cargo.toml
@@ -20,4 +20,4 @@ extension-module = ["pyo3/extension-module"]
 
 [dependencies]
 autoagents-mistral-rs-py-core = { path = "../autoagents-mistralrs-core" }
-pyo3 = { version = "0.28.2", features = ["abi3-py39"] }
+pyo3 = { version = "0.29.0", features = ["abi3-py39"] }

--- a/bindings/python/autoagents/Cargo.toml
+++ b/bindings/python/autoagents/Cargo.toml
@@ -22,9 +22,9 @@ extension-module = ["pyo3/extension-module"]
 autoagents-core     = { workspace = true, features = ["codeact"] }
 autoagents-llm      = { workspace = true, features = ["full"] }
 autoagents-protocol = { workspace = true }
-pyo3                = { version = "0.28.2", features = ["abi3-py39"] }
-pyo3-async-runtimes = { version = "0.28", features = ["tokio-runtime"] }
-pyo3-log            = "0.13"
+pyo3                = { version = "0.29.0", features = ["abi3-py39"] }
+pyo3-async-runtimes = { version = "0.29.0", features = ["tokio-runtime"] }
+pyo3-log            = "0.13.4"
 tokio               = { workspace = true }
 once_cell           = { workspace = true }
 async-trait         = { workspace = true }
@@ -37,4 +37,4 @@ log                 = { workspace = true }
 ractor              = { workspace = true }
 
 [build-dependencies]
-pyo3-build-config   = "0.28.2"
+pyo3-build-config   = "0.29.0"

--- a/bindings/python/autoagents/src/llm/builder.rs
+++ b/bindings/python/autoagents/src/llm/builder.rs
@@ -3,7 +3,7 @@ use autoagents_llm::{HasConfig, LLMProvider};
 use pyo3::exceptions::{PyRuntimeError, PyValueError};
 use pyo3::prelude::*;
 use pyo3::types::PyCapsule;
-use std::ffi::CString;
+use std::ffi::CStr;
 use std::sync::Arc;
 
 /// Opaque wrapper around a built LLM provider. Passed to `PyAgentBuilder.llm()`.
@@ -23,25 +23,18 @@ impl PyLLMProvider {
     }
 }
 
-const LLM_PROVIDER_CAPSULE_NAME: &str = "autoagents_py._autoagents_py.LLMProvider";
-
-fn llm_provider_capsule_name() -> PyResult<CString> {
-    CString::new(LLM_PROVIDER_CAPSULE_NAME)
-        .map_err(|_| PyRuntimeError::new_err("invalid llm provider capsule name"))
-}
+const LLM_PROVIDER_CAPSULE_NAME: &CStr = c"autoagents_py._autoagents_py.LLMProvider";
 
 fn llm_provider_to_capsule<'py>(
     py: Python<'py>,
     inner: Arc<dyn LLMProvider>,
 ) -> PyResult<Bound<'py, PyCapsule>> {
-    let name = llm_provider_capsule_name()?;
-    PyCapsule::new(py, inner, Some(name))
+    PyCapsule::new_with_value(py, inner, LLM_PROVIDER_CAPSULE_NAME)
 }
 
 fn llm_provider_from_capsule(capsule: &Bound<'_, PyCapsule>) -> PyResult<Arc<dyn LLMProvider>> {
-    let name = llm_provider_capsule_name()?;
     let pointer = capsule
-        .pointer_checked(Some(name.as_c_str()))
+        .pointer_checked(Some(LLM_PROVIDER_CAPSULE_NAME))
         .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
     let provider = unsafe { pointer.cast::<Arc<dyn LLMProvider>>().as_ref() };
     Ok(Arc::clone(provider))
@@ -634,7 +627,8 @@ mod tests {
         init_python();
         Python::attach(|py| {
             let module = PyModule::new(py, "foreign_capsule_mod").expect("module should create");
-            let capsule = PyCapsule::new(py, 42_u32, None).expect("foreign capsule should build");
+            let capsule = PyCapsule::new_with_value(py, 42_u32, c"foreign_capsule_mod.Foreign")
+                .expect("foreign capsule should build");
             let err = match _llm_provider_from_capsule(&capsule) {
                 Ok(_) => panic!("foreign capsule should fail"),
                 Err(err) => err,

--- a/crates/autoagents-derive/tests/ui/compile_fail/missing_tool_input_derive.rs
+++ b/crates/autoagents-derive/tests/ui/compile_fail/missing_tool_input_derive.rs
@@ -1,5 +1,7 @@
+#![allow(unused_imports)]
+
 use async_trait::async_trait;
-use autoagents_core::tool::{ToolCallError, ToolInputT, ToolRuntime, ToolT};
+use autoagents_core::tool::{ToolCallError, ToolInputSchema, ToolInputT, ToolRuntime, ToolT};
 use autoagents_derive::tool;
 use serde_json::Value;
 

--- a/crates/autoagents-derive/tests/ui/compile_fail/missing_tool_input_derive.stderr
+++ b/crates/autoagents-derive/tests/ui/compile_fail/missing_tool_input_derive.stderr
@@ -1,11 +1,11 @@
 error[E0277]: the trait bound `ManualArgs: ToolInputSchema` is not satisfied
-  --> tests/ui/compile_fail/missing_tool_input_derive.rs:16:70
+  --> tests/ui/compile_fail/missing_tool_input_derive.rs:18:70
    |
-16 | #[tool(name = "manual", description = "Manual input schema", input = ManualArgs)]
+18 | #[tool(name = "manual", description = "Manual input schema", input = ManualArgs)]
    |                                                                      ^^^^^^^^^^ unsatisfied trait bound
    |
 help: the trait `ToolInputSchema` is not implemented for `ManualArgs`
-  --> tests/ui/compile_fail/missing_tool_input_derive.rs:8:1
+  --> tests/ui/compile_fail/missing_tool_input_derive.rs:10:1
    |
- 8 | struct ManualArgs;
+10 | struct ManualArgs;
    | ^^^^^^^^^^^^^^^^^

--- a/crates/autoagents-telemetry/Cargo.toml
+++ b/crates/autoagents-telemetry/Cargo.toml
@@ -18,20 +18,21 @@ autoagents-core = { workspace = true }
 autoagents-protocol = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
-tracing-opentelemetry = "0.32.1"
-opentelemetry = "0.31.0"
-opentelemetry-appender-tracing = "0.31.1"
-opentelemetry_sdk = { version = "0.31.0", features = [
+tracing-opentelemetry = "0.33.0"
+opentelemetry = "0.32.0"
+opentelemetry-appender-tracing = "0.32.0"
+opentelemetry_sdk = { version = "0.32.1", features = [
   "rt-tokio",
   "metrics",
   "experimental_metrics_periodicreader_with_async_runtime",
   "experimental_trace_batch_span_processor_with_async_runtime",
 ] }
-opentelemetry-otlp = { version = "0.31.0", features = [
+opentelemetry-otlp = { version = "0.32.0", features = [
   "http-proto",
+  "http-json",
   "reqwest-client",
 ] }
-opentelemetry-http = { version = "0.31.0", features = ["reqwest"] }
+opentelemetry-http = { version = "0.32.0", features = ["reqwest"] }
 reqwest = { workspace = true, features = ["json", "stream"] }
 futures-util = { workspace = true }
 tokio = { workspace = true }
@@ -42,4 +43,4 @@ async-trait = { workspace = true }
 serde_json = { workspace = true }
 
 [dev-dependencies]
-opentelemetry_sdk = { version = "0.31.0", features = ["testing"] }
+opentelemetry_sdk = { version = "0.32.1", features = ["testing"] }

--- a/crates/autoagents-telemetry/src/exporter.rs
+++ b/crates/autoagents-telemetry/src/exporter.rs
@@ -45,14 +45,14 @@ impl SpanExporterWrapper {
         }
     }
 
-    fn force_flush(&mut self) -> OTelSdkResult {
+    fn force_flush(&self) -> OTelSdkResult {
         match self {
             SpanExporterWrapper::Otlp(exporter) => exporter.force_flush(),
             SpanExporterWrapper::Stdout(exporter) => exporter.force_flush(),
         }
     }
 
-    fn shutdown_with_timeout(&mut self, timeout: Duration) -> OTelSdkResult {
+    fn shutdown_with_timeout(&self, timeout: Duration) -> OTelSdkResult {
         match self {
             SpanExporterWrapper::Otlp(exporter) => exporter.shutdown_with_timeout(timeout),
             SpanExporterWrapper::Stdout(exporter) => exporter.shutdown_with_timeout(timeout),
@@ -143,9 +143,9 @@ impl SpanExporter for MultiSpanExporter {
         result
     }
 
-    fn shutdown_with_timeout(&mut self, timeout: Duration) -> OTelSdkResult {
+    fn shutdown_with_timeout(&self, timeout: Duration) -> OTelSdkResult {
         let mut result = Ok(());
-        for exporter in &mut self.exporters {
+        for exporter in &self.exporters {
             if let Err(err) = exporter.shutdown_with_timeout(timeout) {
                 result = Err(err);
             }
@@ -153,9 +153,9 @@ impl SpanExporter for MultiSpanExporter {
         result
     }
 
-    fn force_flush(&mut self) -> OTelSdkResult {
+    fn force_flush(&self) -> OTelSdkResult {
         let mut result = Ok(());
-        for exporter in &mut self.exporters {
+        for exporter in &self.exporters {
             if let Err(err) = exporter.force_flush() {
                 result = Err(err);
             }
@@ -305,7 +305,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_multi_span_exporter_export_and_flush() {
-        let mut exporter =
+        let exporter =
             MultiSpanExporter::new(vec![SpanExporterWrapper::Stdout(StdoutSpanExporter)]);
         exporter.export(Vec::new()).await.expect("export ok");
         exporter.force_flush().expect("flush ok");

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -9132,9 +9132,9 @@
       }
     },
     "node_modules/gray-matter/node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
@@ -9656,9 +9656,9 @@
       }
     },
     "node_modules/http-proxy-middleware": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.9.tgz",
-      "integrity": "sha512-c1IyJYLYppU574+YI7R4QyX2ystMtVXZwIdzazUIPIJsHuWNd+mho2j+bKoHftndicGj9yh+xjd+l0yj7VeT1Q==",
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.10.tgz",
+      "integrity": "sha512-RKzRWNPxUZqbuk3BC5mGVJbBnWgr+diEnjJexIOytFbBzDy88Fbh/YvBr3DsNrl1jYAfjWfpATEv0NO35FDuPQ==",
       "license": "MIT",
       "dependencies": {
         "@types/http-proxy": "^1.17.8",
@@ -10251,9 +10251,9 @@
       }
     },
     "node_modules/joi": {
-      "version": "17.13.3",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.3.tgz",
-      "integrity": "sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==",
+      "version": "17.13.4",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.4.tgz",
+      "integrity": "sha512-1RuuER6kmt8K8I3nIWvPZKi5RQCb568ZPyY4Pwjlua+yo+63ZTmIwxLZH0heBmiKN4uxjvCiarDrjaeH84xicQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@hapi/hoek": "^9.3.0",
@@ -18005,9 +18005,9 @@
       }
     },
     "node_modules/webpack-dev-server": {
-      "version": "5.2.4",
-      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.4.tgz",
-      "integrity": "sha512-GqDPGZN9bRqKBTkp4aWkobDDHMsrXKoGSdOH56smIri8qR0JG8gfL8/v/f/OZR3/OKXjG8uwJbFVhKm/FNU/UA==",
+      "version": "5.2.6",
+      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.6.tgz",
+      "integrity": "sha512-HNLRmamRvVavZQ+avceZifmv8hmdUjg43t6MI4SqJDwFdW7RPQwH5vzGhDRZSX59SgfbeHhLnq3g+uooWo7pVw==",
       "license": "MIT",
       "dependencies": {
         "@types/bonjour": "^3.5.13",
@@ -18028,7 +18028,7 @@
         "graceful-fs": "^4.2.6",
         "http-proxy-middleware": "^2.0.9",
         "ipaddr.js": "^2.1.0",
-        "launch-editor": "^2.6.1",
+        "launch-editor": "^2.14.1",
         "open": "^10.0.3",
         "p-retry": "^6.2.0",
         "schema-utils": "^4.2.0",


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates dependency versions and the small code changes needed for those updates. The main changes are:

- PyO3 bindings moved to `0.29.0`.
- LLM provider capsules now use the newer `PyCapsule` API.
- OpenTelemetry telemetry crates moved to the `0.32` line.
- Compile-fail test output was refreshed for the updated import shape.
- Rust and docs lockfiles were updated.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| bindings/python/autoagents/src/llm/builder.rs | Updates LLM provider capsule creation and validation to the PyO3 0.29 API. |
| crates/autoagents-telemetry/src/exporter.rs | Updates exporter flush and shutdown methods to the newer shared-reference OpenTelemetry API shape. |
| crates/autoagents-telemetry/Cargo.toml | Bumps OpenTelemetry-related crates and enables OTLP HTTP JSON support. |
| crates/autoagents-derive/tests/ui/compile_fail/missing_tool_input_derive.rs | Refreshes the compile-fail fixture so the expected `ToolInputSchema` diagnostic remains stable. |
| docs/package-lock.json | Updates locked docs dependencies. |

<sub>Reviews (1): Last reviewed commit: ["\[FIX\]: Fix dependabot issues"](https://github.com/liquidos-ai/autoagents/commit/ce9d4443a04260a2bbac0a89473bd9c45e6b11c2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42328948)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - AGENTS.md ([source](https://app.greptile.com/liquidos/github/liquidos-ai/autoagents/-/custom-context?memory=3016560d-8393-46c9-8b28-32dd4efbbe2e))
- Context used - CLAUDE.md ([source](https://app.greptile.com/liquidos/github/liquidos-ai/autoagents/-/custom-context?memory=b47666cb-3593-419b-8e94-f613c4c4a23c))
- Context used - docs/content/core-concepts/agents.md ([source](https://app.greptile.com/liquidos/github/liquidos-ai/autoagents/-/custom-context?memory=ee5ee7f3-1bae-40fc-ab9a-3cfb1dc16d60))
</details>

<!-- /greptile_comment -->