### PR TITLE
[MAINT]: Add rust publish CI

### DIFF
--- a/.github/workflows/python-bindings.yml
+++ b/.github/workflows/python-bindings.yml
@@ -1,4 +1,4 @@
-name: Python Bindings
+name: Release Python Bindings
 
 on:
   push:

--- a/.github/workflows/release-rust-crates.yml
+++ b/.github/workflows/release-rust-crates.yml
@@ -52,12 +52,12 @@ jobs:
             autoagents-llamacpp
             autoagents-mistral-rs
             autoagents-core
-            autoagents-toolkit
             autoagents-guardrails
             autoagents-qdrant
             autoagents-speech
             autoagents-telemetry
             autoagents
+            autoagents-toolkit
           )
 
           dry_run=0

--- a/.github/workflows/release-rust-crates.yml
+++ b/.github/workflows/release-rust-crates.yml
@@ -1,0 +1,112 @@
+name: Release Rust Crates
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Run cargo publish --dry-run instead of publishing"
+        required: true
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  CARGO_INCREMENTAL: "0"
+
+jobs:
+  publish:
+    name: Publish crates.io packages
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          cache-targets: false
+
+      - name: Publish Rust crates
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          crates=(
+            autoagents-derive
+            autoagents-protocol
+            autoagents-llm
+            autoagents-llamacpp
+            autoagents-mistral-rs
+            autoagents-core
+            autoagents-toolkit
+            autoagents-guardrails
+            autoagents-qdrant
+            autoagents-speech
+            autoagents-telemetry
+            autoagents
+          )
+
+          dry_run=0
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.dry_run }}" = "true" ]; then
+            dry_run=1
+          fi
+
+          if [ "$dry_run" = "1" ]; then
+            publish_args=()
+            for crate in "${crates[@]}"; do
+              publish_args+=("-p" "$crate")
+            done
+
+            cargo publish --dry-run "${publish_args[@]}"
+            exit 0
+          fi
+
+          if [ "$dry_run" = "0" ] && [ -z "${CARGO_REGISTRY_TOKEN:-}" ]; then
+            echo "CARGO_REGISTRY_TOKEN is required for crates.io publishing"
+            exit 1
+          fi
+
+          publish_crate() {
+            crate="$1"
+            publish_output="$(mktemp)"
+
+            for attempt in 1 2 3 4 5; do
+              if cargo publish -p "$crate" 2>&1 | tee "$publish_output"; then
+                rm -f "$publish_output"
+                return
+              fi
+
+              if grep -qiE "already (uploaded|exists)|previously uploaded" "$publish_output"; then
+                echo "$crate is already published; continuing"
+                rm -f "$publish_output"
+                return
+              fi
+
+              if [ "$attempt" = "5" ]; then
+                echo "Failed to publish $crate after $attempt attempts"
+                rm -f "$publish_output"
+                return 1
+              fi
+
+              echo "Publish for $crate failed; waiting for crates.io index propagation before retry $((attempt + 1))"
+              sleep 60
+            done
+          }
+
+          for crate in "${crates[@]}"; do
+            publish_crate "$crate"
+          done

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1322,9 +1322,9 @@ checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 dependencies = [
  "serde",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,11 +6,11 @@ default-members = [
     "crates/autoagents-protocol",
     "crates/autoagents-llm",
     "crates/autoagents-core",
-    "crates/autoagents-toolkit",
     "crates/autoagents-guardrails",
     "crates/autoagents-qdrant",
     "crates/autoagents-telemetry",
     "crates/autoagents",
+    "crates/autoagents-toolkit",
 ]
 members = ["crates/*", "examples/*", "bindings/python/*"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,11 +2,15 @@
 resolver = "2"
 
 default-members = [
-    "crates/autoagents",
-    "crates/autoagents-core",
-    "crates/autoagents-llm",
     "crates/autoagents-derive",
     "crates/autoagents-protocol",
+    "crates/autoagents-llm",
+    "crates/autoagents-core",
+    "crates/autoagents-toolkit",
+    "crates/autoagents-guardrails",
+    "crates/autoagents-qdrant",
+    "crates/autoagents-telemetry",
+    "crates/autoagents",
 ]
 members = ["crates/*", "examples/*", "bindings/python/*"]
 

--- a/PUBLISH.md
+++ b/PUBLISH.md
@@ -1,4 +1,4 @@
-# Cargo Publish Guide for AutoAgents
+# Publish Guide for AutoAgents
 
 **Follow the below instructions in sequence**
 
@@ -10,9 +10,9 @@ git pull origin main
 git checkout -b feature/vx.x.x
 ```
 
-2. Update the Cargo.toml `[workspace.package]` version and `[workspace.dependencies]` version. We use SemVer versions.
-   Update the pyproject.toml version and dependencies version and variants
-   Run `Cargo update` and `make python-bindings-build` or `make python-bindings-build-cuda`
+2. Update the Cargo.toml `[workspace.package]` version and `[workspace.dependencies]` versions. We use SemVer versions.
+   Update the pyproject.toml versions, dependency versions, and variants.
+   Run `cargo update` and `make python-bindings-build` or `make python-bindings-build-cuda`.
 
 3. Commit the release changes on the release branch:
 
@@ -33,97 +33,61 @@ git checkout main
 git pull origin main
 ```
 
-7. Publish to Crates.io from `main` (MAINTAIN the order)
+7. Validate the Rust crates from `main`:
 
 ```shell
-cd crates/autoagents-derive
-cargo publish --dry-run # Test first
-cargo publish
+cargo publish --dry-run \
+  -p autoagents-derive \
+  -p autoagents-protocol \
+  -p autoagents-llm \
+  -p autoagents-llamacpp \
+  -p autoagents-mistral-rs \
+  -p autoagents-core \
+  -p autoagents-toolkit \
+  -p autoagents-guardrails \
+  -p autoagents-qdrant \
+  -p autoagents-speech \
+  -p autoagents-telemetry \
+  -p autoagents
 ```
 
-```shell
-cd crates/autoagents-protocol
-cargo publish --dry-run # Test first
-cargo publish
-```
+This dry run covers the full Rust crates.io release set:
 
-```shell
-cd ../autoagents-llm
-cargo publish --dry-run
-cargo publish
-```
+- `autoagents-derive`
+- `autoagents-protocol`
+- `autoagents-llm`
+- `autoagents-llamacpp`
+- `autoagents-mistral-rs`
+- `autoagents-core`
+- `autoagents-toolkit`
+- `autoagents-guardrails`
+- `autoagents-qdrant`
+- `autoagents-speech`
+- `autoagents-telemetry`
+- `autoagents`
 
-```shell
-cd ../autoagents-llamacpp
-cargo publish --dry-run
-cargo publish
-```
+The workspace `default-members` list intentionally excludes `autoagents-llamacpp`, `autoagents-mistral-rs`, and `autoagents-speech` for normal root-level development commands. The Rust release workflow still publishes those crates.
 
----
-```shell
-cd ../autoagents-mistral-rs
-cargo publish --dry-run
-cargo publish
-```
----
+8. Publish Rust crates from GitHub Actions.
 
-```shell
-cd ../autoagents-core
-cargo publish --dry-run
-cargo publish
-```
+Run the `Release Rust Crates` workflow manually with `dry_run=true` before tagging if you want a CI dry run. Pushing the `vx.x.x` tag publishes the full Rust crates.io release set in dependency order. The workflow requires the `CARGO_REGISTRY_TOKEN` repository secret for real publishing.
 
-```shell
-cd ../autoagents
-cargo publish --dry-run
-cargo publish
-```
-
-```shell
-cd ../autoagents-toolkit
-cargo publish --dry-run
-cargo publish
-```
-
-```shell
-cd ../autoagents-qdrant
-cargo publish --dry-run
-cargo publish
-```
-
-```shell
-cd ../autoagents-speech
-cargo publish --dry-run
-cargo publish
-```
-
-```shell
-cd ../autoagents-telemetry
-cargo publish --dry-run
-cargo publish
-```
-
-```shell
-cd ../autoagents-guardrails
-cargo publish --dry-run
-cargo publish
-```
-
----
-
-8. Build Python packages locally before tagging
+9. Build Python packages locally before tagging.
 
 ```shell
 # Build manylinux wheels (CPU variants)
 make python-bindings-build
 ```
+
 This builds:
+
 - `autoagents` base wheel
 - `autoagents-guardrails` wheel
 - `autoagents-llamacpp` CPU wheel
 - `autoagents-mistral-rs` CPU wheel
 
-To Test the cuda version run
+To test the CUDA version, run:
+
 ```shell
 make python-bindings-build-cuda
 ```
@@ -131,13 +95,12 @@ make python-bindings-build-cuda
 #### Note
 
 - The `Python Bindings CI` GitHub Actions workflow runs on PRs to validate the Python packaging matrix before merge.
-- The Python bindings are published via GitHub Actions only when a `v*` tag is pushed.
+- The `Release Python Bindings` GitHub Actions workflow publishes Python bindings when a `v*` tag is pushed.
 - Use the local build commands above to validate the Python bindings before creating the release tag.
 
-9. Create the release tag on the merged `main` commit:
+10. Create the release tag on the merged `main` commit:
 
 ```shell
-cd ../.. # Back to project root
 git tag -a vx.x.x -m "Release vx.x.x
 
 Features:
@@ -153,4 +116,7 @@ Improvements:
 git push origin vx.x.x
 ```
 
-10. Pushing the `vx.x.x` tag triggers the Python bindings workflow and publishes the Python packages from GitHub Actions.
+11. Pushing the `vx.x.x` tag triggers both release workflows:
+
+- `Release Rust Crates` publishes the full Rust crates.io release set.
+- `Release Python Bindings` publishes the Python packages from GitHub Actions.

--- a/PUBLISH.md
+++ b/PUBLISH.md
@@ -43,12 +43,12 @@ cargo publish --dry-run \
   -p autoagents-llamacpp \
   -p autoagents-mistral-rs \
   -p autoagents-core \
-  -p autoagents-toolkit \
   -p autoagents-guardrails \
   -p autoagents-qdrant \
   -p autoagents-speech \
   -p autoagents-telemetry \
-  -p autoagents
+  -p autoagents \
+  -p autoagents-toolkit
 ```
 
 This dry run covers the full Rust crates.io release set:
@@ -59,12 +59,12 @@ This dry run covers the full Rust crates.io release set:
 - `autoagents-llamacpp`
 - `autoagents-mistral-rs`
 - `autoagents-core`
-- `autoagents-toolkit`
 - `autoagents-guardrails`
 - `autoagents-qdrant`
 - `autoagents-speech`
 - `autoagents-telemetry`
 - `autoagents`
+- `autoagents-toolkit`
 
 The workspace `default-members` list intentionally excludes `autoagents-llamacpp`, `autoagents-mistral-rs`, and `autoagents-speech` for normal root-level development commands. The Rust release workflow still publishes those crates.
 


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds CI support and docs for publishing Rust crates. The main changes are:

- Adds a `Release Rust Crates` workflow for tag and manual publishing.
- Updates the publish guide to use the workflow and list the crate release set.
- Adjusts workspace default members for normal Rust commands.
- Renames the Python bindings workflow.
- Updates the locked `bytes` patch version.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/release-rust-crates.yml | Adds the Rust crates publishing workflow with the release crates listed in dependency order. |
| PUBLISH.md | Updates the release guide to describe Rust publishing through GitHub Actions. |
| Cargo.toml | Updates the workspace default members used by root-level Cargo commands. |
| .github/workflows/python-bindings.yml | Renames the workflow to clarify its release role. |
| Cargo.lock | Updates the locked `bytes` dependency patch version. |

<sub>Reviews (2): Last reviewed commit: ["\[MAINT\]: Add rust publish CI"](https://github.com/liquidos-ai/autoagents/commit/26cd29139633bc69771c7c892a24f87ddde13e6a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42684511)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - AGENTS.md ([source](https://app.greptile.com/liquidos/github/liquidos-ai/autoagents/-/custom-context?memory=3016560d-8393-46c9-8b28-32dd4efbbe2e))
- Context used - CLAUDE.md ([source](https://app.greptile.com/liquidos/github/liquidos-ai/autoagents/-/custom-context?memory=b47666cb-3593-419b-8e94-f613c4c4a23c))
- Context used - docs/content/core-concepts/agents.md ([source](https://app.greptile.com/liquidos/github/liquidos-ai/autoagents/-/custom-context?memory=ee5ee7f3-1bae-40fc-ab9a-3cfb1dc16d60))
</details>

<!-- /greptile_comment -->