### PR TITLE
[REFACTOR]: Upgrade llamacpp and mistral-rs versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ REPO_CONTEXT.md
 
 tarpaulin-report.html
 checkpoints
+reference/
 
 usls
 demo_models

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -504,12 +504,14 @@ version = "0.4.0"
 dependencies = [
  "async-trait",
  "autoagents-llm",
+ "chrono",
  "encoding_rs",
  "futures",
  "hf-hub 0.5.0",
  "llama-cpp-2",
  "llama-cpp-sys-2",
  "log",
+ "minijinja",
  "rand 0.10.2",
  "serde",
  "serde_json",
@@ -704,7 +706,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "base64 0.22.1",
- "candle-core",
+ "candle-core 0.9.2",
  "cpal",
  "env_logger",
  "futures",
@@ -1021,17 +1023,6 @@ dependencies = [
  "rustc-hash 2.1.3",
  "shlex 1.3.0",
  "syn 2.0.118",
-]
-
-[[package]]
-name = "bindgen_cuda"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be55fb326843bb67cccceeeaf21c961ef303f60018f9a2ab69494dad8eaf9"
-dependencies = [
- "glob",
- "num_cpus",
- "rayon",
 ]
 
 [[package]]
@@ -1395,13 +1386,36 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c15b675b80d994b2eadb20a4bbe434eabeb454eac3ee5e2b4cf6f147ee9be091"
 dependencies = [
+ "byteorder",
+ "float8 0.6.1",
+ "gemm 0.19.0",
+ "half",
+ "libm",
+ "memmap2",
+ "num-traits",
+ "num_cpus",
+ "rand 0.9.4",
+ "rand_distr 0.5.1",
+ "rayon",
+ "safetensors 0.7.0",
+ "thiserror 2.0.18",
+ "yoke 0.8.3",
+ "zip 7.2.0",
+]
+
+[[package]]
+name = "candle-core"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bd9895436c1ba5dc1037a19935d084b838db066ff4e15ef7dded020b7c12a4a"
+dependencies = [
  "accelerate-src",
  "byteorder",
  "candle-kernels",
  "candle-metal-kernels",
  "candle-ug",
  "cudarc 0.19.8",
- "float8 0.6.1",
+ "float8 0.7.0",
  "gemm 0.19.0",
  "half",
  "intel-mkl-src",
@@ -1417,46 +1431,37 @@ dependencies = [
  "rayon",
  "safetensors 0.7.0",
  "thiserror 2.0.18",
+ "tokenizers 0.22.2",
  "yoke 0.8.3",
  "zip 7.2.0",
 ]
 
 [[package]]
 name = "candle-flash-attn"
-version = "0.9.2"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c94ddd2e7bb828777b0a8d999ed40d2d6c3c96c9ef2a3111a69e0d96efc436d2"
+checksum = "12512cf8e706744642e9a8579305a6ed1e44a0c636ce20c416cd5c519de19b7d"
 dependencies = [
  "anyhow",
- "bindgen_cuda",
- "candle-core",
- "candle-flash-attn-build",
+ "candle-core 0.10.2",
+ "cudaforge",
  "half",
 ]
 
 [[package]]
-name = "candle-flash-attn-build"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bd79da06f2a3b831cb4f5a1ee393d6f2c5a913e28f5000c678a84108519a78c"
-dependencies = [
- "anyhow",
-]
-
-[[package]]
 name = "candle-kernels"
-version = "0.9.2"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8455f84bd810047c7c41216683c1020c915a9f8a740b3b0eabdd4fb2fbaa660"
+checksum = "742e2ac226b777134436e9e692f44e77c278b8a7abb1554dc10e44dc911b349f"
 dependencies = [
- "bindgen_cuda",
+ "cudaforge",
 ]
 
 [[package]]
 name = "candle-metal-kernels"
-version = "0.9.2"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fdfe9d06de16ce49961e49084e5b79a75a9bdf157246e7c7b6328e87a7aa25d"
+checksum = "4b6b5a4cae6b4e1ab0efcee4dc05272d11b374a3d1ba121b3a961e36be54ab60"
 dependencies = [
  "half",
  "objc2",
@@ -1473,8 +1478,24 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3045fa9e7aef8567d209a27d56b692f60b96f4d0569f4c3011f8ca6715c65e03"
 dependencies = [
+ "candle-core 0.9.2",
+ "half",
+ "libc",
+ "num-traits",
+ "rayon",
+ "safetensors 0.7.0",
+ "serde",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "candle-nn"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9317a09d6530b758990ed7f625ac69ff43653bc9ee28b0464644ad1169ada87"
+dependencies = [
  "accelerate-src",
- "candle-core",
+ "candle-core 0.10.2",
  "candle-metal-kernels",
  "half",
  "intel-mkl-src",
@@ -1494,8 +1515,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b538ec4aa807c416a2ddd3621044888f188827862e2a6fcacba4738e89795d01"
 dependencies = [
  "byteorder",
- "candle-core",
- "candle-nn",
+ "candle-core 0.9.2",
+ "candle-nn 0.9.2",
  "fancy-regex 0.17.0",
  "num-traits",
  "rand 0.9.4",
@@ -1508,9 +1529,9 @@ dependencies = [
 
 [[package]]
 name = "candle-ug"
-version = "0.9.2"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c22d62be69068bf58987a45f690612739d8d2ea1bf508c1b87dc6815a019575d"
+checksum = "ca0fc3167cbc99c8ec1be618cb620aa21dca95038f118c3579a79370e3dc5f77"
 dependencies = [
  "ug",
  "ug-cuda",
@@ -2444,6 +2465,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "cudaforge"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d475ff95b9e4096878f47fe0ca5dbad0e23849a79fc225305ea06c2f25771cd"
+dependencies = [
+ "anyhow",
+ "fs2",
+ "glob",
+ "num_cpus",
+ "rayon",
+ "serde",
+ "serde_json",
+ "sha2",
+ "thiserror 2.0.18",
+ "walkdir",
+ "which",
+]
+
+[[package]]
 name = "cudarc"
 version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2948,6 +2988,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
  "bitflags 2.13.0",
+ "block2",
  "objc2",
 ]
 
@@ -3154,6 +3195,12 @@ dependencies = [
  "log",
  "regex",
 ]
+
+[[package]]
+name = "env_home"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f84e12ccf0a7ddc17a6c41c93326024c42920d7ee630d04950e6926645c0fe"
 
 [[package]]
 name = "env_logger"
@@ -3402,7 +3449,6 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719a903cc23e4a89e87962c2a80fdb45cdaad0983a89bd150bb57b4c8571a7d5"
 dependencies = [
- "cudarc 0.19.8",
  "half",
  "num-traits",
  "rand 0.9.4",
@@ -3416,6 +3462,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2d1f04709a8ac06e8e8042875a3c466cc4832d3c1a18dbcb9dba3c6e83046bc"
 dependencies = [
  "half",
+ "num-traits",
+ "rand 0.9.4",
+ "rand_distr 0.5.1",
 ]
 
 [[package]]
@@ -3495,6 +3544,16 @@ checksum = "e5ff35a391aef949120a0340d690269b3d9f63460a6106e99bd07b961f345ea9"
 dependencies = [
  "swc_macros_common",
  "syn 2.0.118",
+]
+
+[[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -4425,7 +4484,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -5092,9 +5151,9 @@ checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "llama-cpp-2"
-version = "0.1.146"
+version = "0.1.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3b0f368c76cc0fe475e8257aeeec269e0d6569bd48b1f503efd0963fc3ee397"
+checksum = "36ead0925a19d754d5d13761ceb0f0fe49d36f8103c3596588ac1fb8911e5223"
 dependencies = [
  "encoding_rs",
  "enumflags2",
@@ -5106,9 +5165,9 @@ dependencies = [
 
 [[package]]
 name = "llama-cpp-sys-2"
-version = "0.1.146"
+version = "0.1.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b291e4bc2d10c43cd8dec16d49b6104cb3cb125f596ec380a753a5db1d965dd"
+checksum = "23c676b02f8f2bdd9d7df7bcca0bd176b27964440998e7aa31c6fe32552964d0"
 dependencies = [
  "bindgen",
  "cc",
@@ -5523,13 +5582,13 @@ dependencies = [
 
 [[package]]
 name = "mistralrs"
-version = "0.7.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b94ffe881c76d6531a334c729743db91a255267a097e9b20b52f66d8531296d1"
+checksum = "9bb0a83340b4492ebba9760ba6845364de369c7e10c1f91af8733d574c7405fa"
 dependencies = [
  "anyhow",
- "candle-core",
- "candle-nn",
+ "candle-core 0.10.2",
+ "candle-nn 0.10.2",
  "clap",
  "either",
  "futures",
@@ -5542,6 +5601,7 @@ dependencies = [
  "schemars 1.2.1",
  "serde",
  "serde_json",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -5550,9 +5610,9 @@ dependencies = [
 
 [[package]]
 name = "mistralrs-audio"
-version = "0.7.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a78dd99327fca9c2c59ac8e5aa0a922db076645e4b46a1dbe6cfbb9fe11443b"
+checksum = "5ac5d36f634c7c20c45845bc995be3b6387ab01048410386a5b180cfeaf89c72"
 dependencies = [
  "anyhow",
  "apodize",
@@ -5562,9 +5622,9 @@ dependencies = [
 
 [[package]]
 name = "mistralrs-core"
-version = "0.7.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44fb8dc16443f611d7611c377e3239cd4c41fa4fbbcebdbd40dc80549436b125"
+checksum = "a2b8b9e5c94491d9ceeded3a30291cb6af6ae74810a5776dd55e3bbb8b3429d4"
 dependencies = [
  "ahash",
  "akin",
@@ -5573,23 +5633,23 @@ dependencies = [
  "as-any",
  "async-trait",
  "base64 0.22.1",
- "bindgen_cuda",
  "bm25",
  "bytemuck",
  "bytemuck_derive",
- "candle-core",
+ "candle-core 0.10.2",
  "candle-flash-attn",
  "candle-metal-kernels",
- "candle-nn",
+ "candle-nn 0.10.2",
  "cfgrammar",
  "chrono",
  "clap",
  "csv",
+ "cudaforge",
  "derive-new",
  "derive_more",
  "dirs",
  "either",
- "float8 0.6.1",
+ "float8 0.7.0",
  "futures",
  "galil-seiferas",
  "half",
@@ -5648,6 +5708,7 @@ dependencies = [
  "tokio",
  "tokio-rayon",
  "tokio-tungstenite",
+ "toktrie",
  "toktrie_hf_tokenizers",
  "toml 0.9.12+spec-1.1.0",
  "tqdm",
@@ -5661,9 +5722,9 @@ dependencies = [
 
 [[package]]
 name = "mistralrs-macros"
-version = "0.7.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c4805bae591126918a68c86cb541498ee64e4a584451127e6044643f2fafc1b"
+checksum = "5aa9b4794322d3f89fe61d21f33f67be494c16d5bd869604b111218f32544d32"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -5673,9 +5734,9 @@ dependencies = [
 
 [[package]]
 name = "mistralrs-mcp"
-version = "0.7.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e82edad2da585a3ea817684856b3ffd6d8da2a4996e829c767de2a77c83c1b8"
+checksum = "4fa97d4e3189ed80ebbc730b7da5b2356df0ae004ab489066249340c33c089ab"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5694,15 +5755,16 @@ dependencies = [
 
 [[package]]
 name = "mistralrs-paged-attn"
-version = "0.7.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6000b390e4a7b56a58fc7005ac721780edd6fd28e70cb6a138872dd3c700dda"
+checksum = "6e53ddf1537426997b46abdadbe6ca8a7ce7668004ed2b7cf00115016558bae8"
 dependencies = [
  "anyhow",
- "bindgen_cuda",
- "candle-core",
+ "candle-core 0.10.2",
  "candle-metal-kernels",
- "float8 0.6.1",
+ "cudaforge",
+ "dispatch2",
+ "float8 0.7.0",
  "half",
  "objc2-foundation",
  "objc2-metal",
@@ -5711,16 +5773,17 @@ dependencies = [
 
 [[package]]
 name = "mistralrs-quant"
-version = "0.7.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb9fb187f2c9397a73f2b00437f6bbedb4c556f1c06d13af2f8d35ec5543a00"
+checksum = "980715493d252e9aaf0779c4c101576d67ef4dd9812bfd77a54987f6f17526f4"
 dependencies = [
- "bindgen_cuda",
  "byteorder",
- "candle-core",
+ "candle-core 0.10.2",
  "candle-metal-kernels",
- "candle-nn",
- "float8 0.6.1",
+ "candle-nn 0.10.2",
+ "cudaforge",
+ "dispatch2",
+ "float8 0.7.0",
  "half",
  "hf-hub 0.4.3",
  "lazy_static",
@@ -5741,11 +5804,11 @@ dependencies = [
 
 [[package]]
 name = "mistralrs-vision"
-version = "0.7.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d79247946a50fdac4300e80504bc6950e298a9c2e7e1a2bcd948fe91852b8a7b"
+checksum = "10046a3da2de5b702d3e829b5ddef7aa829ad454819dcc4876dea481a6cb5456"
 dependencies = [
- "candle-core",
+ "candle-core 0.10.2",
  "image",
  "rayon",
 ]
@@ -6873,8 +6936,8 @@ checksum = "8633c5e97cfe7855486cd6b6f0d9fe90443e405d0873e11fa18116687c5957af"
 dependencies = [
  "anyhow",
  "byteorder",
- "candle-core",
- "candle-nn",
+ "candle-core 0.9.2",
+ "candle-nn 0.9.2",
  "candle-transformers",
  "console_error_panic_hook",
  "getrandom 0.2.17",
@@ -7350,7 +7413,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.3",
  "rustls",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -7389,7 +7452,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.61.2",
 ]
@@ -10154,6 +10217,39 @@ dependencies = [
 
 [[package]]
 name = "tokenizers"
+version = "0.22.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b238e22d44a15349529690fb07bd645cf58149a1b1e44d6cb5bd1641ff1a6223"
+dependencies = [
+ "ahash",
+ "aho-corasick",
+ "compact_str 0.9.1",
+ "dary_heap",
+ "derive_builder",
+ "esaxx-rs",
+ "getrandom 0.3.4",
+ "itertools 0.14.0",
+ "log",
+ "macro_rules_attribute",
+ "monostate",
+ "onig",
+ "paste",
+ "rand 0.9.4",
+ "rayon",
+ "rayon-cond",
+ "regex",
+ "regex-syntax",
+ "serde",
+ "serde_json",
+ "spm_precompiled",
+ "thiserror 2.0.18",
+ "unicode-normalization-alignments",
+ "unicode-segmentation",
+ "unicode_categories",
+]
+
+[[package]]
+name = "tokenizers"
 version = "0.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44e5bea67576e04b6ff8564c5d9e09c2ef0cf476502245f2f120e497769d3112"
@@ -11708,6 +11804,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
 
 [[package]]
+name = "which"
+version = "7.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d643ce3fd3e5b54854602a080f34fb10ab75e0b813ee32d00ca2b44fa74762"
+dependencies = [
+ "either",
+ "env_home",
+ "rustix 1.1.4",
+ "winsafe",
+]
+
+[[package]]
 name = "wide"
 version = "0.7.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12297,6 +12405,12 @@ checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "wit-bindgen"

--- a/crates/autoagents-core/src/agent/prebuilt/executor/react.rs
+++ b/crates/autoagents-core/src/agent/prebuilt/executor/react.rs
@@ -353,6 +353,7 @@ impl<T: AgentDeriveT + AgentHooks> AgentExecutor for ReActAgent<T> {
         let producer = async move {
             let mut accumulated_tool_calls = Vec::new();
             let mut final_response = String::new();
+            let mut final_reasoning_content = String::new();
 
             for turn_index in 0..max_turns {
                 let turn_stream = engine
@@ -424,6 +425,7 @@ impl<T: AgentDeriveT + AgentHooks> AgentExecutor for ReActAgent<T> {
                 match result {
                     crate::agent::executor::TurnResult::Complete(output) => {
                         final_response = output.response.clone();
+                        final_reasoning_content = output.reasoning_content.clone();
                         accumulated_tool_calls.extend(output.tool_calls);
                         accumulated_tool_calls = dedupe_tool_calls(accumulated_tool_calls);
                         break;
@@ -431,6 +433,9 @@ impl<T: AgentDeriveT + AgentHooks> AgentExecutor for ReActAgent<T> {
                     crate::agent::executor::TurnResult::Continue(Some(output)) => {
                         if !output.response.is_empty() {
                             final_response = output.response;
+                        }
+                        if !output.reasoning_content.is_empty() {
+                            final_reasoning_content = output.reasoning_content;
                         }
                         accumulated_tool_calls.extend(output.tool_calls);
                         accumulated_tool_calls = dedupe_tool_calls(accumulated_tool_calls);
@@ -441,6 +446,9 @@ impl<T: AgentDeriveT + AgentHooks> AgentExecutor for ReActAgent<T> {
 
             let tx_event = context_clone.tx().ok();
             EventHelper::send_stream_complete(&tx_event, task.submission_id).await;
+            if final_response.is_empty() && accumulated_tool_calls.is_empty() {
+                final_response = final_reasoning_content;
+            }
             let output = ReActAgentOutput {
                 response: final_response.clone(),
                 done: true,
@@ -808,6 +816,48 @@ mod tests {
         assert!(!outputs[0].done);
         assert_eq!(outputs[1].response, "done");
         assert!(outputs[1].done);
+    }
+
+    #[tokio::test]
+    async fn test_react_agent_execute_stream_preserves_reasoning_only_final_output() {
+        use crate::agent::{AgentConfig, Context};
+        use autoagents_protocol::ActorID;
+        use futures::StreamExt;
+
+        let llm = Arc::new(ConfigurableLLMProvider {
+            stream_chunks: vec![
+                StreamChunk::ReasoningContent("plan".to_string()),
+                StreamChunk::Done {
+                    stop_reason: "length".to_string(),
+                },
+            ],
+            ..ConfigurableLLMProvider::default()
+        });
+
+        let mock = MockAgentImpl::new("stream_reasoning_only_test", "desc");
+        let agent = ReActAgent::new(mock);
+        let config = AgentConfig {
+            id: ActorID::new_v4(),
+            name: "stream_reasoning_only_test".to_string(),
+            description: "desc".to_string(),
+            output_schema: None,
+        };
+        let context = Arc::new(Context::new(llm, None).with_config(config));
+        let task = crate::agent::task::Task::new("test");
+
+        let mut stream = agent.execute_stream(&task, context).await.unwrap();
+        let mut final_output = None;
+        while let Some(item) = stream.next().await {
+            let output = item.unwrap();
+            if output.done {
+                final_output = Some(output);
+                break;
+            }
+        }
+
+        let output = final_output.expect("final output");
+        assert_eq!(output.response, "plan");
+        assert!(output.done);
     }
 
     #[tokio::test]

--- a/crates/autoagents-core/src/agent/prebuilt/executor/react.rs
+++ b/crates/autoagents-core/src/agent/prebuilt/executor/react.rs
@@ -282,7 +282,7 @@ impl<T: AgentDeriveT + AgentHooks> AgentExecutor for ReActAgent<T> {
         let mut turn_state = engine.turn_state(&context);
         let max_turns = self.config().max_turns;
         let mut accumulated_tool_calls = Vec::new();
-        let mut final_response = String::new();
+        let mut final_response = String::default();
         for turn_index in 0..max_turns {
             let result = engine
                 .run_turn(self, task, &context, &mut turn_state, turn_index, max_turns)
@@ -290,7 +290,7 @@ impl<T: AgentDeriveT + AgentHooks> AgentExecutor for ReActAgent<T> {
 
             match result {
                 crate::agent::executor::TurnResult::Complete(output) => {
-                    final_response = output.response.clone();
+                    final_response.clone_from(&output.response);
                     accumulated_tool_calls.extend(output.tool_calls);
                     accumulated_tool_calls = dedupe_tool_calls(accumulated_tool_calls);
 
@@ -352,8 +352,8 @@ impl<T: AgentDeriveT + AgentHooks> AgentExecutor for ReActAgent<T> {
 
         let producer = async move {
             let mut accumulated_tool_calls = Vec::new();
-            let mut final_response = String::new();
-            let mut final_reasoning_content = String::new();
+            let mut final_response = String::default();
+            let mut final_reasoning_content = String::default();
 
             for turn_index in 0..max_turns {
                 let turn_stream = engine
@@ -378,7 +378,7 @@ impl<T: AgentDeriveT + AgentHooks> AgentExecutor for ReActAgent<T> {
                                     let _ = tx
                                         .send(Ok(ReActAgentOutput {
                                             response: content,
-                                            tool_calls: Vec::new(),
+                                            tool_calls: Vec::default(),
                                             done: false,
                                         }))
                                         .await;
@@ -424,8 +424,8 @@ impl<T: AgentDeriveT + AgentHooks> AgentExecutor for ReActAgent<T> {
 
                 match result {
                     crate::agent::executor::TurnResult::Complete(output) => {
-                        final_response = output.response.clone();
-                        final_reasoning_content = output.reasoning_content.clone();
+                        final_response.clone_from(&output.response);
+                        final_reasoning_content.clone_from(&output.reasoning_content);
                         accumulated_tool_calls.extend(output.tool_calls);
                         accumulated_tool_calls = dedupe_tool_calls(accumulated_tool_calls);
                         break;

--- a/crates/autoagents-llamacpp/Cargo.toml
+++ b/crates/autoagents-llamacpp/Cargo.toml
@@ -16,8 +16,8 @@ vulkan = ["llama-cpp-2/vulkan"]
 mtmd = ["llama-cpp-2/mtmd"]
 
 [dependencies]
-llama-cpp-2 = { version = "=0.1.146", default-features = false }
-llama-cpp-sys-2 = { version = "=0.1.146", default-features = false }
+llama-cpp-2 = { version = "=0.1.151", default-features = false, features = ["common"] }
+llama-cpp-sys-2 = { version = "=0.1.151", default-features = false, features = ["common"] }
 autoagents-llm = { workspace = true }
 async-trait = { workspace = true }
 hf-hub = { workspace = true, default-features = false, features = ["ureq"] }
@@ -28,6 +28,8 @@ futures = { workspace = true }
 rand = { workspace = true }
 log = { workspace = true }
 encoding_rs.workspace = true
+minijinja = { workspace = true }
+chrono = { workspace = true }
 
 [dev-dependencies]
 tempfile = { workspace = true }

--- a/crates/autoagents-llamacpp/src/builder.rs
+++ b/crates/autoagents-llamacpp/src/builder.rs
@@ -44,6 +44,21 @@ impl LlamaCppProviderBuilder {
         self
     }
 
+    pub fn force_pure_content(mut self, force: bool) -> Self {
+        self.config_builder = self.config_builder.force_pure_content(force);
+        self
+    }
+
+    pub fn tokenizer_add_bos(mut self, add: bool) -> Self {
+        self.config_builder = self.config_builder.tokenizer_add_bos(add);
+        self
+    }
+
+    pub fn tokenizer_add_eos(mut self, add: bool) -> Self {
+        self.config_builder = self.config_builder.tokenizer_add_eos(add);
+        self
+    }
+
     /// Set reasoning extraction format.
     pub fn reasoning_format(mut self, format: crate::config::LlamaCppReasoningFormat) -> Self {
         self.config_builder = self.config_builder.reasoning_format(format);
@@ -116,6 +131,31 @@ impl LlamaCppProviderBuilder {
         self
     }
 
+    pub fn min_p(mut self, p: f32) -> Self {
+        self.config_builder = self.config_builder.min_p(p);
+        self
+    }
+
+    pub fn typical_p(mut self, p: f32) -> Self {
+        self.config_builder = self.config_builder.typical_p(p);
+        self
+    }
+
+    pub fn top_n_sigma(mut self, n: f32) -> Self {
+        self.config_builder = self.config_builder.top_n_sigma(n);
+        self
+    }
+
+    pub fn xtc(mut self, probability: f32, threshold: f32) -> Self {
+        self.config_builder = self.config_builder.xtc(probability, threshold);
+        self
+    }
+
+    pub fn dynatemp(mut self, range: f32, exponent: f32) -> Self {
+        self.config_builder = self.config_builder.dynatemp(range, exponent);
+        self
+    }
+
     /// Set frequency penalty.
     pub fn frequency_penalty(mut self, penalty: f32) -> Self {
         self.config_builder = self.config_builder.frequency_penalty(penalty);
@@ -137,6 +177,39 @@ impl LlamaCppProviderBuilder {
     /// Set sampling seed.
     pub fn seed(mut self, seed: u32) -> Self {
         self.config_builder = self.config_builder.seed(seed);
+        self
+    }
+
+    pub fn min_keep(mut self, min_keep: usize) -> Self {
+        self.config_builder = self.config_builder.min_keep(min_keep);
+        self
+    }
+
+    pub fn mirostat(mut self, mode: u8, tau: f32, eta: f32) -> Self {
+        self.config_builder = self.config_builder.mirostat(mode, tau, eta);
+        self
+    }
+
+    pub fn dry(
+        mut self,
+        multiplier: f32,
+        base: f32,
+        allowed_length: i32,
+        penalty_last_n: i32,
+        sequence_breakers: Vec<String>,
+    ) -> Self {
+        self.config_builder = self.config_builder.dry(
+            multiplier,
+            base,
+            allowed_length,
+            penalty_last_n,
+            sequence_breakers,
+        );
+        self
+    }
+
+    pub fn logit_bias(mut self, biases: Vec<(i32, f32)>) -> Self {
+        self.config_builder = self.config_builder.logit_bias(biases);
         self
     }
 
@@ -212,6 +285,44 @@ impl LlamaCppProviderBuilder {
         self
     }
 
+    pub fn add_generation_prompt(mut self, enable: bool) -> Self {
+        self.config_builder = self.config_builder.add_generation_prompt(enable);
+        self
+    }
+
+    pub fn continue_final_message(
+        mut self,
+        continuation: crate::config::LlamaCppChatContinuation,
+    ) -> Self {
+        self.config_builder = self.config_builder.continue_final_message(continuation);
+        self
+    }
+
+    pub fn tool_choice(mut self, choice: crate::config::LlamaCppToolChoice) -> Self {
+        self.config_builder = self.config_builder.tool_choice(choice);
+        self
+    }
+
+    pub fn tool_choice_function(mut self, name: impl Into<String>) -> Self {
+        self.config_builder = self.config_builder.tool_choice_function(name);
+        self
+    }
+
+    pub fn parallel_tool_calls(mut self, enable: bool) -> Self {
+        self.config_builder = self.config_builder.parallel_tool_calls(enable);
+        self
+    }
+
+    pub fn n_slots(mut self, n_slots: usize) -> Self {
+        self.config_builder = self.config_builder.n_slots(n_slots);
+        self
+    }
+
+    pub fn queue_capacity(mut self, capacity: usize) -> Self {
+        self.config_builder = self.config_builder.queue_capacity(capacity);
+        self
+    }
+
     /// Enable KV-cache prefix reuse across inference calls.
     ///
     /// When enabled, the provider persists the `LlamaContext` between calls and
@@ -232,7 +343,9 @@ impl LlamaCppProviderBuilder {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::{LlamaCppReasoningFormat, LlamaCppSplitMode};
+    use crate::config::{
+        LlamaCppChatContinuation, LlamaCppReasoningFormat, LlamaCppSplitMode, LlamaCppToolChoice,
+    };
     use crate::models::ModelSource;
 
     #[test]
@@ -242,6 +355,9 @@ mod tests {
             .chat_template("chat")
             .system_prompt("system")
             .force_json_grammar(true)
+            .force_pure_content(true)
+            .tokenizer_add_bos(true)
+            .tokenizer_add_eos(true)
             .reasoning_format(LlamaCppReasoningFormat::Auto)
             .extra_body(serde_json::json!({
                 "chat_template_kwargs": {
@@ -258,10 +374,19 @@ mod tests {
             .temperature(0.2)
             .top_p(0.9)
             .top_k(42)
+            .min_p(0.05)
+            .typical_p(0.8)
+            .top_n_sigma(2.0)
+            .xtc(0.1, 0.5)
+            .dynatemp(0.2, 1.5)
             .frequency_penalty(0.1)
             .presence_penalty(0.2)
             .repeat_last_n(64)
             .seed(7)
+            .min_keep(2)
+            .mirostat(2, 5.0, 0.1)
+            .dry(0.8, 1.75, 2, 64, vec!["\n".to_string()])
+            .logit_bias(vec![(1, -1.0)])
             .n_ctx(2048)
             .n_batch(16)
             .n_ubatch(8)
@@ -271,13 +396,23 @@ mod tests {
             .main_gpu(1)
             .split_mode(LlamaCppSplitMode::Row)
             .use_mlock(true)
-            .devices(vec![0, 1]);
+            .devices(vec![0, 1])
+            .enable_thinking(true)
+            .add_generation_prompt(false)
+            .continue_final_message(LlamaCppChatContinuation::Content)
+            .tool_choice(LlamaCppToolChoice::Required)
+            .parallel_tool_calls(true)
+            .n_slots(2)
+            .queue_capacity(17);
 
         let config = builder.config_builder.build();
         assert_eq!(config.model_source, ModelSource::gguf("model.gguf"));
         assert_eq!(config.chat_template.as_deref(), Some("chat"));
         assert_eq!(config.system_prompt.as_deref(), Some("system"));
         assert!(config.force_json_grammar);
+        assert!(config.force_pure_content);
+        assert_eq!(config.tokenizer_add_bos, Some(true));
+        assert_eq!(config.tokenizer_add_eos, Some(true));
         assert_eq!(config.reasoning_format, Some(LlamaCppReasoningFormat::Auto));
         assert_eq!(
             config
@@ -298,10 +433,27 @@ mod tests {
         assert_eq!(config.temperature, Some(0.2));
         assert_eq!(config.top_p, Some(0.9));
         assert_eq!(config.top_k, Some(42));
+        assert_eq!(config.min_p, Some(0.05));
+        assert_eq!(config.typical_p, Some(0.8));
+        assert_eq!(config.top_n_sigma, Some(2.0));
+        assert_eq!(config.xtc_probability, Some(0.1));
+        assert_eq!(config.xtc_threshold, Some(0.5));
+        assert_eq!(config.dynatemp_range, Some(0.2));
+        assert_eq!(config.dynatemp_exponent, Some(1.5));
         assert_eq!(config.frequency_penalty, Some(0.1));
         assert_eq!(config.presence_penalty, Some(0.2));
         assert_eq!(config.repeat_last_n, Some(64));
         assert_eq!(config.seed, Some(7));
+        assert_eq!(config.min_keep, Some(2));
+        assert_eq!(config.mirostat, Some(2));
+        assert_eq!(config.mirostat_tau, Some(5.0));
+        assert_eq!(config.mirostat_eta, Some(0.1));
+        assert_eq!(config.dry_multiplier, Some(0.8));
+        assert_eq!(config.dry_base, Some(1.75));
+        assert_eq!(config.dry_allowed_length, Some(2));
+        assert_eq!(config.dry_penalty_last_n, Some(64));
+        assert_eq!(config.dry_sequence_breakers, Some(vec!["\n".to_string()]));
+        assert_eq!(config.logit_bias, Some(vec![(1, -1.0)]));
         assert_eq!(config.n_ctx, Some(2048));
         assert_eq!(config.n_batch, Some(16));
         assert_eq!(config.n_ubatch, Some(8));
@@ -312,5 +464,30 @@ mod tests {
         assert_eq!(config.split_mode, Some(LlamaCppSplitMode::Row));
         assert_eq!(config.use_mlock, Some(true));
         assert_eq!(config.devices, Some(vec![0, 1]));
+        assert_eq!(config.enable_thinking, Some(true));
+        assert!(!config.add_generation_prompt);
+        assert_eq!(
+            config.continue_final_message,
+            LlamaCppChatContinuation::Content
+        );
+        assert_eq!(config.tool_choice, LlamaCppToolChoice::Required);
+        assert_eq!(config.parallel_tool_calls, Some(true));
+        assert_eq!(config.scheduler.n_slots, 2);
+        assert_eq!(config.scheduler.queue_capacity, 17);
+    }
+
+    #[test]
+    fn builder_sets_named_tool_choice() {
+        let builder = LlamaCppProviderBuilder::new()
+            .model_path("model.gguf")
+            .tool_choice_function("lookup");
+        let config = builder.config_builder.build();
+
+        assert_eq!(
+            config.tool_choice,
+            LlamaCppToolChoice::Function {
+                name: "lookup".to_string()
+            }
+        );
     }
 }

--- a/crates/autoagents-llamacpp/src/builder.rs
+++ b/crates/autoagents-llamacpp/src/builder.rs
@@ -478,7 +478,7 @@ mod tests {
 
     #[test]
     fn builder_sets_named_tool_choice() {
-        let builder = LlamaCppProviderBuilder::new()
+        let builder = LlamaCppProviderBuilder::default()
             .model_path("model.gguf")
             .tool_choice_function("lookup");
         let config = builder.config_builder.build();

--- a/crates/autoagents-llamacpp/src/chat_template.rs
+++ b/crates/autoagents-llamacpp/src/chat_template.rs
@@ -46,7 +46,7 @@ pub(crate) enum GrammarTrigger {
     Token(i32),
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub(crate) struct RenderedChat {
     pub(crate) prompt: String,
     pub(crate) generation_prompt: String,
@@ -149,67 +149,132 @@ pub(crate) fn render_chat_template(
     grammar: Option<String>,
     tokens: &TemplateTokens,
 ) -> Result<RenderedChat, LlamaCppProviderError> {
-    let caps = TemplateCapabilities::analyze(&template.source);
-    let prepared = prepare_template_inputs(config, messages, tools, caps.server_caps)?;
-    let kwargs = chat_template_kwargs(config)?;
-    let enable_thinking = resolve_enable_thinking(config, &kwargs)?;
-
-    let env = chat_template_environment(&template.source)?;
-    let tmpl = env
-        .get_template("chat")
-        .map_err(|err| LlamaCppProviderError::Template(format!("Chat template missing: {err}")))?;
-
-    let prompt_enable_thinking = if config.force_pure_content {
-        false
-    } else {
-        enable_thinking.unwrap_or(true)
-    };
-    let root_context = build_template_context(
+    RenderChatTemplateRequest {
         config,
-        prepared.messages,
-        prepared.tools_value,
-        kwargs,
-        tokens,
-        prompt_enable_thinking,
-    );
-
-    let mut prompt_context = root_context.clone();
-    set_add_generation_prompt(
-        &mut prompt_context,
-        config.add_generation_prompt && prepared.continuation.is_none(),
-    );
-    let mut prompt = render_template_context(&tmpl, prompt_context, tokens).map_err(|err| {
-        LlamaCppProviderError::Template(format!("Failed to render chat template: {err}"))
-    })?;
-    let mut generation_prompt = render_generation_prompt(
-        config,
-        &caps,
-        &tmpl,
-        &root_context,
-        prepared.continuation,
-        &prepared.continuation_messages,
-        prepared.continuation_prepared_messages,
-        &mut prompt,
-        prompt_enable_thinking,
-        tokens,
-    )?;
-    caps.apply_prompt_workarounds(
-        &mut prompt,
-        &mut generation_prompt,
-        config.add_generation_prompt,
-    );
-
-    Ok(rendered_chat_result(
-        config,
-        &caps,
+        template,
+        messages,
         tools,
         json_schema,
         grammar,
-        prompt,
-        generation_prompt,
-        prepared.continuation.is_some(),
         tokens,
-    ))
+    }
+    .render()
+}
+
+struct RenderChatTemplateRequest<'a> {
+    config: &'a LlamaCppConfig,
+    template: &'a TemplateSource,
+    messages: &'a [ChatMessage],
+    tools: Option<&'a [Tool]>,
+    json_schema: Option<&'a StructuredOutputFormat>,
+    grammar: Option<String>,
+    tokens: &'a TemplateTokens,
+}
+
+impl RenderChatTemplateRequest<'_> {
+    fn render(self) -> Result<RenderedChat, LlamaCppProviderError> {
+        let caps = TemplateCapabilities::analyze(&self.template.source);
+        let prepared =
+            prepare_template_inputs(self.config, self.messages, self.tools, caps.server_caps)?;
+        let kwargs = chat_template_kwargs(self.config)?;
+        let prompt_enable_thinking =
+            prompt_enable_thinking(self.config, resolve_enable_thinking(self.config, &kwargs)?);
+        let env = chat_template_environment(&self.template.source)?;
+        let tmpl = env.get_template("chat").map_err(|err| {
+            LlamaCppProviderError::Template(format!("Chat template missing: {err}"))
+        })?;
+        let PreparedTemplateInputs {
+            messages,
+            continuation,
+            continuation_messages,
+            continuation_prepared_messages,
+            tools_value,
+        } = prepared;
+        let root_context = build_template_context(
+            self.config,
+            messages,
+            tools_value,
+            kwargs,
+            self.tokens,
+            prompt_enable_thinking,
+        );
+        self.render_with_context(TemplateRenderContext {
+            caps,
+            continuation,
+            continuation_messages,
+            continuation_prepared_messages,
+            root_context,
+            tmpl: &tmpl,
+            prompt_enable_thinking,
+        })
+    }
+
+    fn render_with_context(
+        self,
+        context: TemplateRenderContext<'_>,
+    ) -> Result<RenderedChat, LlamaCppProviderError> {
+        let mut prompt = render_prompt(
+            context.tmpl,
+            context.root_context.clone(),
+            self.config.add_generation_prompt && context.continuation.is_none(),
+            self.tokens,
+        )?;
+        let mut generation_prompt = render_generation_prompt(
+            self.config,
+            &context.caps,
+            context.tmpl,
+            &context.root_context,
+            context.continuation,
+            &context.continuation_messages,
+            context.continuation_prepared_messages,
+            &mut prompt,
+            context.prompt_enable_thinking,
+            self.tokens,
+        )?;
+        context.caps.apply_prompt_workarounds(
+            &mut prompt,
+            &mut generation_prompt,
+            self.config.add_generation_prompt,
+        );
+
+        Ok(rendered_chat_result(
+            self.config,
+            &context.caps,
+            self.tools,
+            self.json_schema,
+            self.grammar,
+            prompt,
+            generation_prompt,
+            context.continuation.is_some(),
+            self.tokens,
+        ))
+    }
+}
+
+struct TemplateRenderContext<'a> {
+    caps: TemplateCapabilities,
+    continuation: Option<LlamaCppChatContinuation>,
+    continuation_messages: Vec<ServerChatMessage>,
+    continuation_prepared_messages: Vec<Value>,
+    root_context: Map<String, Value>,
+    tmpl: &'a Template<'a, 'a>,
+    prompt_enable_thinking: bool,
+}
+
+fn prompt_enable_thinking(config: &LlamaCppConfig, enable_thinking: Option<bool>) -> bool {
+    !config.force_pure_content && enable_thinking.unwrap_or(true)
+}
+
+fn render_prompt(
+    tmpl: &Template<'_, '_>,
+    mut context: Map<String, Value>,
+    add_generation_prompt: bool,
+    tokens: &TemplateTokens,
+) -> Result<String, LlamaCppProviderError> {
+    set_add_generation_prompt(&mut context, add_generation_prompt);
+    render_template_context(tmpl, context, tokens).map_err(|err| {
+        LlamaCppProviderError::Template(format!("Failed to render chat template: {err}"))
+    })
 }
 
 struct PreparedTemplateInputs {
@@ -378,7 +443,9 @@ fn build_template_context(
 
     let mut kwargs_object = Map::new();
     for (key, value) in kwargs {
-        root_context.insert(key.clone(), value.clone());
+        if key != "enable_thinking" {
+            root_context.insert(key.clone(), value.clone());
+        }
         kwargs_object.insert(key, value);
     }
     root_context.insert("kwargs".to_string(), Value::Object(kwargs_object.clone()));
@@ -413,7 +480,8 @@ fn render_generation_prompt(
     prompt_enable_thinking: bool,
     tokens: &TemplateTokens,
 ) -> Result<String, LlamaCppProviderError> {
-    if continuation == Some(LlamaCppChatContinuation::Reasoning)
+    if !config.force_pure_content
+        && continuation == Some(LlamaCppChatContinuation::Reasoning)
         && !continuation_messages.is_empty()
     {
         return render_reasoning_continuation_prompt(
@@ -499,12 +567,13 @@ fn generation_prompt_suffix(
     root_context: Map<String, Value>,
     tokens: &TemplateTokens,
 ) -> Result<String, LlamaCppProviderError> {
-    let no_gen_prompt =
-        render_template_context(tmpl, root_context.clone(), tokens).map_err(|err| {
-            LlamaCppProviderError::Template(format!(
-                "Failed to render chat template without generation prompt: {err}"
-            ))
-        })?;
+    let mut no_gen_context = root_context.clone();
+    set_add_generation_prompt(&mut no_gen_context, false);
+    let no_gen_prompt = render_template_context(tmpl, no_gen_context, tokens).map_err(|err| {
+        LlamaCppProviderError::Template(format!(
+            "Failed to render chat template without generation prompt: {err}"
+        ))
+    })?;
     let mut gen_context = root_context;
     set_add_generation_prompt(&mut gen_context, true);
     let gen_prompt = render_template_context(tmpl, gen_context, tokens).map_err(|err| {
@@ -592,11 +661,22 @@ fn resolve_enable_thinking(
 ) -> Result<Option<bool>, LlamaCppProviderError> {
     match kwargs.get("enable_thinking") {
         Some(Value::Bool(value)) => Ok(Some(*value)),
-        Some(Value::String(_)) => Ok(config.enable_thinking),
+        Some(Value::String(value)) => resolve_enable_thinking_string(config, value),
         Some(_) => Err(LlamaCppProviderError::Template(
             "invalid type for `enable_thinking` (expected boolean)".to_string(),
         )),
         None => Ok(config.enable_thinking),
+    }
+}
+
+fn resolve_enable_thinking_string(
+    config: &LlamaCppConfig,
+    value: &str,
+) -> Result<Option<bool>, LlamaCppProviderError> {
+    match value.trim() {
+        "true" => Ok(Some(true)),
+        "false" => Ok(Some(false)),
+        _ => Ok(config.enable_thinking),
     }
 }
 
@@ -660,45 +740,61 @@ fn pycompat_string_method(
     method: &str,
     args: &[JinjaValue],
 ) -> Result<JinjaValue, JinjaError> {
-    match method {
-        "startswith" | "endswith" => pycompat_string_predicate(text, method, args),
-        "strip" | "lstrip" | "rstrip" => pycompat_string_trim(text, method, args),
-        "split" => pycompat_string_split(text, args),
-        "lower" | "upper" => pycompat_string_case(text, method, args),
-        "replace" => pycompat_string_replace(text, args),
-        _ => Err(JinjaError::from(ErrorKind::UnknownMethod)),
-    }
-}
-
-fn pycompat_string_predicate(
-    text: &str,
-    method: &str,
-    args: &[JinjaValue],
-) -> Result<JinjaValue, JinjaError> {
-    let needle = string_arg(method, args, 0)?;
-    ensure_arg_count(method, args, 1)?;
-    let value = match method {
-        "startswith" => text.starts_with(needle),
-        "endswith" => text.ends_with(needle),
-        _ => unreachable!("predicate dispatcher only passes supported methods"),
+    let Some(handler) = pycompat_string_handler(method) else {
+        return Err(JinjaError::from(ErrorKind::UnknownMethod));
     };
-    Ok(JinjaValue::from(value))
+    handler(text, args)
 }
 
-fn pycompat_string_trim(
-    text: &str,
-    method: &str,
-    args: &[JinjaValue],
-) -> Result<JinjaValue, JinjaError> {
-    ensure_max_arg_count(method, args, 1)?;
+type PycompatStringHandler = fn(&str, &[JinjaValue]) -> Result<JinjaValue, JinjaError>;
+
+fn pycompat_string_handler(method: &str) -> Option<PycompatStringHandler> {
+    PYCOMPAT_STRING_METHODS
+        .iter()
+        .find(|(name, _)| *name == method)
+        .map(|(_, handler)| *handler)
+}
+
+const PYCOMPAT_STRING_METHODS: &[(&str, PycompatStringHandler)] = &[
+    ("startswith", pycompat_string_startswith),
+    ("endswith", pycompat_string_endswith),
+    ("strip", pycompat_string_strip),
+    ("lstrip", pycompat_string_lstrip),
+    ("rstrip", pycompat_string_rstrip),
+    ("split", pycompat_string_split),
+    ("lower", pycompat_string_lower),
+    ("upper", pycompat_string_upper),
+    ("replace", pycompat_string_replace),
+];
+
+fn pycompat_string_startswith(text: &str, args: &[JinjaValue]) -> Result<JinjaValue, JinjaError> {
+    let prefix = string_arg("startswith", args, 0)?;
+    ensure_arg_count("startswith", args, 1)?;
+    Ok(JinjaValue::from(text.starts_with(prefix)))
+}
+
+fn pycompat_string_endswith(text: &str, args: &[JinjaValue]) -> Result<JinjaValue, JinjaError> {
+    let suffix = string_arg("endswith", args, 0)?;
+    ensure_arg_count("endswith", args, 1)?;
+    Ok(JinjaValue::from(text.ends_with(suffix)))
+}
+
+fn pycompat_string_strip(text: &str, args: &[JinjaValue]) -> Result<JinjaValue, JinjaError> {
+    ensure_max_arg_count("strip", args, 1)?;
     let chars = optional_string_arg(args, 0)?;
-    let value = match method {
-        "strip" => strip_chars(text, chars),
-        "lstrip" => lstrip_chars(text, chars),
-        "rstrip" => rstrip_chars(text, chars),
-        _ => unreachable!("trim dispatcher only passes supported methods"),
-    };
-    Ok(JinjaValue::from(value))
+    Ok(JinjaValue::from(strip_chars(text, chars)))
+}
+
+fn pycompat_string_lstrip(text: &str, args: &[JinjaValue]) -> Result<JinjaValue, JinjaError> {
+    ensure_max_arg_count("lstrip", args, 1)?;
+    let chars = optional_string_arg(args, 0)?;
+    Ok(JinjaValue::from(lstrip_chars(text, chars)))
+}
+
+fn pycompat_string_rstrip(text: &str, args: &[JinjaValue]) -> Result<JinjaValue, JinjaError> {
+    ensure_max_arg_count("rstrip", args, 1)?;
+    let chars = optional_string_arg(args, 0)?;
+    Ok(JinjaValue::from(rstrip_chars(text, chars)))
 }
 
 fn pycompat_string_split(text: &str, args: &[JinjaValue]) -> Result<JinjaValue, JinjaError> {
@@ -708,18 +804,14 @@ fn pycompat_string_split(text: &str, args: &[JinjaValue]) -> Result<JinjaValue, 
     Ok(JinjaValue::from_iter(split_string(text, sep, maxsplit)))
 }
 
-fn pycompat_string_case(
-    text: &str,
-    method: &str,
-    args: &[JinjaValue],
-) -> Result<JinjaValue, JinjaError> {
-    ensure_arg_count(method, args, 0)?;
-    let value = match method {
-        "lower" => text.to_lowercase(),
-        "upper" => text.to_uppercase(),
-        _ => unreachable!("case dispatcher only passes supported methods"),
-    };
-    Ok(JinjaValue::from(value))
+fn pycompat_string_lower(text: &str, args: &[JinjaValue]) -> Result<JinjaValue, JinjaError> {
+    ensure_arg_count("lower", args, 0)?;
+    Ok(JinjaValue::from(text.to_lowercase()))
+}
+
+fn pycompat_string_upper(text: &str, args: &[JinjaValue]) -> Result<JinjaValue, JinjaError> {
+    ensure_arg_count("upper", args, 0)?;
+    Ok(JinjaValue::from(text.to_uppercase()))
 }
 
 fn pycompat_string_replace(text: &str, args: &[JinjaValue]) -> Result<JinjaValue, JinjaError> {
@@ -1195,7 +1287,7 @@ mod tests {
             ..Default::default()
         };
         let template = explicit_template_source(
-            "{{ enable_thinking is string }}:{{ enable_thinking }}:{{ custom_label }}",
+            "{{ enable_thinking is boolean }}:{{ enable_thinking }}:{{ kwargs['enable_thinking'] is string }}:{{ kwargs['enable_thinking'] }}:{{ custom_label }}",
         );
 
         let rendered = render_chat_template(
@@ -1209,7 +1301,35 @@ mod tests {
         )
         .expect("template should render");
 
-        assert_eq!(rendered.prompt, "true:true:\"server-style\"");
+        assert_eq!(rendered.prompt, "true:true:true:true:\"server-style\"");
+    }
+
+    #[test]
+    fn string_enable_thinking_false_disables_top_level_prompt_flag() {
+        let config = LlamaCppConfig {
+            extra_body: Some(json!({
+                "chat_template_kwargs": {
+                    "enable_thinking": "false"
+                }
+            })),
+            ..Default::default()
+        };
+        let template = explicit_template_source(
+            "{% if enable_thinking %}<think>{% endif %}{{ kwargs['enable_thinking'] is string }}:{{ kwargs['enable_thinking'] }}:{{ messages[0]['content'] }}",
+        );
+
+        let rendered = render_chat_template(
+            &config,
+            &template,
+            &[user_message("solve")],
+            None,
+            None,
+            None,
+            &empty_tokens(),
+        )
+        .expect("template should render");
+
+        assert_eq!(rendered.prompt, "true:false:solve");
     }
 
     #[test]
@@ -1841,6 +1961,41 @@ mod tests {
     }
 
     #[test]
+    fn force_pure_content_reasoning_continuation_uses_content_prefill() {
+        let config = LlamaCppConfig {
+            continue_final_message: LlamaCppChatContinuation::Reasoning,
+            force_pure_content: true,
+            ..Default::default()
+        };
+        let template = explicit_template_source(
+            "{% for message in messages %}{{ message['role'] }}:{{ message['content'] }}\n{% endfor %}{% if add_generation_prompt %}<|assistant|>{% endif %}{# <think></think> #}",
+        );
+        let assistant = ChatMessage {
+            role: ChatRole::Assistant,
+            message_type: MessageType::Text,
+            content: "plan".to_string(),
+        };
+
+        let rendered = render_chat_template(
+            &config,
+            &template,
+            &[user_message("hi"), assistant],
+            None,
+            None,
+            Some("root ::= \"{}\"".to_string()),
+            &empty_tokens(),
+        )
+        .expect("pure content continuation should render");
+
+        assert_eq!(rendered.prompt, "user:hi\nassistant:plan\n");
+        assert_eq!(rendered.generation_prompt, "assistant:plan\n");
+        assert!(rendered.force_pure_content);
+        assert!(rendered.is_continuation);
+        assert!(!rendered.prompt.contains("<think>"));
+        assert_eq!(rendered.reasoning_format, None);
+    }
+
+    #[test]
     fn continue_final_message_reasoning_rejects_unknown_template_markers() {
         let config = LlamaCppConfig {
             continue_final_message: LlamaCppChatContinuation::Reasoning,
@@ -1958,6 +2113,28 @@ mod tests {
 
         assert_eq!(rendered.prompt, "true:true|user:hi");
         assert_eq!(rendered.generation_prompt, "");
+    }
+
+    #[test]
+    fn generation_prompt_baseline_defines_add_generation_prompt_false() {
+        let config = LlamaCppConfig::default();
+        let template = explicit_template_source(
+            "{% if add_generation_prompt is not defined %}{{ raise_exception('missing add_generation_prompt') }}{% endif %}{% for message in messages %}{{ message['content'] }}{% endfor %}{% if add_generation_prompt %}assistant:{% endif %}",
+        );
+
+        let rendered = render_chat_template(
+            &config,
+            &template,
+            &[user_message("hi")],
+            None,
+            None,
+            Some("root ::= \"{}\"".to_string()),
+            &empty_tokens(),
+        )
+        .expect("baseline and generation template contexts should render");
+
+        assert_eq!(rendered.prompt, "hiassistant:");
+        assert_eq!(rendered.generation_prompt, "assistant:");
     }
 
     #[test]

--- a/crates/autoagents-llamacpp/src/chat_template.rs
+++ b/crates/autoagents-llamacpp/src/chat_template.rs
@@ -1,0 +1,2035 @@
+use crate::{
+    config::{
+        LlamaCppChatContinuation, LlamaCppConfig, LlamaCppReasoningFormat, LlamaCppToolChoice,
+    },
+    error::LlamaCppProviderError,
+    server_chat::{
+        ServerChatMessage, ServerTemplateCaps, apply_server_workarounds, messages_from_autoagents,
+        render_messages_to_json,
+    },
+};
+use autoagents_llm::chat::{ChatMessage, StructuredOutputFormat, Tool};
+use chrono::Local;
+use minijinja::State;
+use minijinja::value::{Kwargs, ValueKind};
+use minijinja::{Environment, Error as JinjaError, ErrorKind, Value as JinjaValue};
+use serde::Serialize;
+use serde_json::{Map, Value, json};
+use std::collections::HashSet;
+
+const CHATML_TEMPLATE: &str = r#"{%- for message in messages -%}
+{%- if message['role'] == 'system' -%}
+<|im_start|>system
+{{ message['content'] }}<|im_end|>
+{%- elif message['role'] == 'user' -%}
+<|im_start|>user
+{{ message['content'] }}<|im_end|>
+{%- elif message['role'] == 'assistant' -%}
+<|im_start|>assistant
+{{ message['content'] }}<|im_end|>
+{%- elif message['role'] == 'tool' -%}
+<|im_start|>tool
+{{ message['content'] }}<|im_end|>
+{%- endif -%}
+{%- endfor -%}
+{%- if add_generation_prompt -%}
+<|im_start|>assistant
+{%- endif -%}"#;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum GrammarTrigger {
+    Word(String),
+    Pattern(String),
+    #[allow(dead_code)]
+    PatternFull(String),
+    #[allow(dead_code)]
+    Token(i32),
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct RenderedChat {
+    pub(crate) prompt: String,
+    pub(crate) generation_prompt: String,
+    pub(crate) force_pure_content: bool,
+    pub(crate) is_continuation: bool,
+    pub(crate) add_bos: bool,
+    pub(crate) grammar: Option<String>,
+    pub(crate) grammar_lazy: bool,
+    pub(crate) grammar_triggers: Vec<GrammarTrigger>,
+    pub(crate) preserved_tokens: Vec<String>,
+    pub(crate) additional_stops: Vec<String>,
+    pub(crate) parse_tool_calls: bool,
+    pub(crate) tool_names: Vec<String>,
+    pub(crate) reasoning_format: Option<LlamaCppReasoningFormat>,
+    pub(crate) reasoning_start_tag: Option<String>,
+    pub(crate) reasoning_end_tag: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct TemplateSource {
+    pub(crate) source: String,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub(crate) struct TemplateTokens {
+    pub(crate) bos_token: String,
+    pub(crate) eos_token: String,
+    pub(crate) add_bos: Option<bool>,
+    pub(crate) add_eos: Option<bool>,
+}
+
+pub(crate) fn explicit_template_source(template: &str) -> TemplateSource {
+    TemplateSource {
+        source: normalize_template_source(template),
+    }
+}
+
+pub(crate) fn normalize_template_source(template: &str) -> String {
+    match template {
+        "chatml" | "chat_ml" => CHATML_TEMPLATE.to_string(),
+        _ => template.to_string(),
+    }
+}
+
+fn strip_hf_generation_blocks(source: &str) -> String {
+    let mut output = String::with_capacity(source.len());
+    let mut rest = source;
+
+    while let Some(start) = rest.find("{%") {
+        let (before, after_start) = rest.split_at(start);
+        output.push_str(before);
+
+        let Some(relative_end) = after_start.find("%}") else {
+            output.push_str(after_start);
+            return output;
+        };
+
+        let tag = &after_start[..relative_end + 2];
+        if is_hf_generation_tag(tag) {
+            rest = &after_start[relative_end + 2..];
+        } else {
+            output.push_str(tag);
+            rest = &after_start[relative_end + 2..];
+        }
+    }
+
+    output.push_str(rest);
+    output
+}
+
+fn is_hf_generation_tag(tag: &str) -> bool {
+    let inner = tag
+        .trim_start_matches("{%")
+        .trim_end_matches("%}")
+        .trim()
+        .trim_matches('-')
+        .trim();
+    matches!(inner, "generation" | "endgeneration")
+}
+
+fn resolve_continuation(
+    config: &LlamaCppConfig,
+    _messages: &[ServerChatMessage],
+) -> Result<Option<LlamaCppChatContinuation>, LlamaCppProviderError> {
+    match config.continue_final_message {
+        LlamaCppChatContinuation::None => Ok(None),
+        LlamaCppChatContinuation::Auto | LlamaCppChatContinuation::Content => {
+            Ok(Some(LlamaCppChatContinuation::Content))
+        }
+        LlamaCppChatContinuation::Reasoning => Ok(Some(LlamaCppChatContinuation::Reasoning)),
+    }
+}
+
+pub(crate) fn render_chat_template(
+    config: &LlamaCppConfig,
+    template: &TemplateSource,
+    messages: &[ChatMessage],
+    tools: Option<&[Tool]>,
+    json_schema: Option<&StructuredOutputFormat>,
+    grammar: Option<String>,
+    tokens: &TemplateTokens,
+) -> Result<RenderedChat, LlamaCppProviderError> {
+    let caps = TemplateCapabilities::analyze(&template.source);
+    let server_messages = messages_from_autoagents(config, messages)?;
+    let continuation = resolve_continuation(config, &server_messages)?;
+    let (render_messages, continuation_messages) =
+        if continuation.is_some() && !server_messages.is_empty() {
+            server_messages.split_at(server_messages.len() - 1)
+        } else {
+            (server_messages.as_slice(), [].as_slice())
+        };
+    let mut prepared_messages = render_messages_to_json(render_messages, caps.server_caps);
+    apply_server_workarounds(&mut prepared_messages, caps.server_caps)?;
+    let mut continuation_prepared_messages =
+        render_messages_to_json(&server_messages, caps.server_caps);
+    apply_server_workarounds(&mut continuation_prepared_messages, caps.server_caps)?;
+    let tools_value = tools
+        .filter(|tools| !tools.is_empty())
+        .map(serde_json::to_value)
+        .transpose()
+        .map_err(|err| LlamaCppProviderError::Template(format!("Failed to encode tools: {err}")))?
+        .unwrap_or_else(|| Value::Array(Vec::new()));
+    let kwargs = chat_template_kwargs(config)?;
+    let enable_thinking = resolve_enable_thinking(config, &kwargs)?;
+
+    let mut env = Environment::new();
+    env.add_filter("tojson", tojson_filter);
+    env.add_function("raise_exception", raise_exception);
+    env.add_function("strftime_now", strftime_now);
+    env.set_unknown_method_callback(pycompat_method_callback);
+    let render_source = strip_hf_generation_blocks(&template.source);
+    env.add_template("chat", &render_source).map_err(|err| {
+        LlamaCppProviderError::Template(format!("Invalid llama.cpp chat template: {err}"))
+    })?;
+    let tmpl = env
+        .get_template("chat")
+        .map_err(|err| LlamaCppProviderError::Template(format!("Chat template missing: {err}")))?;
+
+    let mut root_context = Map::new();
+    let prompt_enable_thinking = if config.force_pure_content {
+        false
+    } else {
+        enable_thinking.unwrap_or(true)
+    };
+    root_context.insert("messages".to_string(), Value::Array(prepared_messages));
+    root_context.insert(
+        "bos_token".to_string(),
+        Value::String(tokens.bos_token.clone()),
+    );
+    root_context.insert(
+        "eos_token".to_string(),
+        Value::String(tokens.eos_token.clone()),
+    );
+    root_context.insert(
+        "enable_thinking".to_string(),
+        Value::Bool(prompt_enable_thinking),
+    );
+    root_context.insert(
+        "parallel_tool_calls".to_string(),
+        Value::Bool(config.parallel_tool_calls.unwrap_or(false)),
+    );
+    root_context.insert(
+        "tool_choice".to_string(),
+        match &config.tool_choice {
+            LlamaCppToolChoice::Auto => Value::String("auto".to_string()),
+            LlamaCppToolChoice::Required => Value::String("required".to_string()),
+            LlamaCppToolChoice::None => Value::String("none".to_string()),
+            LlamaCppToolChoice::Function { name } => json!({
+                "type": "function",
+                "function": {
+                    "name": name
+                }
+            }),
+        },
+    );
+    root_context.insert("date_string".to_string(), Value::String(date_string()));
+    root_context.insert("datetime".to_string(), Value::String(datetime_string()));
+    if !tools_value.as_array().is_some_and(Vec::is_empty) {
+        root_context.insert("tools".to_string(), tools_value);
+    }
+
+    let mut kwargs_object = Map::new();
+    for (key, value) in kwargs {
+        root_context.insert(key.clone(), value.clone());
+        kwargs_object.insert(key, value);
+    }
+    root_context.insert("kwargs".to_string(), Value::Object(kwargs_object.clone()));
+    root_context.insert("extra_context".to_string(), Value::Object(kwargs_object));
+
+    let mut prompt_context = root_context.clone();
+    set_add_generation_prompt(
+        &mut prompt_context,
+        config.add_generation_prompt && continuation.is_none(),
+    );
+    let mut prompt = render_template_context(&tmpl, prompt_context, tokens).map_err(|err| {
+        LlamaCppProviderError::Template(format!("Failed to render chat template: {err}"))
+    })?;
+    let mut generation_prompt = if continuation == Some(LlamaCppChatContinuation::Reasoning)
+        && !continuation_messages.is_empty()
+    {
+        let reasoning_prefill = continuation_messages[0].render_content("\n");
+        let base_generation_prompt = if config.add_generation_prompt {
+            generation_prompt_suffix(&tmpl, root_context.clone(), tokens)?
+        } else {
+            String::new()
+        };
+        let reasoning_prompt = caps.reasoning_continuation_prompt(
+            &prompt,
+            &base_generation_prompt,
+            &reasoning_prefill,
+        )?;
+        prompt.push_str(&reasoning_prompt);
+        reasoning_prompt
+    } else if continuation.is_some() && !continuation_messages.is_empty() {
+        let no_continuation_prompt = prompt.clone();
+        let mut continuation_context = root_context.clone();
+        continuation_context.insert(
+            "messages".to_string(),
+            Value::Array(continuation_prepared_messages),
+        );
+        set_add_generation_prompt(&mut continuation_context, false);
+        let continuation_prompt = render_template_context(&tmpl, continuation_context, tokens)
+            .map_err(|err| {
+                LlamaCppProviderError::Template(format!(
+                    "Failed to render chat continuation prompt: {err}"
+                ))
+            })?;
+        prompt = continuation_prompt;
+        string_suffix_after_common_prefix(&no_continuation_prompt, &prompt).to_string()
+    } else if config.add_generation_prompt {
+        let mut generation_root_context = root_context.clone();
+        generation_root_context.insert(
+            "enable_thinking".to_string(),
+            Value::Bool(enable_thinking.unwrap_or(true)),
+        );
+        generation_prompt_suffix(&tmpl, generation_root_context, tokens)?
+    } else {
+        String::new()
+    };
+    caps.apply_prompt_workarounds(
+        &mut prompt,
+        &mut generation_prompt,
+        config.add_generation_prompt,
+    );
+
+    let has_tools = tools.is_some_and(|tools| !tools.is_empty())
+        && !matches!(&config.tool_choice, LlamaCppToolChoice::None);
+    let use_native_tools = has_tools && caps.supports_tools;
+    let parse_tool_calls = has_tools && !config.force_pure_content;
+    let grammar_lazy = !config.force_pure_content
+        && use_native_tools
+        && matches!(&config.tool_choice, LlamaCppToolChoice::Auto)
+        && grammar.is_some()
+        && json_schema.is_none();
+
+    Ok(RenderedChat {
+        force_pure_content: config.force_pure_content,
+        is_continuation: continuation.is_some(),
+        add_bos: tokenizer_add_special(tokens, &prompt),
+        prompt,
+        generation_prompt,
+        grammar: if config.force_pure_content {
+            None
+        } else {
+            grammar
+        },
+        grammar_lazy,
+        grammar_triggers: if grammar_lazy {
+            caps.grammar_triggers()
+        } else {
+            Vec::new()
+        },
+        preserved_tokens: caps.preserved_tokens(),
+        additional_stops: caps.additional_stops(),
+        parse_tool_calls,
+        tool_names: tools
+            .unwrap_or_default()
+            .iter()
+            .map(|tool| tool.function.name.clone())
+            .collect(),
+        reasoning_format: if config.force_pure_content {
+            None
+        } else {
+            config.reasoning_format
+        },
+        reasoning_start_tag: if config.force_pure_content {
+            None
+        } else {
+            caps.reasoning_start_tag.map(ToOwned::to_owned)
+        },
+        reasoning_end_tag: if config.force_pure_content {
+            None
+        } else {
+            caps.reasoning_end_tag.map(ToOwned::to_owned)
+        },
+    })
+}
+
+fn render_template_context(
+    tmpl: &minijinja::Template<'_, '_>,
+    context: Map<String, Value>,
+    tokens: &TemplateTokens,
+) -> Result<String, JinjaError> {
+    let mut rendered = tmpl.render(Value::Object(context))?;
+    strip_tokenizer_added_specials(&mut rendered, tokens);
+    Ok(rendered)
+}
+
+fn generation_prompt_suffix(
+    tmpl: &minijinja::Template<'_, '_>,
+    root_context: Map<String, Value>,
+    tokens: &TemplateTokens,
+) -> Result<String, LlamaCppProviderError> {
+    let no_gen_prompt =
+        render_template_context(tmpl, root_context.clone(), tokens).map_err(|err| {
+            LlamaCppProviderError::Template(format!(
+                "Failed to render chat template without generation prompt: {err}"
+            ))
+        })?;
+    let mut gen_context = root_context;
+    set_add_generation_prompt(&mut gen_context, true);
+    let gen_prompt = render_template_context(tmpl, gen_context, tokens).map_err(|err| {
+        LlamaCppProviderError::Template(format!(
+            "Failed to render chat template with generation prompt: {err}"
+        ))
+    })?;
+    Ok(string_suffix_after_common_prefix(&no_gen_prompt, &gen_prompt).to_string())
+}
+
+fn set_add_generation_prompt(context: &mut Map<String, Value>, enabled: bool) {
+    if enabled {
+        context.insert("add_generation_prompt".to_string(), Value::Bool(true));
+    } else {
+        context.remove("add_generation_prompt");
+    }
+}
+
+fn tokenizer_add_special(tokens: &TemplateTokens, rendered_prompt: &str) -> bool {
+    match (tokens.add_bos, tokens.add_eos) {
+        (Some(add_bos), Some(add_eos)) => add_bos || add_eos,
+        (Some(add_bos), None) => add_bos,
+        (None, Some(add_eos)) => add_eos,
+        (None, None) => {
+            tokens.bos_token.is_empty() || !rendered_prompt.starts_with(&tokens.bos_token)
+        }
+    }
+}
+
+fn strip_tokenizer_added_specials(rendered: &mut String, tokens: &TemplateTokens) {
+    if tokens.add_bos == Some(true)
+        && !tokens.bos_token.is_empty()
+        && rendered.starts_with(&tokens.bos_token)
+    {
+        rendered.replace_range(..tokens.bos_token.len(), "");
+    }
+    if tokens.add_eos == Some(true)
+        && !tokens.eos_token.is_empty()
+        && rendered.ends_with(&tokens.eos_token)
+    {
+        let end = rendered.len() - tokens.eos_token.len();
+        rendered.truncate(end);
+    }
+}
+
+fn string_suffix_after_common_prefix<'a>(left: &str, right: &'a str) -> &'a str {
+    let mut prefix_len = 0;
+    for ((left_idx, left_ch), (right_idx, right_ch)) in
+        left.char_indices().zip(right.char_indices())
+    {
+        if left_ch != right_ch {
+            break;
+        }
+        prefix_len = left_idx + left_ch.len_utf8();
+        if prefix_len != right_idx + right_ch.len_utf8() {
+            break;
+        }
+    }
+
+    &right[prefix_len..]
+}
+
+fn chat_template_kwargs(
+    config: &LlamaCppConfig,
+) -> Result<Map<String, Value>, LlamaCppProviderError> {
+    let Some(value) = config
+        .extra_body
+        .as_ref()
+        .and_then(|body| body.get("chat_template_kwargs"))
+    else {
+        return Ok(Map::new());
+    };
+    let object = value.as_object().ok_or_else(|| {
+        LlamaCppProviderError::Template(
+            "llama.cpp chat_template_kwargs must be a JSON object".to_string(),
+        )
+    })?;
+
+    let mut parsed = Map::new();
+    for (key, value) in object {
+        let value = match value {
+            Value::String(text) => {
+                serde_json::from_str::<Value>(text).unwrap_or_else(|_| value.clone())
+            }
+            _ => value.clone(),
+        };
+        parsed.insert(key.clone(), value);
+    }
+    Ok(parsed)
+}
+
+fn resolve_enable_thinking(
+    config: &LlamaCppConfig,
+    kwargs: &Map<String, Value>,
+) -> Result<Option<bool>, LlamaCppProviderError> {
+    match kwargs.get("enable_thinking") {
+        Some(Value::Bool(value)) => Ok(Some(*value)),
+        Some(Value::String(_)) => Err(LlamaCppProviderError::Template(
+            "invalid type for `enable_thinking` (expected boolean, got string)".to_string(),
+        )),
+        Some(_) => Err(LlamaCppProviderError::Template(
+            "invalid type for `enable_thinking` (expected boolean)".to_string(),
+        )),
+        None => Ok(config.enable_thinking),
+    }
+}
+
+fn tojson_filter(value: JinjaValue, kwargs: Kwargs) -> Result<JinjaValue, JinjaError> {
+    let json = if let Ok(indent) = kwargs.get::<usize>("indent") {
+        let mut buf = Vec::new();
+        let spaces = b" ".repeat(indent);
+        let formatter = serde_json::ser::PrettyFormatter::with_indent(&spaces);
+        let mut serializer = serde_json::Serializer::with_formatter(&mut buf, formatter);
+        value.serialize(&mut serializer).map_err(|err| {
+            JinjaError::new(ErrorKind::BadSerialization, "cannot serialize to JSON")
+                .with_source(err)
+        })?;
+        String::from_utf8(buf).map_err(|err| {
+            JinjaError::new(ErrorKind::BadSerialization, "cannot serialize to JSON")
+                .with_source(err)
+        })?
+    } else {
+        serde_json::to_string(&value).map_err(|err| {
+            JinjaError::new(ErrorKind::BadSerialization, "cannot serialize to JSON")
+                .with_source(err)
+        })?
+    };
+
+    let mut escaped = String::with_capacity(json.len());
+    for ch in json.chars() {
+        match ch {
+            '<' => escaped.push_str("\\u003c"),
+            '>' => escaped.push_str("\\u003e"),
+            '&' => escaped.push_str("\\u0026"),
+            '\'' => escaped.push_str("\\u0027"),
+            _ => escaped.push(ch),
+        }
+    }
+    Ok(JinjaValue::from_safe_string(escaped))
+}
+
+fn pycompat_method_callback(
+    state: &State,
+    value: &JinjaValue,
+    method: &str,
+    args: &[JinjaValue],
+) -> Result<JinjaValue, JinjaError> {
+    if value.kind() == ValueKind::Map {
+        return match method {
+            "items" => state.apply_filter("items", std::slice::from_ref(value)),
+            "get" => map_get(value, args),
+            _ => Err(JinjaError::from(ErrorKind::UnknownMethod)),
+        };
+    }
+
+    let Some(text) = value.as_str() else {
+        return Err(JinjaError::from(ErrorKind::UnknownMethod));
+    };
+
+    match method {
+        "startswith" => {
+            let prefix = string_arg(method, args, 0)?;
+            ensure_arg_count(method, args, 1)?;
+            Ok(JinjaValue::from(text.starts_with(prefix)))
+        }
+        "endswith" => {
+            let suffix = string_arg(method, args, 0)?;
+            ensure_arg_count(method, args, 1)?;
+            Ok(JinjaValue::from(text.ends_with(suffix)))
+        }
+        "strip" => {
+            ensure_max_arg_count(method, args, 1)?;
+            Ok(JinjaValue::from(strip_chars(
+                text,
+                optional_string_arg(args, 0)?,
+            )))
+        }
+        "lstrip" => {
+            ensure_max_arg_count(method, args, 1)?;
+            Ok(JinjaValue::from(lstrip_chars(
+                text,
+                optional_string_arg(args, 0)?,
+            )))
+        }
+        "rstrip" => {
+            ensure_max_arg_count(method, args, 1)?;
+            Ok(JinjaValue::from(rstrip_chars(
+                text,
+                optional_string_arg(args, 0)?,
+            )))
+        }
+        "split" => {
+            ensure_max_arg_count(method, args, 2)?;
+            let sep = optional_string_arg(args, 0)?;
+            let maxsplit = optional_usize_arg(args, 1)?;
+            Ok(JinjaValue::from_iter(split_string(text, sep, maxsplit)))
+        }
+        "lower" => {
+            ensure_arg_count(method, args, 0)?;
+            Ok(JinjaValue::from(text.to_lowercase()))
+        }
+        "upper" => {
+            ensure_arg_count(method, args, 0)?;
+            Ok(JinjaValue::from(text.to_uppercase()))
+        }
+        "replace" => {
+            let from = string_arg(method, args, 0)?;
+            let to = string_arg(method, args, 1)?;
+            ensure_max_arg_count(method, args, 3)?;
+            let replaced = if let Some(count) = optional_usize_arg(args, 2)? {
+                text.replacen(from, to, count)
+            } else {
+                text.replace(from, to)
+            };
+            Ok(JinjaValue::from(replaced))
+        }
+        _ => Err(JinjaError::from(ErrorKind::UnknownMethod)),
+    }
+}
+
+fn map_get(value: &JinjaValue, args: &[JinjaValue]) -> Result<JinjaValue, JinjaError> {
+    if !(1..=2).contains(&args.len()) {
+        return Err(invalid_method_args("get"));
+    }
+
+    let resolved = value.get_item(&args[0])?;
+    if resolved.is_undefined() {
+        Ok(args.get(1).cloned().unwrap_or_else(|| JinjaValue::from(())))
+    } else {
+        Ok(resolved)
+    }
+}
+
+fn string_arg<'a>(
+    method: &str,
+    args: &'a [JinjaValue],
+    index: usize,
+) -> Result<&'a str, JinjaError> {
+    args.get(index)
+        .and_then(JinjaValue::as_str)
+        .ok_or_else(|| invalid_method_args(method))
+}
+
+fn optional_string_arg(args: &[JinjaValue], index: usize) -> Result<Option<&str>, JinjaError> {
+    match args.get(index) {
+        Some(value) => value
+            .as_str()
+            .map(Some)
+            .ok_or_else(|| invalid_method_args("string method")),
+        None => Ok(None),
+    }
+}
+
+fn optional_usize_arg(args: &[JinjaValue], index: usize) -> Result<Option<usize>, JinjaError> {
+    match args.get(index) {
+        Some(value) => value
+            .as_usize()
+            .map(Some)
+            .ok_or_else(|| invalid_method_args("string method")),
+        None => Ok(None),
+    }
+}
+
+fn ensure_arg_count(method: &str, args: &[JinjaValue], expected: usize) -> Result<(), JinjaError> {
+    if args.len() == expected {
+        Ok(())
+    } else {
+        Err(invalid_method_args(method))
+    }
+}
+
+fn ensure_max_arg_count(method: &str, args: &[JinjaValue], max: usize) -> Result<(), JinjaError> {
+    if args.len() <= max {
+        Ok(())
+    } else {
+        Err(invalid_method_args(method))
+    }
+}
+
+fn invalid_method_args(method: &str) -> JinjaError {
+    JinjaError::new(
+        ErrorKind::InvalidOperation,
+        format!("invalid arguments for Python-compatible string method `{method}`"),
+    )
+}
+
+fn strip_chars(text: &str, chars: Option<&str>) -> String {
+    match chars {
+        Some(chars) => text.trim_matches(|ch| chars.contains(ch)).to_string(),
+        None => text.trim().to_string(),
+    }
+}
+
+fn lstrip_chars(text: &str, chars: Option<&str>) -> String {
+    match chars {
+        Some(chars) => text.trim_start_matches(|ch| chars.contains(ch)).to_string(),
+        None => text.trim_start().to_string(),
+    }
+}
+
+fn rstrip_chars(text: &str, chars: Option<&str>) -> String {
+    match chars {
+        Some(chars) => text.trim_end_matches(|ch| chars.contains(ch)).to_string(),
+        None => text.trim_end().to_string(),
+    }
+}
+
+fn split_string(text: &str, sep: Option<&str>, maxsplit: Option<usize>) -> Vec<String> {
+    match (sep, maxsplit) {
+        (Some(sep), Some(maxsplit)) => text
+            .splitn(maxsplit.saturating_add(1), sep)
+            .map(ToOwned::to_owned)
+            .collect(),
+        (Some(sep), None) => text.split(sep).map(ToOwned::to_owned).collect(),
+        (None, Some(maxsplit)) => text
+            .split_whitespace()
+            .take(maxsplit.saturating_add(1))
+            .map(ToOwned::to_owned)
+            .collect(),
+        (None, None) => text.split_whitespace().map(ToOwned::to_owned).collect(),
+    }
+}
+
+fn raise_exception(message: String) -> Result<String, JinjaError> {
+    Err(JinjaError::new(ErrorKind::InvalidOperation, message))
+}
+
+fn strftime_now(format: String) -> String {
+    Local::now().format(&format).to_string()
+}
+
+fn date_string() -> String {
+    Local::now().format("%d %b %Y").to_string()
+}
+
+fn datetime_string() -> String {
+    Local::now().format("%b %d %Y").to_string()
+}
+
+#[derive(Debug, Clone)]
+struct TemplateCapabilities {
+    supports_tools: bool,
+    reasoning_start_tag: Option<&'static str>,
+    reasoning_end_tag: Option<&'static str>,
+    markers: HashSet<&'static str>,
+    server_caps: ServerTemplateCaps,
+}
+
+impl TemplateCapabilities {
+    fn analyze(source: &str) -> Self {
+        let supports_tools = source.contains("tools");
+        let supports_tool_calls = source.contains("tool_calls")
+            || source.contains("<tool_call>")
+            || source.contains("[TOOL_CALLS]")
+            || source.contains("to=functions.");
+        let supports_typed_content = source.contains("content[")
+            || source.contains("content |")
+            || source.contains("content|")
+            || source.contains("message['content']")
+            || source.contains("message.content")
+            || source.contains("media_marker")
+            || source.contains("'type'")
+            || source.contains("\"type\"");
+        let supports_string_content = !source.contains("content[0]")
+            || source.contains("is string")
+            || source.contains("is_string")
+            || source.contains("message['content']");
+        let supports_system_role = source.contains("system")
+            || source.contains("developer")
+            || !source.contains("raise_exception");
+        let supports_object_arguments = source.contains("arguments|tojson")
+            || source.contains("arguments | tojson")
+            || source.contains("arguments: tool_call")
+            || source.contains("arguments']");
+        let gemma4_tool_response_compat = source.contains("'<|tool_call>call:'")
+            && !source.contains("{#- OpenAI Chat Completions:");
+        let reasoning = if source.contains("<think>") || source.contains("enable_thinking") {
+            (Some("<think>"), Some("</think>"))
+        } else if source.contains("<|channel>thought") {
+            (Some("<|channel>thought"), Some("<channel|>"))
+        } else if source.contains("[THINK]") {
+            (Some("[THINK]"), Some("[/THINK]"))
+        } else {
+            (None, None)
+        };
+
+        let mut markers = HashSet::new();
+        for marker in [
+            "<tool_call>",
+            "</tool_call>",
+            "<function=",
+            "</function>",
+            "[TOOL_CALLS]",
+            "[/TOOL_CALLS]",
+            "[ARGS]",
+            "[/ARGS]",
+            "<think>",
+            "</think>",
+            "[THINK]",
+            "[/THINK]",
+            "<|channel|>",
+            "<|start|>",
+            "<|message|>",
+            "<|end|>",
+            "<|return|>",
+            "<|channel>",
+            "<channel|>",
+            "<|tool_call>",
+            "<tool_call|>",
+            "<|turn>",
+            "<turn|>",
+            ">>>all",
+            ">>>${recipient}",
+            "[SYSTEM_PROMPT]",
+            "[CALL_ID]",
+            "<|tool_calls_section_begin|>",
+            "<|tool_calls_section_end|>",
+            "<|tool_call_begin|>",
+            "<|tool_call_argument_begin|>",
+            "<|tool_call_end|>",
+            "<|tool_call_start|>",
+            "<|tool_call_end|>",
+            "<|tool_list_start|>",
+            "<|tool_list_end|>",
+            "<|message_sep|>\n\n",
+            "<|message_sep|>\n\nfunction call<|role_sep|>\n",
+            "<|role_sep|>\n",
+            "｜DSML｜",
+            "<｜DSML｜function_calls>",
+            ">>>",
+        ] {
+            if source.contains(marker) {
+                markers.insert(marker);
+            }
+        }
+        let gpt_oss_reasoning_compat = markers.contains("<|channel|>");
+        let ministral_reasoning_blocks_compat = markers.contains("[SYSTEM_PROMPT]")
+            && markers.contains("[TOOL_CALLS]")
+            && markers.contains("[ARGS]")
+            && !markers.contains("[CALL_ID]");
+        let lfm2_reasoning_compat = (markers.contains("<|tool_list_start|>")
+            && markers.contains("<|tool_list_end|>"))
+            || (source.contains("List of tools: [") && !markers.contains("<|tool_list_start|>"));
+
+        Self {
+            supports_tools,
+            reasoning_start_tag: reasoning.0,
+            reasoning_end_tag: reasoning.1,
+            markers,
+            server_caps: ServerTemplateCaps {
+                supports_string_content,
+                supports_typed_content,
+                supports_system_role,
+                supports_tool_calls,
+                supports_object_arguments,
+                gpt_oss_reasoning_compat,
+                ministral_reasoning_blocks_compat,
+                lfm2_reasoning_compat,
+                gemma4_tool_response_compat,
+            },
+        }
+    }
+
+    fn grammar_triggers(&self) -> Vec<GrammarTrigger> {
+        let mut triggers = Vec::new();
+        if self.markers.contains("<|channel|>") {
+            triggers.push(GrammarTrigger::Pattern("^\\s+to$".to_string()));
+            triggers.push(GrammarTrigger::Pattern(
+                "^<\\|channel\\|>(?:commentary|analysis)\\s+to=functions$".to_string(),
+            ));
+            triggers.push(GrammarTrigger::Pattern(
+                "<\\|start\\|>assistant(\\s+to)".to_string(),
+            ));
+            triggers.push(GrammarTrigger::Pattern(
+                "<\\|start\\|>assistant(<\\|channel\\|>(?:commentary|analysis)\\s+to)".to_string(),
+            ));
+        }
+        if self.markers.contains(">>>all") && self.markers.contains(">>>${recipient}") {
+            triggers.push(GrammarTrigger::Pattern(">>>(?!all)".to_string()));
+        }
+        for marker in [
+            "<|tool_call>",
+            "<|tool_call_begin|>",
+            "<|tool_call_start|>",
+            "<|message_sep|>\n\nfunction call<|role_sep|>\n",
+            "<｜DSML｜function_calls>",
+        ] {
+            if self.markers.contains(marker) {
+                triggers.push(GrammarTrigger::Word(marker.to_string()));
+            }
+        }
+        if self.markers.contains("<function=") {
+            triggers.push(GrammarTrigger::Word("<function=".to_string()));
+        }
+        for marker in ["<tool_call>", "[TOOL_CALLS]", "{\"type\": \"function\","] {
+            if self.markers.contains(marker) || marker.starts_with('{') {
+                triggers.push(GrammarTrigger::Word(marker.to_string()));
+            }
+        }
+        triggers
+    }
+
+    fn preserved_tokens(&self) -> Vec<String> {
+        self.markers
+            .iter()
+            .map(|marker| (*marker).to_string())
+            .collect()
+    }
+
+    fn additional_stops(&self) -> Vec<String> {
+        Vec::new()
+    }
+
+    fn reasoning_continuation_prompt(
+        &self,
+        prompt: &str,
+        base_generation_prompt: &str,
+        reasoning_prefill: &str,
+    ) -> Result<String, LlamaCppProviderError> {
+        if self.markers.contains("<|channel|>")
+            && self.markers.contains("<|start|>")
+            && self.markers.contains("<|message|>")
+        {
+            return Ok(format!(
+                "<|start|>assistant<|channel|>analysis<|message|>{reasoning_prefill}"
+            ));
+        }
+
+        if self.markers.contains("<|channel>")
+            && self.markers.contains("<channel|>")
+            && self.markers.contains("<|turn>")
+        {
+            let model_turn = if prompt.ends_with("<turn|>\n") {
+                "<|turn>model\n"
+            } else {
+                ""
+            };
+            return Ok(format!(
+                "{model_turn}<|channel>thought\n{reasoning_prefill}"
+            ));
+        }
+
+        if self.markers.contains("[THINK]") {
+            return Ok(format!("[THINK]{reasoning_prefill}"));
+        }
+
+        if self.markers.contains("<|tool_calls_section_begin|>") && self.markers.contains("<think>")
+        {
+            return Ok(format!(
+                "<|im_assistant|>assistant<|im_middle|><think>{reasoning_prefill}"
+            ));
+        }
+
+        if self.markers.contains("｜DSML｜") && self.markers.contains("<think>") {
+            return Ok(format!("<｜Assistant｜><think>{reasoning_prefill}"));
+        }
+
+        if self.markers.contains("<think>") {
+            return Ok(format!(
+                "{base_generation_prompt}<think>{reasoning_prefill}"
+            ));
+        }
+
+        Err(LlamaCppProviderError::Template(
+            "continue_final_message=reasoning requires a supported reasoning chat template"
+                .to_string(),
+        ))
+    }
+
+    fn apply_prompt_workarounds(
+        &self,
+        prompt: &mut String,
+        generation_prompt: &mut String,
+        add_generation_prompt: bool,
+    ) {
+        if !add_generation_prompt
+            && self.markers.contains("<|return|>")
+            && self.markers.contains("<|end|>")
+            && let Some(pos) = prompt.rfind("<|return|>")
+        {
+            prompt.replace_range(pos..pos + "<|return|>".len(), "<|end|>");
+        }
+
+        if !add_generation_prompt {
+            return;
+        }
+
+        if self.markers.contains("<|turn>") && prompt.ends_with("<turn|>\n") {
+            const GEMMA4_MODEL_TURN: &str = "<|turn>model\n";
+            prompt.push_str(GEMMA4_MODEL_TURN);
+            *generation_prompt = GEMMA4_MODEL_TURN.to_string();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use autoagents_llm::chat::{ChatRole, FunctionTool, MessageType, Tool};
+    use autoagents_llm::{FunctionCall, ToolCall};
+    use serde_json::json;
+
+    fn empty_tokens() -> TemplateTokens {
+        TemplateTokens::default()
+    }
+
+    fn user_message(content: &str) -> ChatMessage {
+        ChatMessage {
+            role: ChatRole::User,
+            message_type: MessageType::Text,
+            content: content.to_string(),
+        }
+    }
+
+    #[test]
+    fn renders_chat_template_kwargs_as_top_level_context() {
+        let config = LlamaCppConfig {
+            extra_body: Some(json!({
+                "chat_template_kwargs": {
+                    "custom_flag": "enabled"
+                }
+            })),
+            ..Default::default()
+        };
+        let template = explicit_template_source(
+            "{{ custom_flag }}:{% for message in messages %}{{ message['role'] }}={{ message['content'] }}{% endfor %}",
+        );
+
+        let rendered = render_chat_template(
+            &config,
+            &template,
+            &[user_message("hi")],
+            None,
+            None,
+            None,
+            &empty_tokens(),
+        )
+        .expect("template should render");
+
+        assert_eq!(rendered.prompt, "enabled:user=hi");
+    }
+
+    #[test]
+    fn renders_server_style_stringified_chat_template_kwargs() {
+        let config = LlamaCppConfig {
+            extra_body: Some(json!({
+                "chat_template_kwargs": {
+                    "enable_thinking": "true",
+                    "custom_label": "\"server-style\""
+                }
+            })),
+            ..Default::default()
+        };
+        let template = explicit_template_source(
+            "{% if enable_thinking %}<think>{% endif %}{{ custom_label }}",
+        );
+
+        let rendered = render_chat_template(
+            &config,
+            &template,
+            &[user_message("hi")],
+            None,
+            None,
+            None,
+            &empty_tokens(),
+        )
+        .expect("template should render");
+
+        assert_eq!(rendered.prompt, "<think>server-style");
+    }
+
+    #[test]
+    fn renders_named_tool_choice_as_openai_object_context() {
+        let config = LlamaCppConfig {
+            tool_choice: LlamaCppToolChoice::Function {
+                name: "lookup".to_string(),
+            },
+            ..Default::default()
+        };
+        let template = explicit_template_source(
+            "{{ tool_choice['type'] }}:{{ tool_choice['function']['name'] }}",
+        );
+
+        let rendered = render_chat_template(
+            &config,
+            &template,
+            &[user_message("hi")],
+            None,
+            None,
+            None,
+            &empty_tokens(),
+        )
+        .expect("template should render");
+
+        assert_eq!(rendered.prompt, "function:lookup");
+    }
+
+    #[test]
+    fn enable_thinking_uses_kwargs_over_config_without_prompt_rewrite() {
+        let config = LlamaCppConfig {
+            enable_thinking: Some(false),
+            extra_body: Some(json!({
+                "chat_template_kwargs": {
+                    "enable_thinking": true
+                }
+            })),
+            ..Default::default()
+        };
+        let template = explicit_template_source(
+            "{% if enable_thinking %}<think>{% endif %}{{ messages[0]['content'] }}",
+        );
+
+        let rendered = render_chat_template(
+            &config,
+            &template,
+            &[user_message("solve")],
+            None,
+            None,
+            None,
+            &empty_tokens(),
+        )
+        .expect("template should render");
+
+        assert_eq!(rendered.prompt, "<think>solve");
+    }
+
+    #[test]
+    fn rejects_non_object_chat_template_kwargs() {
+        let config = LlamaCppConfig {
+            extra_body: Some(json!({
+                "chat_template_kwargs": true
+            })),
+            ..Default::default()
+        };
+        let template = explicit_template_source("{{ messages[0]['content'] }}");
+
+        let err = render_chat_template(
+            &config,
+            &template,
+            &[user_message("hi")],
+            None,
+            None,
+            None,
+            &empty_tokens(),
+        )
+        .expect_err("non-object kwargs should fail");
+
+        assert!(err.to_string().contains("chat_template_kwargs"));
+    }
+
+    #[test]
+    fn tojson_filter_renders_valid_json_not_display_text() {
+        let config = LlamaCppConfig {
+            extra_body: Some(json!({
+                "chat_template_kwargs": {
+                    "payload": {
+                        "name": "lookup",
+                        "description": "a < b & c",
+                        "arguments": {
+                            "q": "rust"
+                        }
+                    }
+                }
+            })),
+            ..Default::default()
+        };
+        let template = explicit_template_source("{{ payload|tojson }}");
+
+        let rendered = render_chat_template(
+            &config,
+            &template,
+            &[user_message("hi")],
+            None,
+            None,
+            None,
+            &empty_tokens(),
+        )
+        .expect("template should render");
+
+        assert!(rendered.prompt.contains("\"name\":\"lookup\""));
+        assert!(rendered.prompt.contains("\\u003c"));
+        assert!(rendered.prompt.contains("\\u0026"));
+        let parsed: Value = serde_json::from_str(&rendered.prompt).expect("valid JSON output");
+        assert_eq!(parsed["name"], "lookup");
+        assert_eq!(parsed["description"], "a < b & c");
+        assert_eq!(parsed["arguments"]["q"], "rust");
+    }
+
+    #[test]
+    fn strftime_now_renders_current_time() {
+        let config = LlamaCppConfig::default();
+        let template = explicit_template_source("{{ strftime_now(\"%Y-%m-%d\") }}");
+
+        let rendered = render_chat_template(
+            &config,
+            &template,
+            &[user_message("hi")],
+            None,
+            None,
+            None,
+            &empty_tokens(),
+        )
+        .expect("template should render");
+
+        assert_eq!(rendered.prompt, Local::now().format("%Y-%m-%d").to_string());
+    }
+
+    #[test]
+    fn template_receives_llama_server_date_context() {
+        let config = LlamaCppConfig::default();
+        let template = explicit_template_source("{{ date_string }}|{{ datetime }}");
+
+        let rendered = render_chat_template(
+            &config,
+            &template,
+            &[user_message("hi")],
+            None,
+            None,
+            None,
+            &empty_tokens(),
+        )
+        .expect("template should render");
+
+        assert_eq!(
+            rendered.prompt,
+            format!(
+                "{}|{}",
+                Local::now().format("%d %b %Y"),
+                Local::now().format("%b %d %Y")
+            )
+        );
+    }
+
+    #[test]
+    fn tool_template_sets_lazy_grammar_metadata() {
+        let config = LlamaCppConfig::default();
+        let template = explicit_template_source(
+            "{% for message in messages %}{{ message['content'] }}{% endfor %}{% if tools %}<tool_call>{% endif %}",
+        );
+        let tool = Tool {
+            tool_type: "function".to_string(),
+            function: FunctionTool {
+                name: "lookup".to_string(),
+                description: "Lookup value".to_string(),
+                parameters: json!({
+                    "type": "object",
+                    "properties": {
+                        "q": { "type": "string" }
+                    },
+                    "required": ["q"]
+                }),
+            },
+        };
+
+        let rendered = render_chat_template(
+            &config,
+            &template,
+            &[user_message("hi")],
+            Some(&[tool]),
+            None,
+            Some("root ::= \"{}\"".to_string()),
+            &empty_tokens(),
+        )
+        .expect("tool template should render");
+
+        assert!(rendered.parse_tool_calls);
+        assert!(rendered.grammar_lazy);
+        assert!(
+            rendered.grammar_triggers.iter().any(
+                |trigger| matches!(trigger, GrammarTrigger::Word(word) if word == "<tool_call>")
+            )
+        );
+    }
+
+    #[test]
+    fn tool_call_history_support_does_not_imply_tool_definition_support() {
+        let config = LlamaCppConfig::default();
+        let template = explicit_template_source(
+            "{% for message in messages %}{% if message.tool_calls %}<tool_call>{{ message.tool_calls|tojson }}</tool_call>{% endif %}{{ message['content'] }}{% endfor %}",
+        );
+        let tool = Tool {
+            tool_type: "function".to_string(),
+            function: FunctionTool {
+                name: "lookup".to_string(),
+                description: "Lookup value".to_string(),
+                parameters: json!({
+                    "type": "object",
+                    "properties": {
+                        "q": { "type": "string" }
+                    },
+                    "required": ["q"]
+                }),
+            },
+        };
+
+        let rendered = render_chat_template(
+            &config,
+            &template,
+            &[user_message("hi")],
+            Some(&[tool]),
+            None,
+            Some("root ::= \"{}\"".to_string()),
+            &empty_tokens(),
+        )
+        .expect("tool-call history template should render");
+
+        assert!(rendered.parse_tool_calls);
+        assert!(
+            !rendered.grammar_lazy,
+            "template has tool_call history support but cannot render tool definitions"
+        );
+        assert!(rendered.grammar_triggers.is_empty());
+    }
+
+    #[test]
+    fn specialized_template_markers_set_server_preserved_tokens_and_triggers() {
+        let config = LlamaCppConfig::default();
+        let template = explicit_template_source(
+            "{{ tools|tojson }}<function=</function><|tool_call_begin|><|tool_call_argument_begin|><|tool_call_end|><|message_sep|>\n\nfunction call<|role_sep|>\n<｜DSML｜function_calls>>>>all\n>>>${recipient}",
+        );
+        let tool = Tool {
+            tool_type: "function".to_string(),
+            function: FunctionTool {
+                name: "lookup".to_string(),
+                description: "Lookup value".to_string(),
+                parameters: json!({
+                    "type": "object",
+                    "properties": {
+                        "q": { "type": "string" }
+                    }
+                }),
+            },
+        };
+
+        let rendered = render_chat_template(
+            &config,
+            &template,
+            &[user_message("hi")],
+            Some(&[tool]),
+            None,
+            Some("root ::= \"{}\"".to_string()),
+            &empty_tokens(),
+        )
+        .expect("template should render");
+
+        assert!(
+            rendered
+                .preserved_tokens
+                .iter()
+                .any(|token| token == "<|tool_call_begin|>")
+        );
+        assert!(rendered.grammar_triggers.iter().any(
+            |trigger| matches!(trigger, GrammarTrigger::Word(word) if word == "<|tool_call_begin|>")
+        ));
+        assert!(
+            rendered.grammar_triggers.iter().any(
+                |trigger| matches!(trigger, GrammarTrigger::Word(word) if word == "<function=")
+            )
+        );
+        assert!(rendered.grammar_triggers.iter().any(
+            |trigger| matches!(trigger, GrammarTrigger::Pattern(pattern) if pattern == ">>>(?!all)")
+        ));
+    }
+
+    #[test]
+    fn gpt_oss_channel_marker_enables_reasoning_workaround_caps() {
+        let caps = TemplateCapabilities::analyze(
+            "{% for message in messages %}<|start|>{{ message.role }}<|channel|>final<|message|>{{ message.thinking }}{% endfor %}",
+        );
+
+        assert!(caps.server_caps.gpt_oss_reasoning_compat);
+    }
+
+    #[test]
+    fn specialized_reasoning_history_rewrite_caps_match_server_detection() {
+        let ministral = TemplateCapabilities::analyze("[SYSTEM_PROMPT][TOOL_CALLS][ARGS]");
+        let mistral_small =
+            TemplateCapabilities::analyze("[SYSTEM_PROMPT][TOOL_CALLS][ARGS][CALL_ID]");
+        let lfm2 = TemplateCapabilities::analyze("<|tool_list_start|><|tool_list_end|>");
+        let lfm25 = TemplateCapabilities::analyze("List of tools: []");
+
+        assert!(ministral.server_caps.ministral_reasoning_blocks_compat);
+        assert!(!mistral_small.server_caps.ministral_reasoning_blocks_compat);
+        assert!(lfm2.server_caps.lfm2_reasoning_compat);
+        assert!(lfm25.server_caps.lfm2_reasoning_compat);
+    }
+
+    #[test]
+    fn functionary_trigger_requires_server_specialized_markers() {
+        let functionary = TemplateCapabilities::analyze(">>>all\n>>>${recipient}");
+        let generic = TemplateCapabilities::analyze(">>>generic");
+
+        assert!(functionary.grammar_triggers().iter().any(
+            |trigger| matches!(trigger, GrammarTrigger::Pattern(pattern) if pattern == ">>>(?!all)")
+        ));
+        assert!(generic.grammar_triggers().iter().all(
+            |trigger| !matches!(trigger, GrammarTrigger::Pattern(pattern) if pattern == ">>>(?!all)")
+        ));
+    }
+
+    #[test]
+    fn real_template_rendering_goldens_cover_server_specialized_families() {
+        struct GoldenCase {
+            name: &'static str,
+            template: &'static str,
+            config: LlamaCppConfig,
+            expected_prompt_contains: &'static [&'static str],
+            expected_generation_prompt: &'static str,
+            expected_lazy: bool,
+            expected_trigger: Option<&'static str>,
+            expected_preserved: Option<&'static str>,
+            expected_reasoning: Option<(&'static str, &'static str)>,
+        }
+
+        let tool = Tool {
+            tool_type: "function".to_string(),
+            function: FunctionTool {
+                name: "lookup".to_string(),
+                description: "Lookup value".to_string(),
+                parameters: json!({
+                    "type": "object",
+                    "properties": {
+                        "q": { "type": "string" }
+                    },
+                    "required": ["q"]
+                }),
+            },
+        };
+
+        let cases = vec![
+            GoldenCase {
+                name: "qwen chatml thinking",
+                template: "{% for message in messages %}<|im_start|>{{ message['role'] }}\n{{ message['content'] }}<|im_end|>\n{% endfor %}{% if add_generation_prompt %}<|im_start|>assistant\n{% if enable_thinking %}<think>\n{% endif %}{% endif %}{# <think></think> #}",
+                config: LlamaCppConfig {
+                    enable_thinking: Some(true),
+                    reasoning_format: Some(LlamaCppReasoningFormat::Auto),
+                    ..Default::default()
+                },
+                expected_prompt_contains: &[
+                    "<|im_start|>user\nhi<|im_end|>",
+                    "<|im_start|>assistant\n<think>\n",
+                ],
+                expected_generation_prompt: "<|im_start|>assistant\n<think>\n",
+                expected_lazy: false,
+                expected_trigger: None,
+                expected_preserved: None,
+                expected_reasoning: Some(("<think>", "</think>")),
+            },
+            GoldenCase {
+                name: "gpt-oss native channel",
+                template: "{% if tools %}{% for tool in tools %}{{ tool.function.name }}{% endfor %}{% endif %}{% for message in messages %}<|start|>{{ message['role'] }}<|channel|>final<|message|>{{ message['content'] }}<|end|>{% endfor %}{% if add_generation_prompt %}<|start|>assistant<|channel|>final<|message|>{% endif %}{# to=functions <|message|> #}",
+                config: LlamaCppConfig::default(),
+                expected_prompt_contains: &[
+                    "lookup<|start|>user<|channel|>final<|message|>hi<|end|>",
+                    "<|start|>assistant<|channel|>final<|message|>",
+                ],
+                expected_generation_prompt: "<|start|>assistant<|channel|>final<|message|>",
+                expected_lazy: true,
+                expected_trigger: Some("^\\s+to$"),
+                expected_preserved: None,
+                expected_reasoning: None,
+            },
+            GoldenCase {
+                name: "functionary v3.2",
+                template: ">>>all\n{% for message in messages %}{{ message['content'] }}{% endfor %}{% if add_generation_prompt %}>>>${recipient}\n{% endif %}{# tools rendered elsewhere #}",
+                config: LlamaCppConfig::default(),
+                expected_prompt_contains: &[">>>all\nhi>>>${recipient}\n"],
+                expected_generation_prompt: ">>>${recipient}\n",
+                expected_lazy: true,
+                expected_trigger: Some(">>>(?!all)"),
+                expected_preserved: None,
+                expected_reasoning: None,
+            },
+            GoldenCase {
+                name: "kimi k2",
+                template: "{% if tools %}{% for tool in tools %}{{ tool.function.name }}{% endfor %}{% endif %}{% for message in messages %}<|im_user|>{{ message['content'] }}{% endfor %}{% if add_generation_prompt %}<|im_assistant|>{% endif %}{# <|tool_call_begin|>functions.lookup:0<|tool_call_argument_begin|><|tool_call_end|> #}",
+                config: LlamaCppConfig::default(),
+                expected_prompt_contains: &["lookup<|im_user|>hi<|im_assistant|>"],
+                expected_generation_prompt: "<|im_assistant|>",
+                expected_lazy: true,
+                expected_trigger: Some("<|tool_call_begin|>"),
+                expected_preserved: Some("<|tool_call_begin|>"),
+                expected_reasoning: None,
+            },
+            GoldenCase {
+                name: "lfm2 python tools",
+                template: "List of tools: [{% for tool in tools %}{{ tool.function.name }}{% endfor %}]{% for message in messages %}{{ message['content'] }}{% endfor %}{% if add_generation_prompt %}<|assistant|>{% endif %}{# <|tool_call_start|><|tool_call_end|> #}",
+                config: LlamaCppConfig::default(),
+                expected_prompt_contains: &["List of tools: [lookup]hi<|assistant|>"],
+                expected_generation_prompt: "<|assistant|>",
+                expected_lazy: true,
+                expected_trigger: Some("<|tool_call_start|>"),
+                expected_preserved: Some("<|tool_call_start|>"),
+                expected_reasoning: None,
+            },
+            GoldenCase {
+                name: "gigachat v3",
+                template: "{% if tools %}{% for tool in tools %}{{ tool.function.name }}{% endfor %}{% endif %}assistant<|role_sep|>\n{% for message in messages %}{{ message['content'] }}<|message_sep|>\n\n{% endfor %}{% if add_generation_prompt %}assistant<|role_sep|>\n{% endif %}{# <|message_sep|>\n\nfunction call<|role_sep|>\n #}",
+                config: LlamaCppConfig::default(),
+                expected_prompt_contains: &[
+                    "lookupassistant<|role_sep|>\nhi<|message_sep|>\n\nassistant<|role_sep|>\n",
+                ],
+                expected_generation_prompt: "assistant<|role_sep|>\n",
+                expected_lazy: true,
+                expected_trigger: Some("<|message_sep|>\n\nfunction call<|role_sep|>\n"),
+                expected_preserved: Some("<|message_sep|>\n\nfunction call<|role_sep|>\n"),
+                expected_reasoning: None,
+            },
+        ];
+
+        for case in cases {
+            let rendered = render_chat_template(
+                &case.config,
+                &explicit_template_source(case.template),
+                &[user_message("hi")],
+                Some(std::slice::from_ref(&tool)),
+                None,
+                Some("root ::= \"{}\"".to_string()),
+                &empty_tokens(),
+            )
+            .unwrap_or_else(|err| panic!("{} should render: {err}", case.name));
+
+            for expected in case.expected_prompt_contains {
+                assert!(
+                    rendered.prompt.contains(expected),
+                    "{} prompt should contain {expected:?}, got {:?}",
+                    case.name,
+                    rendered.prompt
+                );
+            }
+            assert_eq!(
+                rendered.generation_prompt, case.expected_generation_prompt,
+                "{} generation prompt",
+                case.name
+            );
+            assert!(
+                rendered.parse_tool_calls,
+                "{} should parse tool calls",
+                case.name
+            );
+            assert_eq!(rendered.grammar_lazy, case.expected_lazy, "{}", case.name);
+            if let Some(trigger) = case.expected_trigger {
+                assert!(
+                    rendered
+                        .grammar_triggers
+                        .iter()
+                        .any(|candidate| match candidate {
+                            GrammarTrigger::Word(word) => word == trigger,
+                            GrammarTrigger::Pattern(pattern) => pattern == trigger,
+                            GrammarTrigger::PatternFull(pattern) => pattern == trigger,
+                            GrammarTrigger::Token(_) => false,
+                        }),
+                    "{} should expose trigger {trigger:?}; got {:?}",
+                    case.name,
+                    rendered.grammar_triggers
+                );
+            } else {
+                assert!(
+                    rendered.grammar_triggers.is_empty(),
+                    "{} should not use lazy triggers",
+                    case.name
+                );
+            }
+            if let Some(preserved) = case.expected_preserved {
+                assert!(
+                    rendered
+                        .preserved_tokens
+                        .iter()
+                        .any(|token| token == preserved),
+                    "{} should preserve {preserved:?}",
+                    case.name
+                );
+            }
+            if let Some((start, end)) = case.expected_reasoning {
+                assert_eq!(
+                    rendered.reasoning_start_tag.as_deref(),
+                    Some(start),
+                    "{} reasoning start",
+                    case.name
+                );
+                assert_eq!(
+                    rendered.reasoning_end_tag.as_deref(),
+                    Some(end),
+                    "{} reasoning end",
+                    case.name
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn default_enable_thinking_matches_llama_server_default_true() {
+        let config = LlamaCppConfig::default();
+        let template = explicit_template_source("{% if enable_thinking %}<think>{% endif %}answer");
+
+        let rendered = render_chat_template(
+            &config,
+            &template,
+            &[user_message("hi")],
+            None,
+            None,
+            None,
+            &empty_tokens(),
+        )
+        .expect("template should render");
+
+        assert_eq!(rendered.prompt, "<think>answer");
+    }
+
+    #[test]
+    fn gpt_oss_return_token_is_replaced_without_generation_prompt() {
+        let config = LlamaCppConfig {
+            add_generation_prompt: false,
+            ..Default::default()
+        };
+        let template = explicit_template_source(
+            "{% for message in messages %}<|start|>{{ message['role'] }}<|channel|>final<|message|>{{ message['content'] }}<|return|>{% endfor %}{# <|end|> #}",
+        );
+
+        let rendered = render_chat_template(
+            &config,
+            &template,
+            &[user_message("done")],
+            None,
+            None,
+            None,
+            &empty_tokens(),
+        )
+        .expect("template should render");
+
+        assert_eq!(
+            rendered.prompt,
+            "<|start|>user<|channel|>final<|message|>done<|end|>"
+        );
+        assert_eq!(rendered.generation_prompt, "");
+    }
+
+    #[test]
+    fn continue_final_message_prefills_last_message_without_generation_prompt() {
+        let config = LlamaCppConfig {
+            continue_final_message: LlamaCppChatContinuation::Content,
+            ..Default::default()
+        };
+        let template = explicit_template_source(
+            "{% for message in messages %}{{ message['role'] }}:{{ message['content'] }}\n{% endfor %}{% if add_generation_prompt %}assistant:{% endif %}",
+        );
+        let assistant = ChatMessage {
+            role: ChatRole::Assistant,
+            message_type: MessageType::Text,
+            content: "partial".to_string(),
+        };
+
+        let rendered = render_chat_template(
+            &config,
+            &template,
+            &[user_message("hi"), assistant],
+            None,
+            None,
+            Some("root ::= \"{}\"".to_string()),
+            &empty_tokens(),
+        )
+        .expect("continuation template should render");
+
+        assert_eq!(rendered.prompt, "user:hi\nassistant:partial\n");
+        assert_eq!(rendered.generation_prompt, "assistant:partial\n");
+        assert!(rendered.is_continuation);
+    }
+
+    #[test]
+    fn continue_final_message_reasoning_uses_known_template_markers() {
+        let config = LlamaCppConfig {
+            continue_final_message: LlamaCppChatContinuation::Reasoning,
+            ..Default::default()
+        };
+        let template = explicit_template_source(
+            "{% for message in messages %}{{ message['role'] }}:{{ message['content'] }}\n{% endfor %}{% if add_generation_prompt %}<|assistant|>{% endif %}{# <think></think> #}",
+        );
+        let assistant = ChatMessage {
+            role: ChatRole::Assistant,
+            message_type: MessageType::Text,
+            content: "plan".to_string(),
+        };
+
+        let rendered = render_chat_template(
+            &config,
+            &template,
+            &[user_message("hi"), assistant],
+            None,
+            None,
+            Some("root ::= \"{}\"".to_string()),
+            &empty_tokens(),
+        )
+        .expect("reasoning continuation should render");
+
+        assert_eq!(rendered.prompt, "user:hi\n<|assistant|><think>plan");
+        assert_eq!(rendered.generation_prompt, "<|assistant|><think>plan");
+        assert!(rendered.is_continuation);
+    }
+
+    #[test]
+    fn continue_final_message_reasoning_rejects_unknown_template_markers() {
+        let config = LlamaCppConfig {
+            continue_final_message: LlamaCppChatContinuation::Reasoning,
+            ..Default::default()
+        };
+        let template = explicit_template_source("{{ messages|length }}");
+
+        let err = render_chat_template(
+            &config,
+            &template,
+            &[user_message("hi")],
+            None,
+            None,
+            None,
+            &empty_tokens(),
+        )
+        .expect_err("reasoning continuation requires a known marker family");
+
+        assert!(
+            err.to_string()
+                .contains("supported reasoning chat template")
+        );
+    }
+
+    #[test]
+    fn force_pure_content_disables_parser_and_reasoning_prompt_only() {
+        let config = LlamaCppConfig {
+            force_pure_content: true,
+            enable_thinking: Some(true),
+            ..Default::default()
+        };
+        let template = explicit_template_source(
+            "{% if enable_thinking %}<think>{% endif %}{% for message in messages %}{{ message['content'] }}{% endfor %}{% if tools %}<tool_call>{% endif %}{% if add_generation_prompt %}{% if enable_thinking %}<think>{% endif %}<|assistant|>{% endif %}",
+        );
+        let tool = Tool {
+            tool_type: "function".to_string(),
+            function: FunctionTool {
+                name: "lookup".to_string(),
+                description: "Lookup value".to_string(),
+                parameters: json!({
+                    "type": "object",
+                    "properties": {
+                        "q": { "type": "string" }
+                    },
+                    "required": ["q"]
+                }),
+            },
+        };
+
+        let rendered = render_chat_template(
+            &config,
+            &template,
+            &[user_message("hi")],
+            Some(&[tool]),
+            None,
+            Some("root ::= \"{}\"".to_string()),
+            &empty_tokens(),
+        )
+        .expect("template should render");
+
+        assert_eq!(rendered.prompt, "hi<tool_call><|assistant|>");
+        assert_eq!(rendered.generation_prompt, "<think><|assistant|>");
+        assert!(rendered.force_pure_content);
+        assert!(!rendered.parse_tool_calls);
+        assert!(rendered.grammar.is_none());
+        assert!(!rendered.grammar_lazy);
+        assert!(rendered.grammar_triggers.is_empty());
+        assert_eq!(rendered.reasoning_format, None);
+        assert_eq!(rendered.reasoning_start_tag, None);
+        assert_eq!(rendered.reasoning_end_tag, None);
+    }
+
+    #[test]
+    fn render_tracks_generation_prompt_suffix_for_grammar_prefill() {
+        let config = LlamaCppConfig::default();
+        let template = explicit_template_source(
+            "{% for message in messages %}<|im_start|>{{ message['role'] }}\n{{ message['content'] }}<|im_end|>\n{% endfor %}{% if add_generation_prompt %}<|im_start|>assistant\n{% endif %}",
+        );
+
+        let rendered = render_chat_template(
+            &config,
+            &template,
+            &[user_message("hi")],
+            None,
+            None,
+            Some("root ::= \"{}\"".to_string()),
+            &empty_tokens(),
+        )
+        .expect("template should render");
+
+        assert!(rendered.prompt.ends_with("<|im_start|>assistant\n"));
+        assert_eq!(rendered.generation_prompt, "<|im_start|>assistant\n");
+    }
+
+    #[test]
+    fn add_generation_prompt_false_is_absent_from_template_context() {
+        let config = LlamaCppConfig {
+            add_generation_prompt: false,
+            ..Default::default()
+        };
+        let template = explicit_template_source(
+            "{{ add_generation_prompt is defined }}|{% for message in messages %}{{ message['role'] }}:{{ message['content'] }}{% endfor %}",
+        );
+
+        let rendered = render_chat_template(
+            &config,
+            &template,
+            &[user_message("hi")],
+            None,
+            None,
+            None,
+            &empty_tokens(),
+        )
+        .expect("template should render");
+
+        assert_eq!(rendered.prompt, "false|user:hi");
+        assert_eq!(rendered.generation_prompt, "");
+    }
+
+    #[test]
+    fn gemma4_prompt_workaround_adds_model_turn_after_bare_boundary() {
+        let config = LlamaCppConfig::default();
+        let template = explicit_template_source(
+            "{% for message in messages %}<|turn>{{ message['role'] }}\n{{ message['content'] }}<turn|>\n{% endfor %}{% if add_generation_prompt %}<turn|>\n{% endif %}",
+        );
+
+        let rendered = render_chat_template(
+            &config,
+            &template,
+            &[user_message("hi")],
+            None,
+            None,
+            Some("root ::= \"{}\"".to_string()),
+            &empty_tokens(),
+        )
+        .expect("template should render");
+
+        assert!(rendered.prompt.ends_with("<turn|>\n<|turn>model\n"));
+        assert_eq!(rendered.generation_prompt, "<|turn>model\n");
+    }
+
+    #[test]
+    fn template_receives_model_special_tokens() {
+        let config = LlamaCppConfig::default();
+        let template = explicit_template_source("{{ bos_token }}user{{ eos_token }}");
+        let tokens = TemplateTokens {
+            bos_token: "<s>".to_string(),
+            eos_token: "</s>".to_string(),
+            add_bos: None,
+            add_eos: None,
+        };
+
+        let rendered = render_chat_template(
+            &config,
+            &template,
+            &[user_message("hi")],
+            None,
+            None,
+            None,
+            &tokens,
+        )
+        .expect("template should render");
+
+        assert_eq!(rendered.prompt, "<s>user</s>");
+    }
+
+    #[test]
+    fn rendered_bos_disables_automatic_chat_bos() {
+        let config = LlamaCppConfig::default();
+        let template = explicit_template_source("{{ bos_token }}user");
+        let tokens = TemplateTokens {
+            bos_token: "<s>".to_string(),
+            eos_token: "</s>".to_string(),
+            add_bos: None,
+            add_eos: None,
+        };
+
+        let rendered = render_chat_template(
+            &config,
+            &template,
+            &[user_message("hi")],
+            None,
+            None,
+            None,
+            &tokens,
+        )
+        .expect("template should render");
+
+        assert_eq!(rendered.prompt, "<s>user");
+        assert!(!rendered.add_bos);
+    }
+
+    #[test]
+    fn tokenizer_special_metadata_strips_rendered_bos_and_eos() {
+        let config = LlamaCppConfig::default();
+        let template = explicit_template_source("{{ bos_token }}user{{ eos_token }}");
+        let tokens = TemplateTokens {
+            bos_token: "<s>".to_string(),
+            eos_token: "</s>".to_string(),
+            add_bos: Some(true),
+            add_eos: Some(true),
+        };
+
+        let rendered = render_chat_template(
+            &config,
+            &template,
+            &[user_message("hi")],
+            None,
+            None,
+            None,
+            &tokens,
+        )
+        .expect("template should render");
+
+        assert_eq!(rendered.prompt, "user");
+        assert!(rendered.add_bos);
+    }
+
+    #[test]
+    fn tool_results_expand_to_openai_tool_messages() {
+        let config = LlamaCppConfig::default();
+        let template = explicit_template_source("{{ messages|tojson }}");
+        let tool_result = ChatMessage {
+            role: ChatRole::Tool,
+            message_type: MessageType::ToolResult(vec![
+                ToolCall {
+                    id: "call_1".to_string(),
+                    call_type: "function".to_string(),
+                    function: FunctionCall {
+                        name: "lookup".to_string(),
+                        arguments: "{\"q\":\"rust\"}".to_string(),
+                    },
+                },
+                ToolCall {
+                    id: "call_2".to_string(),
+                    call_type: "function".to_string(),
+                    function: FunctionCall {
+                        name: "search".to_string(),
+                        arguments: "{\"q\":\"llama\"}".to_string(),
+                    },
+                },
+            ]),
+            content: String::new(),
+        };
+
+        let rendered = render_chat_template(
+            &config,
+            &template,
+            &[tool_result],
+            None,
+            None,
+            None,
+            &empty_tokens(),
+        )
+        .expect("template should render");
+        let messages: Value = serde_json::from_str(&rendered.prompt).expect("valid messages JSON");
+        let messages = messages.as_array().expect("messages should be an array");
+
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages[0]["role"], "tool");
+        assert_eq!(messages[0]["tool_call_id"], "call_1");
+        assert_eq!(messages[0]["content"], "{\"q\":\"rust\"}");
+        assert_eq!(messages[1]["tool_call_id"], "call_2");
+        assert!(messages[0].get("tool_calls").is_none());
+    }
+
+    #[test]
+    fn supports_python_string_methods_used_by_hf_templates() {
+        let config = LlamaCppConfig::default();
+        let template = explicit_template_source(
+            r#"{{ messages[0]['content'].startswith('<tool_response>') }}:
+{{ messages[0]['content'].endswith('</tool_response>') }}:
+{{ '  <think>x</think>  '.strip().split('</think>')[0].lstrip().replace('<think>', '') }}:
+{{ 'MiXeD'.lower() }}:
+{{ 'mixed'.upper() }}"#,
+        );
+
+        let rendered = render_chat_template(
+            &config,
+            &template,
+            &[user_message("<tool_response>ok</tool_response>")],
+            None,
+            None,
+            None,
+            &empty_tokens(),
+        )
+        .expect("template should render");
+
+        assert_eq!(rendered.prompt, "true:\ntrue:\nx:\nmixed:\nMIXED");
+    }
+
+    #[test]
+    fn supports_python_map_get_used_by_hf_templates() {
+        let config = LlamaCppConfig::default();
+        let template = explicit_template_source(
+            "{{ messages[0].get('content') }}:{{ messages[0].get('missing', 'fallback') }}:{{ messages[0].get('missing') is none }}",
+        );
+
+        let rendered = render_chat_template(
+            &config,
+            &template,
+            &[user_message("hello")],
+            None,
+            None,
+            None,
+            &empty_tokens(),
+        )
+        .expect("template should render");
+
+        assert_eq!(rendered.prompt, "hello:fallback:true");
+    }
+
+    #[test]
+    fn schema_hint_is_not_injected_as_system_message_for_templates() {
+        let config = LlamaCppConfig::default();
+        let schema = StructuredOutputFormat {
+            name: "MathAgentOutput".to_string(),
+            description: Some("math output".to_string()),
+            schema: Some(json!({
+                "type": "object",
+                "properties": {
+                    "value": { "type": "integer" }
+                }
+            })),
+            strict: Some(true),
+        };
+        let template = explicit_template_source(
+            r#"{% for message in messages %}{% if message['role'] == 'system' %}{{ raise_exception('System role not supported') }}{% endif %}{{ message['role'] }}:{{ message['content'] }}
+{% endfor %}"#,
+        );
+
+        let rendered = render_chat_template(
+            &config,
+            &template,
+            &[user_message("What is 42 + 8?")],
+            None,
+            Some(&schema),
+            None,
+            &empty_tokens(),
+        )
+        .expect("schema grammar must not inject a synthetic system message");
+
+        assert!(!rendered.prompt.contains("Return a valid JSON response"));
+        assert!(rendered.prompt.contains("user:What is 42 + 8?"));
+    }
+
+    #[test]
+    fn hf_generation_blocks_are_render_transparent() {
+        let config = LlamaCppConfig::default();
+        let template = explicit_template_source(
+            "{% for message in messages %}{% generation %}{{ message['content'] }}{% endgeneration %}{% endfor %}",
+        );
+
+        let rendered = render_chat_template(
+            &config,
+            &template,
+            &[user_message("hello")],
+            None,
+            None,
+            None,
+            &empty_tokens(),
+        )
+        .expect("generation blocks should not break minijinja rendering");
+
+        assert_eq!(rendered.prompt, "hello");
+    }
+}

--- a/crates/autoagents-llamacpp/src/chat_template.rs
+++ b/crates/autoagents-llamacpp/src/chat_template.rs
@@ -446,7 +446,12 @@ fn build_template_context(
         if key != "enable_thinking" {
             root_context.insert(key.clone(), value.clone());
         }
-        kwargs_object.insert(key, value);
+        let nested_value = if config.force_pure_content && key == "enable_thinking" {
+            Value::Bool(false)
+        } else {
+            value
+        };
+        kwargs_object.insert(key, nested_value);
     }
     root_context.insert("kwargs".to_string(), Value::Object(kwargs_object.clone()));
     root_context.insert("extra_context".to_string(), Value::Object(kwargs_object));
@@ -2066,6 +2071,36 @@ mod tests {
         assert_eq!(rendered.reasoning_format, None);
         assert_eq!(rendered.reasoning_start_tag, None);
         assert_eq!(rendered.reasoning_end_tag, None);
+    }
+
+    #[test]
+    fn force_pure_content_disables_nested_enable_thinking_context() {
+        let config = LlamaCppConfig {
+            force_pure_content: true,
+            enable_thinking: Some(true),
+            extra_body: Some(json!({
+                "chat_template_kwargs": {
+                    "enable_thinking": true
+                }
+            })),
+            ..Default::default()
+        };
+        let template = explicit_template_source(
+            "{% if enable_thinking %}<think>root{% endif %}{% if kwargs['enable_thinking'] %}<think>kwargs{% endif %}{% if extra_context['enable_thinking'] %}<think>extra{% endif %}{{ messages[0]['content'] }}",
+        );
+
+        let rendered = render_chat_template(
+            &config,
+            &template,
+            &[user_message("solve")],
+            None,
+            None,
+            None,
+            &empty_tokens(),
+        )
+        .expect("template should render");
+
+        assert_eq!(rendered.prompt, "solve");
     }
 
     #[test]

--- a/crates/autoagents-llamacpp/src/chat_template.rs
+++ b/crates/autoagents-llamacpp/src/chat_template.rs
@@ -12,7 +12,7 @@ use autoagents_llm::chat::{ChatMessage, StructuredOutputFormat, Tool};
 use chrono::Local;
 use minijinja::State;
 use minijinja::value::{Kwargs, ValueKind};
-use minijinja::{Environment, Error as JinjaError, ErrorKind, Value as JinjaValue};
+use minijinja::{Environment, Error as JinjaError, ErrorKind, Template, Value as JinjaValue};
 use serde::Serialize;
 use serde_json::{Map, Value, json};
 use std::collections::HashSet;
@@ -168,7 +168,7 @@ pub(crate) fn render_chat_template(
         .map(serde_json::to_value)
         .transpose()
         .map_err(|err| LlamaCppProviderError::Template(format!("Failed to encode tools: {err}")))?
-        .unwrap_or_else(|| Value::Array(Vec::new()));
+        .unwrap_or_else(|| Value::Array(Vec::default()));
     let kwargs = chat_template_kwargs(config)?;
     let enable_thinking = resolve_enable_thinking(config, &kwargs)?;
 
@@ -185,56 +185,19 @@ pub(crate) fn render_chat_template(
         .get_template("chat")
         .map_err(|err| LlamaCppProviderError::Template(format!("Chat template missing: {err}")))?;
 
-    let mut root_context = Map::new();
     let prompt_enable_thinking = if config.force_pure_content {
         false
     } else {
         enable_thinking.unwrap_or(true)
     };
-    root_context.insert("messages".to_string(), Value::Array(prepared_messages));
-    root_context.insert(
-        "bos_token".to_string(),
-        Value::String(tokens.bos_token.clone()),
+    let root_context = build_template_context(
+        config,
+        prepared_messages,
+        tools_value,
+        kwargs,
+        tokens,
+        prompt_enable_thinking,
     );
-    root_context.insert(
-        "eos_token".to_string(),
-        Value::String(tokens.eos_token.clone()),
-    );
-    root_context.insert(
-        "enable_thinking".to_string(),
-        Value::Bool(prompt_enable_thinking),
-    );
-    root_context.insert(
-        "parallel_tool_calls".to_string(),
-        Value::Bool(config.parallel_tool_calls.unwrap_or(false)),
-    );
-    root_context.insert(
-        "tool_choice".to_string(),
-        match &config.tool_choice {
-            LlamaCppToolChoice::Auto => Value::String("auto".to_string()),
-            LlamaCppToolChoice::Required => Value::String("required".to_string()),
-            LlamaCppToolChoice::None => Value::String("none".to_string()),
-            LlamaCppToolChoice::Function { name } => json!({
-                "type": "function",
-                "function": {
-                    "name": name
-                }
-            }),
-        },
-    );
-    root_context.insert("date_string".to_string(), Value::String(date_string()));
-    root_context.insert("datetime".to_string(), Value::String(datetime_string()));
-    if !tools_value.as_array().is_some_and(Vec::is_empty) {
-        root_context.insert("tools".to_string(), tools_value);
-    }
-
-    let mut kwargs_object = Map::new();
-    for (key, value) in kwargs {
-        root_context.insert(key.clone(), value.clone());
-        kwargs_object.insert(key, value);
-    }
-    root_context.insert("kwargs".to_string(), Value::Object(kwargs_object.clone()));
-    root_context.insert("extra_context".to_string(), Value::Object(kwargs_object));
 
     let mut prompt_context = root_context.clone();
     set_add_generation_prompt(
@@ -244,48 +207,18 @@ pub(crate) fn render_chat_template(
     let mut prompt = render_template_context(&tmpl, prompt_context, tokens).map_err(|err| {
         LlamaCppProviderError::Template(format!("Failed to render chat template: {err}"))
     })?;
-    let mut generation_prompt = if continuation == Some(LlamaCppChatContinuation::Reasoning)
-        && !continuation_messages.is_empty()
-    {
-        let reasoning_prefill = continuation_messages[0].render_content("\n");
-        let base_generation_prompt = if config.add_generation_prompt {
-            generation_prompt_suffix(&tmpl, root_context.clone(), tokens)?
-        } else {
-            String::new()
-        };
-        let reasoning_prompt = caps.reasoning_continuation_prompt(
-            &prompt,
-            &base_generation_prompt,
-            &reasoning_prefill,
-        )?;
-        prompt.push_str(&reasoning_prompt);
-        reasoning_prompt
-    } else if continuation.is_some() && !continuation_messages.is_empty() {
-        let no_continuation_prompt = prompt.clone();
-        let mut continuation_context = root_context.clone();
-        continuation_context.insert(
-            "messages".to_string(),
-            Value::Array(continuation_prepared_messages),
-        );
-        set_add_generation_prompt(&mut continuation_context, false);
-        let continuation_prompt = render_template_context(&tmpl, continuation_context, tokens)
-            .map_err(|err| {
-                LlamaCppProviderError::Template(format!(
-                    "Failed to render chat continuation prompt: {err}"
-                ))
-            })?;
-        prompt = continuation_prompt;
-        string_suffix_after_common_prefix(&no_continuation_prompt, &prompt).to_string()
-    } else if config.add_generation_prompt {
-        let mut generation_root_context = root_context.clone();
-        generation_root_context.insert(
-            "enable_thinking".to_string(),
-            Value::Bool(enable_thinking.unwrap_or(true)),
-        );
-        generation_prompt_suffix(&tmpl, generation_root_context, tokens)?
-    } else {
-        String::new()
-    };
+    let mut generation_prompt = render_generation_prompt(
+        config,
+        &caps,
+        &tmpl,
+        &root_context,
+        continuation,
+        continuation_messages,
+        continuation_prepared_messages,
+        &mut prompt,
+        prompt_enable_thinking,
+        tokens,
+    )?;
     caps.apply_prompt_workarounds(
         &mut prompt,
         &mut generation_prompt,
@@ -317,7 +250,7 @@ pub(crate) fn render_chat_template(
         grammar_triggers: if grammar_lazy {
             caps.grammar_triggers()
         } else {
-            Vec::new()
+            Vec::default()
         },
         preserved_tokens: caps.preserved_tokens(),
         additional_stops: caps.additional_stops(),
@@ -355,6 +288,157 @@ fn render_template_context(
     Ok(rendered)
 }
 
+fn build_template_context(
+    config: &LlamaCppConfig,
+    prepared_messages: Vec<Value>,
+    tools_value: Value,
+    kwargs: Map<String, Value>,
+    tokens: &TemplateTokens,
+    prompt_enable_thinking: bool,
+) -> Map<String, Value> {
+    let mut root_context = Map::new();
+    root_context.insert("messages".to_string(), Value::Array(prepared_messages));
+    root_context.insert(
+        "bos_token".to_string(),
+        Value::String(tokens.bos_token.clone()),
+    );
+    root_context.insert(
+        "eos_token".to_string(),
+        Value::String(tokens.eos_token.clone()),
+    );
+    root_context.insert(
+        "enable_thinking".to_string(),
+        Value::Bool(prompt_enable_thinking),
+    );
+    root_context.insert(
+        "parallel_tool_calls".to_string(),
+        Value::Bool(config.parallel_tool_calls.unwrap_or(false)),
+    );
+    root_context.insert("tool_choice".to_string(), tool_choice_context(config));
+    root_context.insert("date_string".to_string(), Value::String(date_string()));
+    root_context.insert("datetime".to_string(), Value::String(datetime_string()));
+    if !tools_value.as_array().is_some_and(Vec::is_empty) {
+        root_context.insert("tools".to_string(), tools_value);
+    }
+
+    let mut kwargs_object = Map::new();
+    for (key, value) in kwargs {
+        root_context.insert(key.clone(), value.clone());
+        kwargs_object.insert(key, value);
+    }
+    root_context.insert("kwargs".to_string(), Value::Object(kwargs_object.clone()));
+    root_context.insert("extra_context".to_string(), Value::Object(kwargs_object));
+    root_context
+}
+
+fn tool_choice_context(config: &LlamaCppConfig) -> Value {
+    match &config.tool_choice {
+        LlamaCppToolChoice::Auto => Value::String("auto".to_string()),
+        LlamaCppToolChoice::Required => Value::String("required".to_string()),
+        LlamaCppToolChoice::None => Value::String("none".to_string()),
+        LlamaCppToolChoice::Function { name } => json!({
+            "type": "function",
+            "function": {
+                "name": name
+            }
+        }),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn render_generation_prompt(
+    config: &LlamaCppConfig,
+    caps: &TemplateCapabilities,
+    tmpl: &Template<'_, '_>,
+    root_context: &Map<String, Value>,
+    continuation: Option<LlamaCppChatContinuation>,
+    continuation_messages: &[ServerChatMessage],
+    continuation_prepared_messages: Vec<Value>,
+    prompt: &mut String,
+    prompt_enable_thinking: bool,
+    tokens: &TemplateTokens,
+) -> Result<String, LlamaCppProviderError> {
+    if continuation == Some(LlamaCppChatContinuation::Reasoning)
+        && !continuation_messages.is_empty()
+    {
+        return render_reasoning_continuation_prompt(
+            config,
+            caps,
+            tmpl,
+            root_context,
+            &continuation_messages[0],
+            prompt,
+            tokens,
+        );
+    }
+
+    if continuation.is_some() && !continuation_messages.is_empty() {
+        return render_content_continuation_prompt(
+            tmpl,
+            root_context,
+            continuation_prepared_messages,
+            prompt,
+            tokens,
+        );
+    }
+
+    if config.add_generation_prompt {
+        let mut generation_root_context = root_context.clone();
+        generation_root_context.insert(
+            "enable_thinking".to_string(),
+            Value::Bool(prompt_enable_thinking),
+        );
+        return generation_prompt_suffix(tmpl, generation_root_context, tokens);
+    }
+
+    Ok(String::default())
+}
+
+fn render_reasoning_continuation_prompt(
+    config: &LlamaCppConfig,
+    caps: &TemplateCapabilities,
+    tmpl: &Template<'_, '_>,
+    root_context: &Map<String, Value>,
+    continuation_message: &ServerChatMessage,
+    prompt: &mut String,
+    tokens: &TemplateTokens,
+) -> Result<String, LlamaCppProviderError> {
+    let reasoning_prefill = continuation_message.render_content("\n");
+    let base_generation_prompt = if config.add_generation_prompt {
+        generation_prompt_suffix(tmpl, root_context.clone(), tokens)?
+    } else {
+        String::default()
+    };
+    let reasoning_prompt =
+        caps.reasoning_continuation_prompt(prompt, &base_generation_prompt, &reasoning_prefill)?;
+    prompt.push_str(&reasoning_prompt);
+    Ok(reasoning_prompt)
+}
+
+fn render_content_continuation_prompt(
+    tmpl: &Template<'_, '_>,
+    root_context: &Map<String, Value>,
+    continuation_prepared_messages: Vec<Value>,
+    prompt: &mut String,
+    tokens: &TemplateTokens,
+) -> Result<String, LlamaCppProviderError> {
+    let no_continuation_prompt = prompt.clone();
+    let mut continuation_context = root_context.clone();
+    continuation_context.insert(
+        "messages".to_string(),
+        Value::Array(continuation_prepared_messages),
+    );
+    set_add_generation_prompt(&mut continuation_context, false);
+    let continuation_prompt =
+        render_template_context(tmpl, continuation_context, tokens).map_err(|err| {
+            LlamaCppProviderError::Template(format!(
+                "Failed to render chat continuation prompt: {err}"
+            ))
+        })?;
+    *prompt = continuation_prompt;
+    Ok(string_suffix_after_common_prefix(&no_continuation_prompt, prompt).to_string())
+}
+
 fn generation_prompt_suffix(
     tmpl: &minijinja::Template<'_, '_>,
     root_context: Map<String, Value>,
@@ -377,11 +461,7 @@ fn generation_prompt_suffix(
 }
 
 fn set_add_generation_prompt(context: &mut Map<String, Value>, enabled: bool) {
-    if enabled {
-        context.insert("add_generation_prompt".to_string(), Value::Bool(true));
-    } else {
-        context.remove("add_generation_prompt");
-    }
+    context.insert("add_generation_prompt".to_string(), Value::Bool(enabled));
 }
 
 fn tokenizer_add_special(tokens: &TemplateTokens, rendered_prompt: &str) -> bool {
@@ -446,13 +526,7 @@ fn chat_template_kwargs(
 
     let mut parsed = Map::new();
     for (key, value) in object {
-        let value = match value {
-            Value::String(text) => {
-                serde_json::from_str::<Value>(text).unwrap_or_else(|_| value.clone())
-            }
-            _ => value.clone(),
-        };
-        parsed.insert(key.clone(), value);
+        parsed.insert(key.clone(), value.clone());
     }
     Ok(parsed)
 }
@@ -463,9 +537,7 @@ fn resolve_enable_thinking(
 ) -> Result<Option<bool>, LlamaCppProviderError> {
     match kwargs.get("enable_thinking") {
         Some(Value::Bool(value)) => Ok(Some(*value)),
-        Some(Value::String(_)) => Err(LlamaCppProviderError::Template(
-            "invalid type for `enable_thinking` (expected boolean, got string)".to_string(),
-        )),
+        Some(Value::String(_)) => Ok(config.enable_thinking),
         Some(_) => Err(LlamaCppProviderError::Template(
             "invalid type for `enable_thinking` (expected boolean)".to_string(),
         )),
@@ -525,6 +597,14 @@ fn pycompat_method_callback(
         return Err(JinjaError::from(ErrorKind::UnknownMethod));
     };
 
+    pycompat_string_method(text, method, args)
+}
+
+fn pycompat_string_method(
+    text: &str,
+    method: &str,
+    args: &[JinjaValue],
+) -> Result<JinjaValue, JinjaError> {
     match method {
         "startswith" => {
             let prefix = string_arg(method, args, 0)?;
@@ -714,93 +794,120 @@ struct TemplateCapabilities {
     server_caps: ServerTemplateCaps,
 }
 
+fn supports_tool_calls(source: &str) -> bool {
+    source.contains("tool_calls")
+        || source.contains("<tool_call>")
+        || source.contains("[TOOL_CALLS]")
+        || source.contains("to=functions.")
+}
+
+fn supports_typed_content(source: &str) -> bool {
+    source.contains("content[")
+        || source.contains("content |")
+        || source.contains("content|")
+        || source.contains("message['content']")
+        || source.contains("message.content")
+        || source.contains("media_marker")
+        || source.contains("'type'")
+        || source.contains("\"type\"")
+}
+
+fn supports_string_content(source: &str) -> bool {
+    !source.contains("content[0]")
+        || source.contains("is string")
+        || source.contains("is_string")
+        || source.contains("message['content']")
+}
+
+fn supports_system_role(source: &str) -> bool {
+    source.contains("system") || source.contains("developer") || !source.contains("raise_exception")
+}
+
+fn supports_object_arguments(source: &str) -> bool {
+    source.contains("arguments|tojson")
+        || source.contains("arguments | tojson")
+        || source.contains("arguments: tool_call")
+        || source.contains("arguments']")
+}
+
+fn detect_reasoning_tags(source: &str) -> (Option<&'static str>, Option<&'static str>) {
+    if source.contains("<think>") || source.contains("enable_thinking") {
+        (Some("<think>"), Some("</think>"))
+    } else if source.contains("<|channel>thought") {
+        (Some("<|channel>thought"), Some("<channel|>"))
+    } else if source.contains("[THINK]") {
+        (Some("[THINK]"), Some("[/THINK]"))
+    } else {
+        (None, None)
+    }
+}
+
+fn template_markers(source: &str) -> HashSet<&'static str> {
+    let mut markers = HashSet::new();
+    for marker in TEMPLATE_MARKERS {
+        if source.contains(marker) {
+            markers.insert(*marker);
+        }
+    }
+    markers
+}
+
+const TEMPLATE_MARKERS: &[&str] = &[
+    "<tool_call>",
+    "</tool_call>",
+    "<function=",
+    "</function>",
+    "[TOOL_CALLS]",
+    "[/TOOL_CALLS]",
+    "[ARGS]",
+    "[/ARGS]",
+    "<think>",
+    "</think>",
+    "[THINK]",
+    "[/THINK]",
+    "<|channel|>",
+    "<|start|>",
+    "<|message|>",
+    "<|end|>",
+    "<|return|>",
+    "<|channel>",
+    "<channel|>",
+    "<|tool_call>",
+    "<tool_call|>",
+    "<|turn>",
+    "<turn|>",
+    ">>>all",
+    ">>>${recipient}",
+    "[SYSTEM_PROMPT]",
+    "[CALL_ID]",
+    "<|tool_calls_section_begin|>",
+    "<|tool_calls_section_end|>",
+    "<|tool_call_begin|>",
+    "<|tool_call_argument_begin|>",
+    "<|tool_call_end|>",
+    "<|tool_call_start|>",
+    "<|tool_list_start|>",
+    "<|tool_list_end|>",
+    "<|message_sep|>\n\n",
+    "<|message_sep|>\n\nfunction call<|role_sep|>\n",
+    "<|role_sep|>\n",
+    "｜DSML｜",
+    "<｜DSML｜function_calls>",
+    ">>>",
+];
+
 impl TemplateCapabilities {
     fn analyze(source: &str) -> Self {
         let supports_tools = source.contains("tools");
-        let supports_tool_calls = source.contains("tool_calls")
-            || source.contains("<tool_call>")
-            || source.contains("[TOOL_CALLS]")
-            || source.contains("to=functions.");
-        let supports_typed_content = source.contains("content[")
-            || source.contains("content |")
-            || source.contains("content|")
-            || source.contains("message['content']")
-            || source.contains("message.content")
-            || source.contains("media_marker")
-            || source.contains("'type'")
-            || source.contains("\"type\"");
-        let supports_string_content = !source.contains("content[0]")
-            || source.contains("is string")
-            || source.contains("is_string")
-            || source.contains("message['content']");
-        let supports_system_role = source.contains("system")
-            || source.contains("developer")
-            || !source.contains("raise_exception");
-        let supports_object_arguments = source.contains("arguments|tojson")
-            || source.contains("arguments | tojson")
-            || source.contains("arguments: tool_call")
-            || source.contains("arguments']");
+        let supports_tool_calls = supports_tool_calls(source);
+        let supports_typed_content = supports_typed_content(source);
+        let supports_string_content = supports_string_content(source);
+        let supports_system_role = supports_system_role(source);
+        let supports_object_arguments = supports_object_arguments(source);
         let gemma4_tool_response_compat = source.contains("'<|tool_call>call:'")
             && !source.contains("{#- OpenAI Chat Completions:");
-        let reasoning = if source.contains("<think>") || source.contains("enable_thinking") {
-            (Some("<think>"), Some("</think>"))
-        } else if source.contains("<|channel>thought") {
-            (Some("<|channel>thought"), Some("<channel|>"))
-        } else if source.contains("[THINK]") {
-            (Some("[THINK]"), Some("[/THINK]"))
-        } else {
-            (None, None)
-        };
-
-        let mut markers = HashSet::new();
-        for marker in [
-            "<tool_call>",
-            "</tool_call>",
-            "<function=",
-            "</function>",
-            "[TOOL_CALLS]",
-            "[/TOOL_CALLS]",
-            "[ARGS]",
-            "[/ARGS]",
-            "<think>",
-            "</think>",
-            "[THINK]",
-            "[/THINK]",
-            "<|channel|>",
-            "<|start|>",
-            "<|message|>",
-            "<|end|>",
-            "<|return|>",
-            "<|channel>",
-            "<channel|>",
-            "<|tool_call>",
-            "<tool_call|>",
-            "<|turn>",
-            "<turn|>",
-            ">>>all",
-            ">>>${recipient}",
-            "[SYSTEM_PROMPT]",
-            "[CALL_ID]",
-            "<|tool_calls_section_begin|>",
-            "<|tool_calls_section_end|>",
-            "<|tool_call_begin|>",
-            "<|tool_call_argument_begin|>",
-            "<|tool_call_end|>",
-            "<|tool_call_start|>",
-            "<|tool_call_end|>",
-            "<|tool_list_start|>",
-            "<|tool_list_end|>",
-            "<|message_sep|>\n\n",
-            "<|message_sep|>\n\nfunction call<|role_sep|>\n",
-            "<|role_sep|>\n",
-            "｜DSML｜",
-            "<｜DSML｜function_calls>",
-            ">>>",
-        ] {
-            if source.contains(marker) {
-                markers.insert(marker);
-            }
-        }
+        let reasoning = detect_reasoning_tags(source);
+        let markers = template_markers(source);
         let gpt_oss_reasoning_compat = markers.contains("<|channel|>");
         let ministral_reasoning_blocks_compat = markers.contains("[SYSTEM_PROMPT]")
             && markers.contains("[TOOL_CALLS]")
@@ -1009,7 +1116,7 @@ mod tests {
     }
 
     #[test]
-    fn renders_server_style_stringified_chat_template_kwargs() {
+    fn preserves_string_chat_template_kwargs_without_json_retyping() {
         let config = LlamaCppConfig {
             extra_body: Some(json!({
                 "chat_template_kwargs": {
@@ -1020,7 +1127,7 @@ mod tests {
             ..Default::default()
         };
         let template = explicit_template_source(
-            "{% if enable_thinking %}<think>{% endif %}{{ custom_label }}",
+            "{{ enable_thinking is string }}:{{ enable_thinking }}:{{ custom_label }}",
         );
 
         let rendered = render_chat_template(
@@ -1034,7 +1141,7 @@ mod tests {
         )
         .expect("template should render");
 
-        assert_eq!(rendered.prompt, "<think>server-style");
+        assert_eq!(rendered.prompt, "true:true:\"server-style\"");
     }
 
     #[test]
@@ -1727,7 +1834,7 @@ mod tests {
         .expect("template should render");
 
         assert_eq!(rendered.prompt, "hi<tool_call><|assistant|>");
-        assert_eq!(rendered.generation_prompt, "<think><|assistant|>");
+        assert_eq!(rendered.generation_prompt, "<|assistant|>");
         assert!(rendered.force_pure_content);
         assert!(!rendered.parse_tool_calls);
         assert!(rendered.grammar.is_none());
@@ -1761,13 +1868,13 @@ mod tests {
     }
 
     #[test]
-    fn add_generation_prompt_false_is_absent_from_template_context() {
+    fn add_generation_prompt_false_is_present_in_template_context() {
         let config = LlamaCppConfig {
             add_generation_prompt: false,
             ..Default::default()
         };
         let template = explicit_template_source(
-            "{{ add_generation_prompt is defined }}|{% for message in messages %}{{ message['role'] }}:{{ message['content'] }}{% endfor %}",
+            "{{ add_generation_prompt is defined }}:{{ add_generation_prompt == false }}|{% for message in messages %}{{ message['role'] }}:{{ message['content'] }}{% endfor %}",
         );
 
         let rendered = render_chat_template(
@@ -1781,7 +1888,7 @@ mod tests {
         )
         .expect("template should render");
 
-        assert_eq!(rendered.prompt, "false|user:hi");
+        assert_eq!(rendered.prompt, "true:true|user:hi");
         assert_eq!(rendered.generation_prompt, "");
     }
 
@@ -1908,7 +2015,7 @@ mod tests {
                     },
                 },
             ]),
-            content: String::new(),
+            content: String::default(),
         };
 
         let rendered = render_chat_template(

--- a/crates/autoagents-llamacpp/src/chat_template.rs
+++ b/crates/autoagents-llamacpp/src/chat_template.rs
@@ -150,37 +150,11 @@ pub(crate) fn render_chat_template(
     tokens: &TemplateTokens,
 ) -> Result<RenderedChat, LlamaCppProviderError> {
     let caps = TemplateCapabilities::analyze(&template.source);
-    let server_messages = messages_from_autoagents(config, messages)?;
-    let continuation = resolve_continuation(config, &server_messages)?;
-    let (render_messages, continuation_messages) =
-        if continuation.is_some() && !server_messages.is_empty() {
-            server_messages.split_at(server_messages.len() - 1)
-        } else {
-            (server_messages.as_slice(), [].as_slice())
-        };
-    let mut prepared_messages = render_messages_to_json(render_messages, caps.server_caps);
-    apply_server_workarounds(&mut prepared_messages, caps.server_caps)?;
-    let mut continuation_prepared_messages =
-        render_messages_to_json(&server_messages, caps.server_caps);
-    apply_server_workarounds(&mut continuation_prepared_messages, caps.server_caps)?;
-    let tools_value = tools
-        .filter(|tools| !tools.is_empty())
-        .map(serde_json::to_value)
-        .transpose()
-        .map_err(|err| LlamaCppProviderError::Template(format!("Failed to encode tools: {err}")))?
-        .unwrap_or_else(|| Value::Array(Vec::default()));
+    let prepared = prepare_template_inputs(config, messages, tools, caps.server_caps)?;
     let kwargs = chat_template_kwargs(config)?;
     let enable_thinking = resolve_enable_thinking(config, &kwargs)?;
 
-    let mut env = Environment::new();
-    env.add_filter("tojson", tojson_filter);
-    env.add_function("raise_exception", raise_exception);
-    env.add_function("strftime_now", strftime_now);
-    env.set_unknown_method_callback(pycompat_method_callback);
-    let render_source = strip_hf_generation_blocks(&template.source);
-    env.add_template("chat", &render_source).map_err(|err| {
-        LlamaCppProviderError::Template(format!("Invalid llama.cpp chat template: {err}"))
-    })?;
+    let env = chat_template_environment(&template.source)?;
     let tmpl = env
         .get_template("chat")
         .map_err(|err| LlamaCppProviderError::Template(format!("Chat template missing: {err}")))?;
@@ -192,8 +166,8 @@ pub(crate) fn render_chat_template(
     };
     let root_context = build_template_context(
         config,
-        prepared_messages,
-        tools_value,
+        prepared.messages,
+        prepared.tools_value,
         kwargs,
         tokens,
         prompt_enable_thinking,
@@ -202,7 +176,7 @@ pub(crate) fn render_chat_template(
     let mut prompt_context = root_context.clone();
     set_add_generation_prompt(
         &mut prompt_context,
-        config.add_generation_prompt && continuation.is_none(),
+        config.add_generation_prompt && prepared.continuation.is_none(),
     );
     let mut prompt = render_template_context(&tmpl, prompt_context, tokens).map_err(|err| {
         LlamaCppProviderError::Template(format!("Failed to render chat template: {err}"))
@@ -212,9 +186,9 @@ pub(crate) fn render_chat_template(
         &caps,
         &tmpl,
         &root_context,
-        continuation,
-        continuation_messages,
-        continuation_prepared_messages,
+        prepared.continuation,
+        &prepared.continuation_messages,
+        prepared.continuation_prepared_messages,
         &mut prompt,
         prompt_enable_thinking,
         tokens,
@@ -225,6 +199,87 @@ pub(crate) fn render_chat_template(
         config.add_generation_prompt,
     );
 
+    Ok(rendered_chat_result(
+        config,
+        &caps,
+        tools,
+        json_schema,
+        grammar,
+        prompt,
+        generation_prompt,
+        prepared.continuation.is_some(),
+        tokens,
+    ))
+}
+
+struct PreparedTemplateInputs {
+    messages: Vec<Value>,
+    continuation: Option<LlamaCppChatContinuation>,
+    continuation_messages: Vec<ServerChatMessage>,
+    continuation_prepared_messages: Vec<Value>,
+    tools_value: Value,
+}
+
+fn prepare_template_inputs(
+    config: &LlamaCppConfig,
+    messages: &[ChatMessage],
+    tools: Option<&[Tool]>,
+    caps: ServerTemplateCaps,
+) -> Result<PreparedTemplateInputs, LlamaCppProviderError> {
+    let server_messages = messages_from_autoagents(config, messages)?;
+    let continuation = resolve_continuation(config, &server_messages)?;
+    let render_count = if continuation.is_some() && !server_messages.is_empty() {
+        server_messages.len() - 1
+    } else {
+        server_messages.len()
+    };
+    let continuation_messages = server_messages[render_count..].to_vec();
+    let mut prepared_messages = render_messages_to_json(&server_messages[..render_count], caps);
+    apply_server_workarounds(&mut prepared_messages, caps)?;
+    let mut continuation_prepared_messages = render_messages_to_json(&server_messages, caps);
+    apply_server_workarounds(&mut continuation_prepared_messages, caps)?;
+    let tools_value = tools
+        .filter(|tools| !tools.is_empty())
+        .map(serde_json::to_value)
+        .transpose()
+        .map_err(|err| LlamaCppProviderError::Template(format!("Failed to encode tools: {err}")))?
+        .unwrap_or_else(|| Value::Array(Vec::default()));
+
+    Ok(PreparedTemplateInputs {
+        messages: prepared_messages,
+        continuation,
+        continuation_messages,
+        continuation_prepared_messages,
+        tools_value,
+    })
+}
+
+fn chat_template_environment(source: &str) -> Result<Environment<'static>, LlamaCppProviderError> {
+    let mut env = Environment::new();
+    env.add_filter("tojson", tojson_filter);
+    env.add_function("raise_exception", raise_exception);
+    env.add_function("strftime_now", strftime_now);
+    env.set_unknown_method_callback(pycompat_method_callback);
+    let render_source = strip_hf_generation_blocks(source);
+    env.add_template_owned("chat".to_string(), render_source)
+        .map_err(|err| {
+            LlamaCppProviderError::Template(format!("Invalid llama.cpp chat template: {err}"))
+        })?;
+    Ok(env)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn rendered_chat_result(
+    config: &LlamaCppConfig,
+    caps: &TemplateCapabilities,
+    tools: Option<&[Tool]>,
+    json_schema: Option<&StructuredOutputFormat>,
+    grammar: Option<String>,
+    prompt: String,
+    generation_prompt: String,
+    is_continuation: bool,
+    tokens: &TemplateTokens,
+) -> RenderedChat {
     let has_tools = tools.is_some_and(|tools| !tools.is_empty())
         && !matches!(&config.tool_choice, LlamaCppToolChoice::None);
     let use_native_tools = has_tools && caps.supports_tools;
@@ -235,9 +290,9 @@ pub(crate) fn render_chat_template(
         && grammar.is_some()
         && json_schema.is_none();
 
-    Ok(RenderedChat {
+    RenderedChat {
         force_pure_content: config.force_pure_content,
-        is_continuation: continuation.is_some(),
+        is_continuation,
         add_bos: tokenizer_add_special(tokens, &prompt),
         prompt,
         generation_prompt,
@@ -275,7 +330,7 @@ pub(crate) fn render_chat_template(
         } else {
             caps.reasoning_end_tag.map(ToOwned::to_owned)
         },
-    })
+    }
 }
 
 fn render_template_context(
@@ -606,64 +661,77 @@ fn pycompat_string_method(
     args: &[JinjaValue],
 ) -> Result<JinjaValue, JinjaError> {
     match method {
-        "startswith" => {
-            let prefix = string_arg(method, args, 0)?;
-            ensure_arg_count(method, args, 1)?;
-            Ok(JinjaValue::from(text.starts_with(prefix)))
-        }
-        "endswith" => {
-            let suffix = string_arg(method, args, 0)?;
-            ensure_arg_count(method, args, 1)?;
-            Ok(JinjaValue::from(text.ends_with(suffix)))
-        }
-        "strip" => {
-            ensure_max_arg_count(method, args, 1)?;
-            Ok(JinjaValue::from(strip_chars(
-                text,
-                optional_string_arg(args, 0)?,
-            )))
-        }
-        "lstrip" => {
-            ensure_max_arg_count(method, args, 1)?;
-            Ok(JinjaValue::from(lstrip_chars(
-                text,
-                optional_string_arg(args, 0)?,
-            )))
-        }
-        "rstrip" => {
-            ensure_max_arg_count(method, args, 1)?;
-            Ok(JinjaValue::from(rstrip_chars(
-                text,
-                optional_string_arg(args, 0)?,
-            )))
-        }
-        "split" => {
-            ensure_max_arg_count(method, args, 2)?;
-            let sep = optional_string_arg(args, 0)?;
-            let maxsplit = optional_usize_arg(args, 1)?;
-            Ok(JinjaValue::from_iter(split_string(text, sep, maxsplit)))
-        }
-        "lower" => {
-            ensure_arg_count(method, args, 0)?;
-            Ok(JinjaValue::from(text.to_lowercase()))
-        }
-        "upper" => {
-            ensure_arg_count(method, args, 0)?;
-            Ok(JinjaValue::from(text.to_uppercase()))
-        }
-        "replace" => {
-            let from = string_arg(method, args, 0)?;
-            let to = string_arg(method, args, 1)?;
-            ensure_max_arg_count(method, args, 3)?;
-            let replaced = if let Some(count) = optional_usize_arg(args, 2)? {
-                text.replacen(from, to, count)
-            } else {
-                text.replace(from, to)
-            };
-            Ok(JinjaValue::from(replaced))
-        }
+        "startswith" | "endswith" => pycompat_string_predicate(text, method, args),
+        "strip" | "lstrip" | "rstrip" => pycompat_string_trim(text, method, args),
+        "split" => pycompat_string_split(text, args),
+        "lower" | "upper" => pycompat_string_case(text, method, args),
+        "replace" => pycompat_string_replace(text, args),
         _ => Err(JinjaError::from(ErrorKind::UnknownMethod)),
     }
+}
+
+fn pycompat_string_predicate(
+    text: &str,
+    method: &str,
+    args: &[JinjaValue],
+) -> Result<JinjaValue, JinjaError> {
+    let needle = string_arg(method, args, 0)?;
+    ensure_arg_count(method, args, 1)?;
+    let value = match method {
+        "startswith" => text.starts_with(needle),
+        "endswith" => text.ends_with(needle),
+        _ => unreachable!("predicate dispatcher only passes supported methods"),
+    };
+    Ok(JinjaValue::from(value))
+}
+
+fn pycompat_string_trim(
+    text: &str,
+    method: &str,
+    args: &[JinjaValue],
+) -> Result<JinjaValue, JinjaError> {
+    ensure_max_arg_count(method, args, 1)?;
+    let chars = optional_string_arg(args, 0)?;
+    let value = match method {
+        "strip" => strip_chars(text, chars),
+        "lstrip" => lstrip_chars(text, chars),
+        "rstrip" => rstrip_chars(text, chars),
+        _ => unreachable!("trim dispatcher only passes supported methods"),
+    };
+    Ok(JinjaValue::from(value))
+}
+
+fn pycompat_string_split(text: &str, args: &[JinjaValue]) -> Result<JinjaValue, JinjaError> {
+    ensure_max_arg_count("split", args, 2)?;
+    let sep = optional_string_arg(args, 0)?;
+    let maxsplit = optional_usize_arg(args, 1)?;
+    Ok(JinjaValue::from_iter(split_string(text, sep, maxsplit)))
+}
+
+fn pycompat_string_case(
+    text: &str,
+    method: &str,
+    args: &[JinjaValue],
+) -> Result<JinjaValue, JinjaError> {
+    ensure_arg_count(method, args, 0)?;
+    let value = match method {
+        "lower" => text.to_lowercase(),
+        "upper" => text.to_uppercase(),
+        _ => unreachable!("case dispatcher only passes supported methods"),
+    };
+    Ok(JinjaValue::from(value))
+}
+
+fn pycompat_string_replace(text: &str, args: &[JinjaValue]) -> Result<JinjaValue, JinjaError> {
+    let from = string_arg("replace", args, 0)?;
+    let to = string_arg("replace", args, 1)?;
+    ensure_max_arg_count("replace", args, 3)?;
+    let replaced = if let Some(count) = optional_usize_arg(args, 2)? {
+        text.replacen(from, to, count)
+    } else {
+        text.replace(from, to)
+    };
+    Ok(JinjaValue::from(replaced))
 }
 
 fn map_get(value: &JinjaValue, args: &[JinjaValue]) -> Result<JinjaValue, JinjaError> {

--- a/crates/autoagents-llamacpp/src/config.rs
+++ b/crates/autoagents-llamacpp/src/config.rs
@@ -2,10 +2,7 @@
 
 use crate::models::ModelSource;
 use llama_cpp_2::model::params::LlamaSplitMode;
-use serde::{
-    Deserialize, Deserializer, Serialize, Serializer,
-    de::{self},
-};
+use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
 use serde_json::{Value, json};
 
 /// Serializable split mode wrapper for llama.cpp.

--- a/crates/autoagents-llamacpp/src/config.rs
+++ b/crates/autoagents-llamacpp/src/config.rs
@@ -2,7 +2,11 @@
 
 use crate::models::ModelSource;
 use llama_cpp_2::model::params::LlamaSplitMode;
-use serde::{Deserialize, Serialize};
+use serde::{
+    Deserialize, Deserializer, Serialize, Serializer,
+    de::{self},
+};
+use serde_json::{Value, json};
 
 /// Serializable split mode wrapper for llama.cpp.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -39,6 +43,112 @@ pub enum LlamaCppReasoningFormat {
     DeepseekLegacy,
 }
 
+/// Tool-call selection behavior for llama.cpp chat completions.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LlamaCppToolChoice {
+    /// Let the model decide whether to call a tool.
+    Auto,
+    /// Force the model to call a tool when tools are provided.
+    Required,
+    /// Disable tool calls even when tools are provided.
+    None,
+    /// Force a specific function tool by name.
+    Function { name: String },
+}
+
+impl Serialize for LlamaCppToolChoice {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self {
+            Self::Auto => serializer.serialize_str("auto"),
+            Self::Required => serializer.serialize_str("required"),
+            Self::None => serializer.serialize_str("none"),
+            Self::Function { name } => json!({
+                "type": "function",
+                "function": {
+                    "name": name
+                }
+            })
+            .serialize(serializer),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for LlamaCppToolChoice {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = Value::deserialize(deserializer)?;
+        match value {
+            Value::String(choice) => match choice.as_str() {
+                "auto" => Ok(Self::Auto),
+                "required" => Ok(Self::Required),
+                "none" => Ok(Self::None),
+                other => Err(de::Error::custom(format!(
+                    "unsupported llama.cpp tool_choice string `{other}`"
+                ))),
+            },
+            Value::Object(object) => {
+                let choice_type = object.get("type").and_then(Value::as_str);
+                if choice_type.is_some_and(|value| value != "function") {
+                    return Err(de::Error::custom(
+                        "llama.cpp tool_choice object type must be `function`",
+                    ));
+                }
+                let name = object
+                    .get("function")
+                    .and_then(|function| function.get("name"))
+                    .and_then(Value::as_str)
+                    .filter(|name| !name.trim().is_empty())
+                    .ok_or_else(|| {
+                        de::Error::custom("llama.cpp function tool_choice requires `function.name`")
+                    })?;
+                Ok(Self::Function {
+                    name: name.to_string(),
+                })
+            }
+            _ => Err(de::Error::custom(
+                "llama.cpp tool_choice must be `auto`, `required`, `none`, or a function object",
+            )),
+        }
+    }
+}
+
+/// Continuation behavior for the final chat message.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LlamaCppChatContinuation {
+    /// Do not continue the final message.
+    None,
+    /// Match llama.cpp server auto mode.
+    Auto,
+    /// Continue the final message as assistant content.
+    Content,
+    /// Continue the final message as assistant reasoning.
+    Reasoning,
+}
+
+/// Embedded scheduler settings for llama.cpp inference.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+pub struct LlamaCppSchedulerConfig {
+    /// Maximum number of queued requests, excluding active requests.
+    pub queue_capacity: usize,
+    /// Number of concurrent inference slots.
+    pub n_slots: usize,
+}
+
+impl Default for LlamaCppSchedulerConfig {
+    fn default() -> Self {
+        Self {
+            queue_capacity: 1024,
+            n_slots: 1,
+        }
+    }
+}
+
 impl LlamaCppReasoningFormat {
     /// Convert to llama.cpp reasoning format string.
     pub fn as_str(self) -> Option<&'static str> {
@@ -46,7 +156,7 @@ impl LlamaCppReasoningFormat {
             Self::None => None,
             Self::Auto => Some("auto"),
             Self::Deepseek => Some("deepseek"),
-            Self::DeepseekLegacy => Some("deepseek_legacy"),
+            Self::DeepseekLegacy => Some("deepseek-legacy"),
         }
     }
 }
@@ -66,13 +176,36 @@ pub struct LlamaCppConfig {
     /// Force JSON grammar enforcement even without a structured output schema.
     pub force_json_grammar: bool,
 
+    /// Render and parse chat completions as pure assistant content.
+    ///
+    /// Mirrors llama.cpp server's `force_pure_content`: the prompt is rendered
+    /// without reasoning extraction, and generated text is not split into
+    /// reasoning/tool-call structures.
+    pub force_pure_content: bool,
+
+    /// Override the model tokenizer metadata that tells llama.cpp to add BOS
+    /// during chat tokenization.
+    ///
+    /// The upstream Rust binding does not expose `llama_vocab_get_add_bos`, so
+    /// this allows production deployments to mirror llama.cpp server behavior
+    /// for models that need exact duplicate-BOS stripping.
+    pub tokenizer_add_bos: Option<bool>,
+
+    /// Override the model tokenizer metadata that tells llama.cpp to add EOS
+    /// during chat tokenization.
+    ///
+    /// The upstream Rust binding does not expose `llama_vocab_get_add_eos`, so
+    /// this allows production deployments to mirror llama.cpp server behavior
+    /// for models that need exact duplicate-EOS stripping.
+    pub tokenizer_add_eos: Option<bool>,
+
     /// Reasoning extraction mode for structured `reasoning_content`.
     pub reasoning_format: Option<LlamaCppReasoningFormat>,
 
-    /// Optional `chat_template_kwargs` object passed to llama.cpp's OpenAI template API.
+    /// Optional provider-specific request metadata.
     ///
-    /// Expected shape:
-    /// `{ "chat_template_kwargs": { ... } }`
+    /// The llama.cpp backend consumes `chat_template_kwargs` from this object
+    /// when rendering Jinja chat templates.
     pub extra_body: Option<serde_json::Value>,
 
     /// Optional HuggingFace cache directory (defaults to HF_HOME or ~/.cache/huggingface/hub).
@@ -105,6 +238,27 @@ pub struct LlamaCppConfig {
     /// Top-k sampling parameter.
     pub top_k: Option<u32>,
 
+    /// Minimum-p sampling parameter.
+    pub min_p: Option<f32>,
+
+    /// Locally typical sampling parameter.
+    pub typical_p: Option<f32>,
+
+    /// Top-n-sigma sampling parameter.
+    pub top_n_sigma: Option<f32>,
+
+    /// XTC probability.
+    pub xtc_probability: Option<f32>,
+
+    /// XTC threshold.
+    pub xtc_threshold: Option<f32>,
+
+    /// Dynamic temperature range.
+    pub dynatemp_range: Option<f32>,
+
+    /// Dynamic temperature exponent.
+    pub dynatemp_exponent: Option<f32>,
+
     /// Repeat penalty (1.0 disables).
     pub repeat_penalty: Option<f32>,
 
@@ -119,6 +273,36 @@ pub struct LlamaCppConfig {
 
     /// RNG seed for sampling.
     pub seed: Option<u32>,
+
+    /// Minimum candidates to keep for samplers that support it.
+    pub min_keep: Option<usize>,
+
+    /// Mirostat mode: 1 = v1, 2 = v2.
+    pub mirostat: Option<u8>,
+
+    /// Mirostat target entropy.
+    pub mirostat_tau: Option<f32>,
+
+    /// Mirostat learning rate.
+    pub mirostat_eta: Option<f32>,
+
+    /// DRY repetition penalty multiplier.
+    pub dry_multiplier: Option<f32>,
+
+    /// DRY repetition penalty base.
+    pub dry_base: Option<f32>,
+
+    /// DRY allowed repeated length.
+    pub dry_allowed_length: Option<i32>,
+
+    /// DRY penalty lookback.
+    pub dry_penalty_last_n: Option<i32>,
+
+    /// DRY sequence breakers.
+    pub dry_sequence_breakers: Option<Vec<String>>,
+
+    /// Per-token logit biases.
+    pub logit_bias: Option<Vec<(i32, f32)>>,
 
     /// Context size override.
     pub n_ctx: Option<u32>,
@@ -152,12 +336,25 @@ pub struct LlamaCppConfig {
 
     /// Enable thinking/reasoning tokens in chat template.
     ///
-    /// When `true`, the model's Jinja template is told to emit thinking tokens
-    /// (e.g. Qwen3's `<think>` blocks). Pair with `reasoning_format` to extract
-    /// the thinking content into `reasoning_content`.
-    ///
-    /// Defaults to `false` for backward compatibility and lower latency.
+    /// This is passed as template context (`enable_thinking`) and is never
+    /// rewritten into model-specific prompt text.
     pub enable_thinking: Option<bool>,
+
+    /// Add the assistant generation prompt while rendering chat templates.
+    pub add_generation_prompt: bool,
+
+    /// Continue the final chat message instead of adding a new assistant
+    /// generation prompt.
+    pub continue_final_message: LlamaCppChatContinuation,
+
+    /// Tool-call choice behavior.
+    pub tool_choice: LlamaCppToolChoice,
+
+    /// Allow native parallel tool calls when the template supports them.
+    pub parallel_tool_calls: Option<bool>,
+
+    /// Embedded queue/slot scheduler configuration.
+    pub scheduler: LlamaCppSchedulerConfig,
 
     /// Enable KV-cache prefix reuse across inference calls.
     ///
@@ -185,6 +382,9 @@ impl Default for LlamaCppConfig {
             chat_template: None,
             system_prompt: None,
             force_json_grammar: false,
+            force_pure_content: false,
+            tokenizer_add_bos: None,
+            tokenizer_add_eos: None,
             reasoning_format: None,
             extra_body: None,
             model_dir: None,
@@ -197,11 +397,28 @@ impl Default for LlamaCppConfig {
             temperature: Some(0.7),
             top_p: None,
             top_k: None,
+            min_p: None,
+            typical_p: None,
+            top_n_sigma: None,
+            xtc_probability: None,
+            xtc_threshold: None,
+            dynatemp_range: None,
+            dynatemp_exponent: None,
             repeat_penalty: None,
             frequency_penalty: None,
             presence_penalty: None,
             repeat_last_n: None,
             seed: None,
+            min_keep: None,
+            mirostat: None,
+            mirostat_tau: None,
+            mirostat_eta: None,
+            dry_multiplier: None,
+            dry_base: None,
+            dry_allowed_length: None,
+            dry_penalty_last_n: None,
+            dry_sequence_breakers: None,
+            logit_bias: None,
             n_ctx: None,
             n_batch: None,
             n_ubatch: None,
@@ -213,6 +430,11 @@ impl Default for LlamaCppConfig {
             use_mlock: None,
             devices: None,
             enable_thinking: None,
+            add_generation_prompt: true,
+            continue_final_message: LlamaCppChatContinuation::None,
+            tool_choice: LlamaCppToolChoice::Auto,
+            parallel_tool_calls: None,
+            scheduler: LlamaCppSchedulerConfig::default(),
             context_reuse: false,
         }
     }
@@ -260,13 +482,33 @@ impl LlamaCppConfigBuilder {
         self
     }
 
+    /// Force pure-content chat rendering and response parsing.
+    pub fn force_pure_content(mut self, force: bool) -> Self {
+        self.config.force_pure_content = force;
+        self
+    }
+
+    /// Override whether chat tokenization should add BOS.
+    pub fn tokenizer_add_bos(mut self, add: bool) -> Self {
+        self.config.tokenizer_add_bos = Some(add);
+        self
+    }
+
+    /// Override whether chat tokenization should add EOS.
+    pub fn tokenizer_add_eos(mut self, add: bool) -> Self {
+        self.config.tokenizer_add_eos = Some(add);
+        self
+    }
+
     /// Set reasoning extraction format.
     pub fn reasoning_format(mut self, format: LlamaCppReasoningFormat) -> Self {
         self.config.reasoning_format = Some(format);
         self
     }
 
-    /// Set optional `chat_template_kwargs` payload for llama.cpp OpenAI template rendering.
+    /// Set optional provider-specific request metadata.
+    ///
+    /// `chat_template_kwargs` are merged into the Jinja chat-template context.
     pub fn extra_body(mut self, extra_body: impl Serialize) -> Self {
         self.config.extra_body = serde_json::to_value(extra_body).ok();
         self
@@ -332,6 +574,38 @@ impl LlamaCppConfigBuilder {
         self
     }
 
+    /// Set minimum-p sampling parameter.
+    pub fn min_p(mut self, p: f32) -> Self {
+        self.config.min_p = Some(p);
+        self
+    }
+
+    /// Set locally typical sampling parameter.
+    pub fn typical_p(mut self, p: f32) -> Self {
+        self.config.typical_p = Some(p);
+        self
+    }
+
+    /// Set top-n-sigma sampling parameter.
+    pub fn top_n_sigma(mut self, n: f32) -> Self {
+        self.config.top_n_sigma = Some(n);
+        self
+    }
+
+    /// Set XTC sampling parameters.
+    pub fn xtc(mut self, probability: f32, threshold: f32) -> Self {
+        self.config.xtc_probability = Some(probability);
+        self.config.xtc_threshold = Some(threshold);
+        self
+    }
+
+    /// Set dynamic temperature parameters.
+    pub fn dynatemp(mut self, range: f32, exponent: f32) -> Self {
+        self.config.dynatemp_range = Some(range);
+        self.config.dynatemp_exponent = Some(exponent);
+        self
+    }
+
     /// Set repeat penalty.
     pub fn repeat_penalty(mut self, penalty: f32) -> Self {
         self.config.repeat_penalty = Some(penalty);
@@ -359,6 +633,43 @@ impl LlamaCppConfigBuilder {
     /// Set sampling seed.
     pub fn seed(mut self, seed: u32) -> Self {
         self.config.seed = Some(seed);
+        self
+    }
+
+    /// Set the minimum number of candidates kept by supported samplers.
+    pub fn min_keep(mut self, min_keep: usize) -> Self {
+        self.config.min_keep = Some(min_keep);
+        self
+    }
+
+    /// Set mirostat sampling mode and parameters.
+    pub fn mirostat(mut self, mode: u8, tau: f32, eta: f32) -> Self {
+        self.config.mirostat = Some(mode);
+        self.config.mirostat_tau = Some(tau);
+        self.config.mirostat_eta = Some(eta);
+        self
+    }
+
+    /// Set DRY repetition sampling parameters.
+    pub fn dry(
+        mut self,
+        multiplier: f32,
+        base: f32,
+        allowed_length: i32,
+        penalty_last_n: i32,
+        sequence_breakers: Vec<String>,
+    ) -> Self {
+        self.config.dry_multiplier = Some(multiplier);
+        self.config.dry_base = Some(base);
+        self.config.dry_allowed_length = Some(allowed_length);
+        self.config.dry_penalty_last_n = Some(penalty_last_n);
+        self.config.dry_sequence_breakers = Some(sequence_breakers);
+        self
+    }
+
+    /// Set per-token logit bias values.
+    pub fn logit_bias(mut self, biases: Vec<(i32, f32)>) -> Self {
+        self.config.logit_bias = Some(biases);
         self
     }
 
@@ -423,8 +734,57 @@ impl LlamaCppConfigBuilder {
     }
 
     /// Enable or disable thinking/reasoning tokens in chat template.
+    ///
     pub fn enable_thinking(mut self, enable: bool) -> Self {
         self.config.enable_thinking = Some(enable);
+        self
+    }
+
+    /// Set whether chat templates should add an assistant generation prompt.
+    pub fn add_generation_prompt(mut self, enable: bool) -> Self {
+        self.config.add_generation_prompt = enable;
+        self
+    }
+
+    /// Set final-message continuation behavior.
+    pub fn continue_final_message(mut self, continuation: LlamaCppChatContinuation) -> Self {
+        self.config.continue_final_message = continuation;
+        self
+    }
+
+    /// Set tool-call choice behavior.
+    pub fn tool_choice(mut self, choice: LlamaCppToolChoice) -> Self {
+        self.config.tool_choice = choice;
+        self
+    }
+
+    /// Force a specific function tool by name.
+    pub fn tool_choice_function(mut self, name: impl Into<String>) -> Self {
+        self.config.tool_choice = LlamaCppToolChoice::Function { name: name.into() };
+        self
+    }
+
+    /// Enable or disable parallel tool calls when supported by the template.
+    pub fn parallel_tool_calls(mut self, enable: bool) -> Self {
+        self.config.parallel_tool_calls = Some(enable);
+        self
+    }
+
+    /// Set embedded scheduler configuration.
+    pub fn scheduler(mut self, scheduler: LlamaCppSchedulerConfig) -> Self {
+        self.config.scheduler = scheduler;
+        self
+    }
+
+    /// Set the number of embedded inference slots.
+    pub fn n_slots(mut self, n_slots: usize) -> Self {
+        self.config.scheduler.n_slots = n_slots.max(1);
+        self
+    }
+
+    /// Set embedded request queue capacity.
+    pub fn queue_capacity(mut self, capacity: usize) -> Self {
+        self.config.scheduler.queue_capacity = capacity;
         self
     }
 
@@ -467,6 +827,9 @@ mod tests {
         let config = LlamaCppConfigBuilder::default()
             .model_path("model.gguf")
             .force_json_grammar(true)
+            .force_pure_content(true)
+            .tokenizer_add_bos(true)
+            .tokenizer_add_eos(true)
             .reasoning_format(LlamaCppReasoningFormat::Deepseek)
             .extra_body(serde_json::json!({
                 "chat_template_kwargs": {
@@ -474,12 +837,20 @@ mod tests {
                 }
             }))
             .mmproj_use_gpu(true)
+            .continue_final_message(LlamaCppChatContinuation::Content)
             .split_mode(LlamaCppSplitMode::Layer)
             .use_mlock(true)
             .devices(vec![0, 1])
             .build();
 
         assert!(config.force_json_grammar);
+        assert!(config.force_pure_content);
+        assert_eq!(config.tokenizer_add_bos, Some(true));
+        assert_eq!(config.tokenizer_add_eos, Some(true));
+        assert_eq!(
+            config.continue_final_message,
+            LlamaCppChatContinuation::Content
+        );
         assert_eq!(
             config.reasoning_format,
             Some(LlamaCppReasoningFormat::Deepseek)
@@ -503,6 +874,58 @@ mod tests {
     fn test_config_default_reasoning_format_is_opt_in() {
         let config = LlamaCppConfig::default();
         assert_eq!(config.reasoning_format, None);
+        assert!(!config.force_pure_content);
+        assert_eq!(config.tokenizer_add_bos, None);
+        assert_eq!(config.tokenizer_add_eos, None);
+        assert_eq!(
+            config.continue_final_message,
+            LlamaCppChatContinuation::None
+        );
+    }
+
+    #[test]
+    fn test_tool_choice_serde_matches_openai_server_shape() {
+        assert_eq!(
+            serde_json::to_value(&LlamaCppToolChoice::Auto).expect("serialize auto"),
+            serde_json::json!("auto")
+        );
+        assert_eq!(
+            serde_json::from_value::<LlamaCppToolChoice>(serde_json::json!("required"))
+                .expect("deserialize required"),
+            LlamaCppToolChoice::Required
+        );
+
+        let named = LlamaCppToolChoice::Function {
+            name: "lookup".to_string(),
+        };
+        let value = serde_json::to_value(&named).expect("serialize named tool choice");
+        assert_eq!(
+            value,
+            serde_json::json!({
+                "type": "function",
+                "function": {
+                    "name": "lookup"
+                }
+            })
+        );
+        assert_eq!(
+            serde_json::from_value::<LlamaCppToolChoice>(value).expect("deserialize named choice"),
+            named
+        );
+    }
+
+    #[test]
+    fn test_config_builder_named_tool_choice() {
+        let config = LlamaCppConfigBuilder::default()
+            .tool_choice_function("lookup")
+            .build();
+
+        assert_eq!(
+            config.tool_choice,
+            LlamaCppToolChoice::Function {
+                name: "lookup".to_string()
+            }
+        );
     }
 
     #[test]

--- a/crates/autoagents-llamacpp/src/conversion.rs
+++ b/crates/autoagents-llamacpp/src/conversion.rs
@@ -1,9 +1,11 @@
 //! Type conversions between AutoAgents types and llama.cpp types.
 
+#[cfg(test)]
 use crate::error::LlamaCppProviderError;
 use autoagents_llm::ToolCall;
 use autoagents_llm::chat::{ChatMessage, ChatResponse, ChatRole, MessageType, Usage};
 use llama_cpp_2::model::AddBos;
+#[cfg(test)]
 use serde_json::{Value, json};
 use std::fmt;
 
@@ -60,6 +62,7 @@ pub(crate) struct PromptData {
     pub add_bos: AddBos,
 }
 
+#[cfg(test)]
 fn convert_role(role: &ChatRole) -> String {
     match role {
         ChatRole::System => "system".to_string(),
@@ -123,6 +126,7 @@ pub(crate) fn build_fallback_prompt(messages: &[ChatMessage]) -> String {
     prompt
 }
 
+#[cfg(test)]
 fn build_openai_message_value(message: &ChatMessage) -> Result<Value, LlamaCppProviderError> {
     if let MessageType::ToolUse(tool_calls) = &message.message_type {
         let mut tool_values = Vec::with_capacity(tool_calls.len());
@@ -149,6 +153,7 @@ fn build_openai_message_value(message: &ChatMessage) -> Result<Value, LlamaCppPr
     }))
 }
 
+#[cfg(test)]
 pub(crate) fn build_openai_messages_json(
     messages: &[ChatMessage],
 ) -> Result<String, LlamaCppProviderError> {

--- a/crates/autoagents-llamacpp/src/lib.rs
+++ b/crates/autoagents-llamacpp/src/lib.rs
@@ -12,17 +12,20 @@
 //!
 
 pub mod builder;
+mod chat_template;
 pub mod config;
 pub mod conversion;
 pub mod error;
 pub mod huggingface;
 pub mod models;
 pub mod provider;
+mod server_chat;
 
 // Re-exports for convenience
 pub use builder::LlamaCppProviderBuilder;
 pub use config::{
-    LlamaCppConfig, LlamaCppConfigBuilder, LlamaCppReasoningFormat, LlamaCppSplitMode,
+    LlamaCppConfig, LlamaCppConfigBuilder, LlamaCppReasoningFormat, LlamaCppSchedulerConfig,
+    LlamaCppSplitMode, LlamaCppToolChoice,
 };
 pub use error::LlamaCppProviderError;
 pub use models::ModelSource;

--- a/crates/autoagents-llamacpp/src/provider.rs
+++ b/crates/autoagents-llamacpp/src/provider.rs
@@ -3851,7 +3851,7 @@ fn stream_delta_from_message_json(message_json: &str) -> Result<String, LlamaCpp
     }
 
     if delta.is_empty() {
-        return Ok(String::new());
+        return Ok(String::default());
     }
     serde_json::to_string(&Value::Object(delta))
         .map_err(|err| LlamaCppProviderError::Template(err.to_string()))
@@ -5472,12 +5472,12 @@ fn wrap_native_tool_payload_grammar(
     let start = if include_markers {
         gbnf_literal(start)
     } else {
-        String::new()
+        String::default()
     };
     let spacing = if include_markers { " tool-ws " } else { "" };
 
     let end = if end.is_empty() {
-        String::new()
+        String::default()
     } else {
         format!(" {}", gbnf_literal(end))
     };
@@ -5767,7 +5767,7 @@ fn decode_model_special_token(
     name: &str,
 ) -> Result<String, LLMError> {
     if token.0 < 0 {
-        return Ok(String::new());
+        return Ok(String::default());
     }
 
     let mut decoder = encoding_rs::UTF_8.new_decoder();
@@ -6559,12 +6559,11 @@ fn generation_prompt_grammar_prefill_for<'a>(
     SERVER_RESPONSE_MARKERS
         .iter()
         .filter(|marker| grammar.contains(&gbnf_literal(marker)))
-        .filter_map(|marker| {
+        .find_map(|marker| {
             generation_prompt
                 .find(marker)
                 .map(|index| &generation_prompt[index..])
         })
-        .next()
 }
 
 fn grammar_trigger_patterns(triggers: &[GrammarTrigger]) -> (Vec<String>, Vec<LlamaToken>) {

--- a/crates/autoagents-llamacpp/src/provider.rs
+++ b/crates/autoagents-llamacpp/src/provider.rs
@@ -515,14 +515,8 @@ impl ChatTemplateResult {
         if !self.force_pure_content
             && let Some((content, reasoning_content)) = parse_native_channel_content_partial(text)
         {
-            let message = match reasoning_content {
-                Some(reasoning_content) if !reasoning_content.is_empty() => {
-                    json!({ "content": content, "reasoning_content": reasoning_content })
-                }
-                _ => json!({ "content": content }),
-            };
-            return serde_json::to_string(&message)
-                .map_err(|err| LlamaCppProviderError::Template(err.to_string()));
+            let message = content_message_value(content, reasoning_content);
+            return Ok(message.to_string());
         }
 
         let mut grammar_source;
@@ -556,15 +550,9 @@ impl ChatTemplateResult {
         } else {
             self.extract_response_reasoning_content(&mut content)
         };
-        let message = match reasoning_content {
-            Some(reasoning_content) if !reasoning_content.is_empty() => {
-                json!({ "content": content, "reasoning_content": reasoning_content })
-            }
-            _ => json!({ "content": content }),
-        };
+        let message = content_message_value(content, reasoning_content);
 
-        serde_json::to_string(&message)
-            .map_err(|err| LlamaCppProviderError::Template(err.to_string()))
+        Ok(message.to_string())
     }
 
     fn parse_partial_response_oaicompat(
@@ -585,15 +573,8 @@ impl ChatTemplateResult {
         if !self.force_pure_content
             && let Some((content, reasoning_content)) = parse_native_channel_content_partial(text)
         {
-            let message = match reasoning_content {
-                Some(reasoning_content) if !reasoning_content.is_empty() => {
-                    json!({ "content": content, "reasoning_content": reasoning_content })
-                }
-                _ => json!({ "content": content }),
-            };
-            return serde_json::to_string(&message)
-                .map(Some)
-                .map_err(|err| LlamaCppProviderError::Template(err.to_string()));
+            let message = content_message_value(content, reasoning_content);
+            return Ok(Some(message.to_string()));
         }
 
         if self.grammar.is_some() {
@@ -607,10 +588,8 @@ impl ChatTemplateResult {
                 if let Some(reasoning_content) =
                     reasoning_content.filter(|reasoning_content| !reasoning_content.is_empty())
                 {
-                    let message = json!({ "content": "", "reasoning_content": reasoning_content });
-                    return serde_json::to_string(&message)
-                        .map(Some)
-                        .map_err(|err| LlamaCppProviderError::Template(err.to_string()));
+                    let message = content_message_value(String::default(), Some(reasoning_content));
+                    return Ok(Some(message.to_string()));
                 }
                 return Ok(None);
             };
@@ -622,15 +601,8 @@ impl ChatTemplateResult {
             } else {
                 payload
             };
-            let message = match reasoning_content {
-                Some(reasoning_content) if !reasoning_content.is_empty() => {
-                    json!({ "content": content, "reasoning_content": reasoning_content })
-                }
-                _ => json!({ "content": content }),
-            };
-            return serde_json::to_string(&message)
-                .map(Some)
-                .map_err(|err| LlamaCppProviderError::Template(err.to_string()));
+            let message = content_message_value(content, reasoning_content);
+            return Ok(Some(message.to_string()));
         }
 
         Ok(None)
@@ -723,6 +695,20 @@ impl ChatTemplateResult {
     }
 }
 
+fn content_message_value(content: String, reasoning_content: Option<String>) -> Value {
+    let mut message = serde_json::Map::new();
+    message.insert("content".to_string(), Value::String(content));
+    if let Some(reasoning_content) =
+        reasoning_content.filter(|reasoning_content| !reasoning_content.is_empty())
+    {
+        message.insert(
+            "reasoning_content".to_string(),
+            Value::String(reasoning_content),
+        );
+    }
+    Value::Object(message)
+}
+
 #[derive(Debug, Deserialize)]
 struct OpenAICompatMessage {
     content: Option<StringOrJson>,
@@ -787,7 +773,7 @@ struct StreamMappingState {
 
 fn append_or_diff_string(previous: &str, current_or_delta: &str) -> String {
     if current_or_delta.is_empty() {
-        return String::new();
+        return String::default();
     }
     if previous.is_empty() {
         return current_or_delta.to_string();
@@ -796,7 +782,7 @@ fn append_or_diff_string(previous: &str, current_or_delta: &str) -> String {
         return delta.to_string();
     }
     if previous.starts_with(current_or_delta) {
-        return String::new();
+        return String::default();
     }
     current_or_delta.to_string()
 }
@@ -1510,7 +1496,7 @@ impl LlamaCppProvider {
             };
             let result = tokio::task::spawn_blocking(
                 move || -> Result<(GenerationResult, String), LlamaCppProviderError> {
-                    let parsed_stream_state = Arc::new(Mutex::new(String::new()));
+                    let parsed_stream_state = Arc::new(Mutex::new(String::default()));
                     let parsed_stream_emitted_for_callback = parsed_stream_emitted.clone();
                     let on_delta: Option<DeltaCallback> = if stream_final_message {
                         let template_result_for_callback = template_result.clone();
@@ -2162,32 +2148,10 @@ fn parse_tool_response_message_with_allowed_tools(
     text: &str,
     allowed_tools: Option<&[String]>,
 ) -> Result<Option<Value>, LlamaCppProviderError> {
-    if let Some(message) = parse_native_channel_tool_calls(text)? {
-        return Ok(filter_tool_message_by_allowed_tools(message, allowed_tools));
-    }
-    if let Some(message) = parse_tool_calls_args_tag(text)? {
-        return Ok(filter_tool_message_by_allowed_tools(message, allowed_tools));
-    }
-    if let Some(message) = parse_gemma4_tool_calls(text)? {
-        return Ok(filter_tool_message_by_allowed_tools(message, allowed_tools));
-    }
-    if let Some(message) = parse_generic_function_tag_tool_calls(text)? {
-        return Ok(filter_tool_message_by_allowed_tools(message, allowed_tools));
-    }
-    if let Some(message) = parse_functionary_tool_calls(text)? {
-        return Ok(filter_tool_message_by_allowed_tools(message, allowed_tools));
-    }
-    if let Some(message) = parse_kimi_k2_tool_calls(text)? {
-        return Ok(filter_tool_message_by_allowed_tools(message, allowed_tools));
-    }
-    if let Some(message) = parse_lfm2_tool_calls(text)? {
-        return Ok(filter_tool_message_by_allowed_tools(message, allowed_tools));
-    }
-    if let Some(message) = parse_gigachat_v3_tool_calls(text)? {
-        return Ok(filter_tool_message_by_allowed_tools(message, allowed_tools));
-    }
-    if let Some(message) = parse_deepseek_dsml_tool_calls(text)? {
-        return Ok(filter_tool_message_by_allowed_tools(message, allowed_tools));
+    for parser in TOOL_RESPONSE_PARSERS {
+        if let Some(message) = parser(text)? {
+            return Ok(filter_tool_message_by_allowed_tools(message, allowed_tools));
+        }
     }
 
     let Some(json_text) = extract_json_payload(text) else {
@@ -2231,6 +2195,20 @@ fn parse_tool_response_message_with_allowed_tools(
 
     Ok(None)
 }
+
+type ToolResponseParser = fn(&str) -> Result<Option<Value>, LlamaCppProviderError>;
+
+const TOOL_RESPONSE_PARSERS: &[ToolResponseParser] = &[
+    parse_native_channel_tool_calls,
+    parse_tool_calls_args_tag,
+    parse_gemma4_tool_calls,
+    parse_generic_function_tag_tool_calls,
+    parse_functionary_tool_calls,
+    parse_kimi_k2_tool_calls,
+    parse_lfm2_tool_calls,
+    parse_gigachat_v3_tool_calls,
+    parse_deepseek_dsml_tool_calls,
+];
 
 fn is_openai_compat_single_tool_call(value: &Value, allowed_tools: Option<&[String]>) -> bool {
     let Some(object) = value.as_object() else {
@@ -2776,7 +2754,7 @@ fn parse_generic_tagged_arguments(
             .map_or(text.len(), |offset| value_start + offset);
         let value_text = text[value_start..value_end].trim();
         let value = if value_text.is_empty() {
-            Value::String(String::new())
+            Value::String(String::default())
         } else if let Ok(value) = serde_json::from_str::<Value>(value_text) {
             value
         } else {
@@ -2932,7 +2910,7 @@ fn quote_unquoted_object_keys(text: &str) -> String {
             }
             ch if expecting_key && ch.is_whitespace() => output.push(ch),
             ch if expecting_key && is_gemma4_unquoted_key_start(ch) => {
-                let mut key = String::new();
+                let mut key = String::with_capacity(16);
                 key.push(ch);
                 while let Some(next) = chars.peek().copied() {
                     if is_gemma4_unquoted_key_char(next) {
@@ -3312,73 +3290,97 @@ fn normalize_lfm2_python_literal(text: &str) -> Result<String, LlamaCppProviderE
                 output.push(ch);
             }
             '\'' => {
-                let mut quoted = String::new();
-                let mut escaped = false;
-                let mut closed = false;
-                for inner in chars.by_ref() {
-                    if escaped {
-                        match inner {
-                            '\\' => quoted.push('\\'),
-                            '\'' => quoted.push('\''),
-                            '"' => quoted.push('"'),
-                            'n' => quoted.push('\n'),
-                            'r' => quoted.push('\r'),
-                            't' => quoted.push('\t'),
-                            other => {
-                                quoted.push('\\');
-                                quoted.push(other);
-                            }
-                        }
-                        escaped = false;
-                    } else if inner == '\\' {
-                        escaped = true;
-                    } else if inner == '\'' {
-                        closed = true;
-                        break;
-                    } else {
-                        quoted.push(inner);
-                    }
-                }
-                if escaped {
-                    return Err(LlamaCppProviderError::Template(
-                        "LFM2 quoted string ends with an escape".to_string(),
-                    ));
-                }
-                if !closed {
-                    return Err(LlamaCppProviderError::Template(
-                        "LFM2 quoted string is missing a closing quote".to_string(),
-                    ));
-                }
-                let encoded = serde_json::to_string(&quoted).map_err(|err| {
-                    LlamaCppProviderError::Template(format!(
-                        "LFM2 quoted string could not be encoded as JSON: {err}"
-                    ))
-                })?;
-                output.push_str(&encoded);
+                push_lfm2_single_quoted_json(&mut output, &mut chars)?;
             }
             ch if ch.is_ascii_alphabetic() || ch == '_' => {
-                let mut ident = String::new();
-                ident.push(ch);
-                while let Some(next) = chars.peek().copied() {
-                    if next.is_ascii_alphanumeric() || next == '_' {
-                        ident.push(next);
-                        chars.next();
-                    } else {
-                        break;
-                    }
-                }
-                match ident.as_str() {
-                    "True" => output.push_str("true"),
-                    "False" => output.push_str("false"),
-                    "None" => output.push_str("null"),
-                    _ => output.push_str(&ident),
-                }
+                push_lfm2_identifier(&mut output, ch, &mut chars);
             }
             _ => output.push(ch),
         }
     }
 
     Ok(remove_lfm2_json_trailing_commas(&output))
+}
+
+fn push_lfm2_single_quoted_json(
+    output: &mut String,
+    chars: &mut std::iter::Peekable<std::str::Chars<'_>>,
+) -> Result<(), LlamaCppProviderError> {
+    let quoted = parse_lfm2_single_quoted(chars)?;
+    let encoded = serde_json::to_string(&quoted).map_err(|err| {
+        LlamaCppProviderError::Template(format!(
+            "LFM2 quoted string could not be encoded as JSON: {err}"
+        ))
+    })?;
+    output.push_str(&encoded);
+    Ok(())
+}
+
+fn parse_lfm2_single_quoted(
+    chars: &mut std::iter::Peekable<std::str::Chars<'_>>,
+) -> Result<String, LlamaCppProviderError> {
+    let mut quoted = String::with_capacity(16);
+    let mut escaped = false;
+
+    for inner in chars.by_ref() {
+        if escaped {
+            push_lfm2_escaped_char(&mut quoted, inner);
+            escaped = false;
+        } else if inner == '\\' {
+            escaped = true;
+        } else if inner == '\'' {
+            return Ok(quoted);
+        } else {
+            quoted.push(inner);
+        }
+    }
+
+    if escaped {
+        return Err(LlamaCppProviderError::Template(
+            "LFM2 quoted string ends with an escape".to_string(),
+        ));
+    }
+    Err(LlamaCppProviderError::Template(
+        "LFM2 quoted string is missing a closing quote".to_string(),
+    ))
+}
+
+fn push_lfm2_escaped_char(output: &mut String, ch: char) {
+    match ch {
+        '\\' => output.push('\\'),
+        '\'' => output.push('\''),
+        '"' => output.push('"'),
+        'n' => output.push('\n'),
+        'r' => output.push('\r'),
+        't' => output.push('\t'),
+        other => {
+            output.push('\\');
+            output.push(other);
+        }
+    }
+}
+
+fn push_lfm2_identifier(
+    output: &mut String,
+    first: char,
+    chars: &mut std::iter::Peekable<std::str::Chars<'_>>,
+) {
+    let mut ident = String::with_capacity(8);
+    ident.push(first);
+    while let Some(next) = chars.peek().copied() {
+        if next.is_ascii_alphanumeric() || next == '_' {
+            ident.push(next);
+            chars.next();
+        } else {
+            break;
+        }
+    }
+    match ident.as_str() {
+        "True" => output.push_str("true"),
+        "False" => output.push_str("false"),
+        "None" => output.push_str("null"),
+        _ => output.push_str(&ident),
+    }
 }
 
 fn remove_lfm2_json_trailing_commas(text: &str) -> String {
@@ -7516,7 +7518,7 @@ mod tests {
     fn test_chat_template_result_parses_content_and_tool_json() {
         let content_result = ChatTemplateResult {
             prompt: "prompt".to_string(),
-            generation_prompt: String::new(),
+            generation_prompt: String::default(),
             force_pure_content: false,
             is_continuation: false,
             add_bos: true,
@@ -7539,7 +7541,7 @@ mod tests {
 
         let tool_result = ChatTemplateResult {
             prompt: "prompt".to_string(),
-            generation_prompt: String::new(),
+            generation_prompt: String::default(),
             force_pure_content: false,
             is_continuation: false,
             add_bos: true,
@@ -7959,7 +7961,7 @@ mod tests {
     fn test_tool_response_parsing_extracts_reasoning_from_content_envelope() {
         let result = ChatTemplateResult {
             prompt: "prompt".to_string(),
-            generation_prompt: String::new(),
+            generation_prompt: String::default(),
             force_pure_content: false,
             is_continuation: false,
             add_bos: true,
@@ -8468,7 +8470,7 @@ content
         for case in cases {
             let result = ChatTemplateResult {
                 prompt: "prompt".to_string(),
-                generation_prompt: String::new(),
+                generation_prompt: String::default(),
                 force_pure_content: false,
                 is_continuation: false,
                 add_bos: true,
@@ -8533,7 +8535,7 @@ content
     fn test_gpt_oss_partial_streaming_diffs_reasoning_content_and_tool_call() {
         let result = ChatTemplateResult {
             prompt: "prompt".to_string(),
-            generation_prompt: String::new(),
+            generation_prompt: String::default(),
             force_pure_content: false,
             is_continuation: false,
             add_bos: true,
@@ -8618,7 +8620,7 @@ content
     fn test_chat_template_result_parses_gpt_oss_final_and_reasoning_channels() {
         let result = ChatTemplateResult {
             prompt: "prompt".to_string(),
-            generation_prompt: String::new(),
+            generation_prompt: String::default(),
             force_pure_content: false,
             is_continuation: false,
             add_bos: true,
@@ -8749,7 +8751,7 @@ content
     fn test_partial_response_parsing_waits_for_complete_structured_json() {
         let result = ChatTemplateResult {
             prompt: "prompt".to_string(),
-            generation_prompt: String::new(),
+            generation_prompt: String::default(),
             force_pure_content: false,
             is_continuation: false,
             add_bos: true,
@@ -8784,7 +8786,7 @@ content
     fn test_structured_response_parsing_preserves_reasoning_before_json() {
         let result = ChatTemplateResult {
             prompt: "prompt".to_string(),
-            generation_prompt: String::new(),
+            generation_prompt: String::default(),
             force_pure_content: false,
             is_continuation: false,
             add_bos: true,
@@ -8924,7 +8926,7 @@ content
     fn test_partial_response_parsing_streams_complete_native_tool_call() {
         let result = ChatTemplateResult {
             prompt: "prompt".to_string(),
-            generation_prompt: String::new(),
+            generation_prompt: String::default(),
             force_pure_content: false,
             is_continuation: false,
             add_bos: true,
@@ -8964,7 +8966,7 @@ content
     fn test_complete_chat_response_stop_detects_structured_content() {
         let result = ChatTemplateResult {
             prompt: "prompt".to_string(),
-            generation_prompt: String::new(),
+            generation_prompt: String::default(),
             force_pure_content: false,
             is_continuation: false,
             add_bos: true,
@@ -8997,7 +8999,7 @@ content
     fn test_complete_chat_response_stop_detects_complete_tool_call() {
         let result = ChatTemplateResult {
             prompt: "prompt".to_string(),
-            generation_prompt: String::new(),
+            generation_prompt: String::default(),
             force_pure_content: false,
             is_continuation: false,
             add_bos: true,
@@ -9033,7 +9035,7 @@ content
     fn test_complete_chat_response_stop_ignores_reasoning_only_native_channel() {
         let result = ChatTemplateResult {
             prompt: "prompt".to_string(),
-            generation_prompt: String::new(),
+            generation_prompt: String::default(),
             force_pure_content: false,
             is_continuation: false,
             add_bos: true,
@@ -9086,7 +9088,7 @@ content
     fn test_chat_template_result_extracts_reasoning_content() {
         let result = ChatTemplateResult {
             prompt: "prompt".to_string(),
-            generation_prompt: String::new(),
+            generation_prompt: String::default(),
             force_pure_content: false,
             is_continuation: false,
             add_bos: true,
@@ -9114,7 +9116,7 @@ content
     fn test_gemma4_reasoning_cleanup_matches_channel_parser() {
         let result = ChatTemplateResult {
             prompt: "prompt".to_string(),
-            generation_prompt: String::new(),
+            generation_prompt: String::default(),
             force_pure_content: false,
             is_continuation: false,
             add_bos: true,
@@ -9144,7 +9146,7 @@ content
     fn test_gemma4_tool_call_reasoning_cleanup_matches_channel_parser() {
         let result = ChatTemplateResult {
             prompt: "prompt".to_string(),
-            generation_prompt: String::new(),
+            generation_prompt: String::default(),
             force_pure_content: false,
             is_continuation: false,
             add_bos: true,
@@ -9177,7 +9179,7 @@ content
     fn test_reasoning_only_chat_template_streams_final_message_delta() {
         let result = ChatTemplateResult {
             prompt: "prompt".to_string(),
-            generation_prompt: String::new(),
+            generation_prompt: String::default(),
             force_pure_content: false,
             is_continuation: false,
             add_bos: true,

--- a/crates/autoagents-llamacpp/src/provider.rs
+++ b/crates/autoagents-llamacpp/src/provider.rs
@@ -2,8 +2,12 @@
 
 use crate::{
     builder::LlamaCppProviderBuilder,
-    config::{LlamaCppConfig, LlamaCppConfigBuilder},
-    conversion::{LlamaCppResponse, PromptData, build_fallback_prompt, build_openai_messages_json},
+    chat_template::{
+        GrammarTrigger, RenderedChat, TemplateSource, TemplateTokens, explicit_template_source,
+        normalize_template_source, render_chat_template,
+    },
+    config::{LlamaCppConfig, LlamaCppConfigBuilder, LlamaCppToolChoice},
+    conversion::{LlamaCppResponse, PromptData, build_fallback_prompt},
     error::LlamaCppProviderError,
     models::ModelSource,
 };
@@ -19,23 +23,21 @@ use autoagents_llm::{
     models::ModelsProvider,
 };
 use futures::{StreamExt, stream::Stream};
+#[cfg(feature = "mtmd")]
+use llama_cpp_2::mtmd::{
+    MtmdBitmap, MtmdContext, MtmdContextParams, MtmdInputText, mtmd_default_marker,
+};
 use llama_cpp_2::{
     context::params::LlamaContextParams,
     llama_backend::LlamaBackend,
     llama_batch::LlamaBatch,
     model::params::LlamaModelParams,
-    model::{AddBos, GrammarTriggerType, LlamaChatTemplate, LlamaModel},
-    openai::OpenAIChatTemplateParams,
+    model::{AddBos, LlamaModel},
     sampling::LlamaSampler,
-    token::LlamaToken,
-};
-#[cfg(feature = "mtmd")]
-use llama_cpp_2::{
-    model::LlamaChatMessage,
-    mtmd::{MtmdBitmap, MtmdContext, MtmdContextParams, MtmdInputText, mtmd_default_marker},
+    token::{LlamaToken, logit_bias::LlamaLogitBias},
 };
 use serde::Deserialize;
-use serde_json::Value;
+use serde_json::{Value, json};
 #[cfg(feature = "mtmd")]
 use std::ffi::CString;
 use std::{
@@ -43,9 +45,12 @@ use std::{
     num::NonZeroU32,
     path::Path,
     pin::Pin,
-    sync::{Arc, OnceLock},
+    sync::{
+        Arc, Mutex, OnceLock,
+        atomic::{AtomicBool, AtomicUsize, Ordering},
+    },
 };
-use tokio::sync::mpsc;
+use tokio::sync::{Semaphore, mpsc};
 
 /// Dedicated tokio runtime for the llamacpp provider.
 ///
@@ -254,6 +259,95 @@ pub struct LlamaCppProvider {
     /// `None` (inner Option) until the first inference call.
     /// The outer Arc<Mutex> is only allocated when `config.context_reuse` is true.
     session_state: Option<SharedSessionState>,
+    scheduler: Arc<ProviderScheduler>,
+}
+
+struct ProviderScheduler {
+    active_slots: Arc<Semaphore>,
+    queued: AtomicUsize,
+    queue_capacity: usize,
+}
+
+struct QueueReservation<'a> {
+    queued: &'a AtomicUsize,
+    active: bool,
+}
+
+impl<'a> QueueReservation<'a> {
+    fn try_new(queued: &'a AtomicUsize, capacity: usize) -> Option<Self> {
+        let mut current = queued.load(Ordering::Acquire);
+        loop {
+            if current >= capacity {
+                return None;
+            }
+            match queued.compare_exchange_weak(
+                current,
+                current + 1,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => {
+                    return Some(Self {
+                        queued,
+                        active: true,
+                    });
+                }
+                Err(observed) => current = observed,
+            }
+        }
+    }
+
+    fn release(&mut self) {
+        if self.active {
+            self.queued.fetch_sub(1, Ordering::AcqRel);
+            self.active = false;
+        }
+    }
+}
+
+impl Drop for QueueReservation<'_> {
+    fn drop(&mut self) {
+        self.release();
+    }
+}
+
+impl ProviderScheduler {
+    fn new(n_slots: usize, queue_capacity: usize) -> Self {
+        Self {
+            active_slots: Arc::new(Semaphore::new(n_slots.max(1))),
+            queued: AtomicUsize::new(0),
+            queue_capacity,
+        }
+    }
+
+    async fn acquire(&self) -> Result<tokio::sync::OwnedSemaphorePermit, LLMError> {
+        match self.active_slots.clone().try_acquire_owned() {
+            Ok(permit) => return Ok(permit),
+            Err(tokio::sync::TryAcquireError::Closed) => {
+                return Err(LLMError::ProviderError(
+                    "llama.cpp scheduler closed".to_string(),
+                ));
+            }
+            Err(tokio::sync::TryAcquireError::NoPermits) => {}
+        }
+
+        let Some(mut reservation) = QueueReservation::try_new(&self.queued, self.queue_capacity)
+        else {
+            return Err(LLMError::ProviderError(format!(
+                "llama.cpp request queue is full (capacity {})",
+                self.queue_capacity
+            )));
+        };
+
+        let permit = self
+            .active_slots
+            .clone()
+            .acquire_owned()
+            .await
+            .map_err(|err| LLMError::ProviderError(format!("llama.cpp scheduler closed: {err}")))?;
+        reservation.release();
+        Ok(permit)
+    }
 }
 
 struct GenerationResult {
@@ -294,7 +388,7 @@ struct MtmdGenerationParams<'a> {
 }
 
 struct ChatGenerationParams<'a> {
-    template_result: &'a llama_cpp_2::model::ChatTemplateResult,
+    template_result: &'a ChatTemplateResult,
     max_tokens: u32,
     temperature: Option<f32>,
     top_p: Option<f32>,
@@ -302,11 +396,331 @@ struct ChatGenerationParams<'a> {
 }
 
 enum ChatPrompt {
-    OpenAI(llama_cpp_2::model::ChatTemplateResult),
+    OpenAI(ChatTemplateResult),
     Fallback {
         prompt: PromptData,
         use_json_grammar: bool,
     },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ToolCallGrammarFormat {
+    OpenAiEnvelope,
+    NativeChannelToolCall,
+    XmlToolCall,
+    ToolCallsArrayTag,
+    ToolCallsArgsTag,
+    GenericFunctionTag,
+    FunctionaryV32,
+    Gemma4ToolCall,
+    KimiK2ToolCall,
+    Lfm2ToolCall,
+    GigaChatV3ToolCall,
+    DeepSeekDsmlToolCall,
+}
+
+fn detect_tool_call_grammar_format(template_source: &str) -> ToolCallGrammarFormat {
+    if template_source.contains("<|tool_call>") || template_source.contains("<tool_call|>") {
+        ToolCallGrammarFormat::Gemma4ToolCall
+    } else if template_source.contains("<|tool_call_begin|>")
+        && template_source.contains("<|tool_call_argument_begin|>")
+    {
+        ToolCallGrammarFormat::KimiK2ToolCall
+    } else if template_source.contains("<|tool_call_start|>")
+        && template_source.contains("<|tool_call_end|>")
+    {
+        ToolCallGrammarFormat::Lfm2ToolCall
+    } else if template_source.contains("<|message_sep|>")
+        && template_source.contains("function call")
+    {
+        ToolCallGrammarFormat::GigaChatV3ToolCall
+    } else if template_source.contains("｜DSML｜")
+        || template_source.contains("<｜DSML｜function_calls>")
+    {
+        ToolCallGrammarFormat::DeepSeekDsmlToolCall
+    } else if template_source.contains("<|channel|>")
+        && (template_source.contains("to=functions") || template_source.contains("<|message|>"))
+    {
+        ToolCallGrammarFormat::NativeChannelToolCall
+    } else if template_source.contains("<tool_call>") || template_source.contains("</tool_call>") {
+        ToolCallGrammarFormat::XmlToolCall
+    } else if template_source.contains("<function=") || template_source.contains("</function>") {
+        ToolCallGrammarFormat::GenericFunctionTag
+    } else if template_source.contains(">>>all") && template_source.contains(">>>${recipient}") {
+        ToolCallGrammarFormat::FunctionaryV32
+    } else if template_source.contains("[TOOL_CALLS]") && template_source.contains("[ARGS]") {
+        ToolCallGrammarFormat::ToolCallsArgsTag
+    } else if template_source.contains("[TOOL_CALLS]") || template_source.contains("[/TOOL_CALLS]")
+    {
+        ToolCallGrammarFormat::ToolCallsArrayTag
+    } else {
+        ToolCallGrammarFormat::OpenAiEnvelope
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ChatTemplateResult {
+    prompt: String,
+    generation_prompt: String,
+    force_pure_content: bool,
+    is_continuation: bool,
+    add_bos: bool,
+    grammar: Option<String>,
+    grammar_lazy: bool,
+    grammar_triggers: Vec<GrammarTrigger>,
+    preserved_tokens: Vec<String>,
+    additional_stops: Vec<String>,
+    parse_tool_calls: bool,
+    tool_names: Vec<String>,
+    reasoning_format: Option<crate::config::LlamaCppReasoningFormat>,
+    reasoning_start_tag: Option<String>,
+    reasoning_end_tag: Option<String>,
+}
+
+impl From<RenderedChat> for ChatTemplateResult {
+    fn from(value: RenderedChat) -> Self {
+        Self {
+            prompt: value.prompt,
+            generation_prompt: value.generation_prompt,
+            force_pure_content: value.force_pure_content,
+            is_continuation: value.is_continuation,
+            add_bos: value.add_bos,
+            grammar: value.grammar,
+            grammar_lazy: value.grammar_lazy,
+            grammar_triggers: value.grammar_triggers,
+            preserved_tokens: value.preserved_tokens,
+            additional_stops: value.additional_stops,
+            parse_tool_calls: value.parse_tool_calls,
+            tool_names: value.tool_names,
+            reasoning_format: value.reasoning_format,
+            reasoning_start_tag: value.reasoning_start_tag,
+            reasoning_end_tag: value.reasoning_end_tag,
+        }
+    }
+}
+
+impl ChatTemplateResult {
+    fn parse_response_oaicompat(&self, text: &str) -> Result<String, LlamaCppProviderError> {
+        let text = self.strip_echoed_continuation(text);
+        if self.parse_tool_calls
+            && let Some(mut message) = parse_tool_response_message_with_allowed_tools(
+                text,
+                Some(self.tool_names.as_slice()),
+            )?
+        {
+            self.extract_reasoning_from_message_content(&mut message);
+            return Ok(message.to_string());
+        }
+
+        if !self.force_pure_content
+            && let Some((content, reasoning_content)) = parse_native_channel_content_partial(text)
+        {
+            let message = match reasoning_content {
+                Some(reasoning_content) if !reasoning_content.is_empty() => {
+                    json!({ "content": content, "reasoning_content": reasoning_content })
+                }
+                _ => json!({ "content": content }),
+            };
+            return serde_json::to_string(&message)
+                .map_err(|err| LlamaCppProviderError::Template(err.to_string()));
+        }
+
+        let mut grammar_source;
+        let grammar_reasoning_content = if self.grammar.is_some() && !self.force_pure_content {
+            grammar_source = text.to_string();
+            self.extract_response_reasoning_content(&mut grammar_source)
+        } else {
+            grammar_source = text.to_string();
+            None
+        };
+
+        let mut content = if self.grammar.is_some() {
+            let payload =
+                extract_json_payload(&grammar_source).unwrap_or_else(|| grammar_source.clone());
+            if self.parse_tool_calls
+                && let Ok(Value::Object(object)) = serde_json::from_str::<Value>(&payload)
+                && let Some(Value::String(content)) = object.get("content")
+            {
+                content.clone()
+            } else {
+                payload
+            }
+        } else {
+            text.to_string()
+        };
+
+        let reasoning_content = if grammar_reasoning_content.is_some() {
+            grammar_reasoning_content
+        } else if self.force_pure_content {
+            None
+        } else {
+            self.extract_response_reasoning_content(&mut content)
+        };
+        let message = match reasoning_content {
+            Some(reasoning_content) if !reasoning_content.is_empty() => {
+                json!({ "content": content, "reasoning_content": reasoning_content })
+            }
+            _ => json!({ "content": content }),
+        };
+
+        serde_json::to_string(&message)
+            .map_err(|err| LlamaCppProviderError::Template(err.to_string()))
+    }
+
+    fn parse_partial_response_oaicompat(
+        &self,
+        text: &str,
+    ) -> Result<Option<String>, LlamaCppProviderError> {
+        let text = self.strip_echoed_continuation(text);
+        if self.parse_tool_calls
+            && let Some(mut message) = parse_tool_response_message_with_allowed_tools(
+                text,
+                Some(self.tool_names.as_slice()),
+            )?
+        {
+            self.extract_reasoning_from_message_content(&mut message);
+            return Ok(Some(message.to_string()));
+        }
+
+        if !self.force_pure_content
+            && let Some((content, reasoning_content)) = parse_native_channel_content_partial(text)
+        {
+            let message = match reasoning_content {
+                Some(reasoning_content) if !reasoning_content.is_empty() => {
+                    json!({ "content": content, "reasoning_content": reasoning_content })
+                }
+                _ => json!({ "content": content }),
+            };
+            return serde_json::to_string(&message)
+                .map(Some)
+                .map_err(|err| LlamaCppProviderError::Template(err.to_string()));
+        }
+
+        if self.grammar.is_some() {
+            let mut grammar_source = text.to_string();
+            let reasoning_content = if self.force_pure_content {
+                None
+            } else {
+                self.extract_partial_reasoning_content(&mut grammar_source)
+            };
+            let Some(payload) = extract_json_payload(&grammar_source) else {
+                if let Some(reasoning_content) =
+                    reasoning_content.filter(|reasoning_content| !reasoning_content.is_empty())
+                {
+                    let message = json!({ "content": "", "reasoning_content": reasoning_content });
+                    return serde_json::to_string(&message)
+                        .map(Some)
+                        .map_err(|err| LlamaCppProviderError::Template(err.to_string()));
+                }
+                return Ok(None);
+            };
+            let content = if self.parse_tool_calls
+                && let Ok(Value::Object(object)) = serde_json::from_str::<Value>(&payload)
+                && let Some(Value::String(content)) = object.get("content")
+            {
+                content.clone()
+            } else {
+                payload
+            };
+            let message = match reasoning_content {
+                Some(reasoning_content) if !reasoning_content.is_empty() => {
+                    json!({ "content": content, "reasoning_content": reasoning_content })
+                }
+                _ => json!({ "content": content }),
+            };
+            return serde_json::to_string(&message)
+                .map(Some)
+                .map_err(|err| LlamaCppProviderError::Template(err.to_string()));
+        }
+
+        Ok(None)
+    }
+
+    fn strip_echoed_continuation<'a>(&self, text: &'a str) -> &'a str {
+        if self.is_continuation
+            && !self.generation_prompt.is_empty()
+            && let Some(rest) = text.strip_prefix(&self.generation_prompt)
+        {
+            return rest;
+        }
+        text
+    }
+
+    fn extract_reasoning_from_message_content(&self, message: &mut Value) {
+        let Some(object) = message.as_object_mut() else {
+            return;
+        };
+        if object.contains_key("reasoning_content") {
+            return;
+        }
+        let Some(Value::String(content)) = object.get_mut("content") else {
+            return;
+        };
+        let reasoning_content = self.extract_response_reasoning_content(content);
+        if let Some(reasoning_content) = reasoning_content
+            && !reasoning_content.is_empty()
+        {
+            object.insert(
+                "reasoning_content".to_string(),
+                Value::String(reasoning_content),
+            );
+        }
+    }
+
+    fn extract_response_reasoning_content(&self, content: &mut String) -> Option<String> {
+        let reasoning = extract_reasoning_content(
+            content,
+            self.reasoning_format,
+            self.reasoning_start_tag.as_deref(),
+            self.reasoning_end_tag.as_deref(),
+        );
+        if reasoning.is_some() {
+            return reasoning;
+        }
+        if let Some((start_tag, end_tag)) = self.reasoning_tags()
+            && content.contains(start_tag)
+        {
+            return extract_tagged_reasoning_partial(content, start_tag, end_tag);
+        }
+        self.extract_prefilled_reasoning_content(content, true)
+    }
+
+    fn extract_partial_reasoning_content(&self, content: &mut String) -> Option<String> {
+        let (start_tag, end_tag) = self.reasoning_tags()?;
+        let reasoning = extract_tagged_reasoning_partial(content, start_tag, end_tag);
+        if reasoning.is_some() {
+            return reasoning;
+        }
+        self.extract_prefilled_reasoning_content(content, true)
+    }
+
+    fn extract_prefilled_reasoning_content(
+        &self,
+        content: &mut String,
+        allow_open: bool,
+    ) -> Option<String> {
+        let (start_tag, end_tag) = self.reasoning_tags()?;
+        if !self.generation_prompt_prefills_reasoning(start_tag) || content.contains(start_tag) {
+            return None;
+        }
+        extract_prefilled_reasoning(content, start_tag, end_tag, allow_open)
+    }
+
+    fn reasoning_tags(&self) -> Option<(&str, &str)> {
+        let format = self.reasoning_format?;
+        if matches!(format, crate::config::LlamaCppReasoningFormat::None) {
+            return None;
+        }
+        Some((
+            self.reasoning_start_tag.as_deref().unwrap_or("<think>"),
+            self.reasoning_end_tag.as_deref().unwrap_or("</think>"),
+        ))
+    }
+
+    fn generation_prompt_prefills_reasoning(&self, start_tag: &str) -> bool {
+        generation_prompt_grammar_prefill(self).is_some_and(|prefill| prefill.contains(start_tag))
+            || self.generation_prompt.contains(start_tag)
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -362,6 +776,29 @@ struct ToolCallState {
     name: String,
     arguments: String,
     started: bool,
+}
+
+#[derive(Debug, Default)]
+struct StreamMappingState {
+    content: String,
+    reasoning_content: String,
+    tool_calls: HashMap<usize, ToolCallState>,
+}
+
+fn append_or_diff_string(previous: &str, current_or_delta: &str) -> String {
+    if current_or_delta.is_empty() {
+        return String::new();
+    }
+    if previous.is_empty() {
+        return current_or_delta.to_string();
+    }
+    if let Some(delta) = current_or_delta.strip_prefix(previous) {
+        return delta.to_string();
+    }
+    if previous.starts_with(current_or_delta) {
+        return String::new();
+    }
+    current_or_delta.to_string()
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -441,6 +878,10 @@ impl LlamaCppProvider {
         Ok(Self {
             backend,
             model,
+            scheduler: Arc::new(ProviderScheduler::new(
+                config.scheduler.n_slots,
+                config.scheduler.queue_capacity,
+            )),
             config,
             session_state,
         })
@@ -469,6 +910,10 @@ impl LlamaCppProvider {
         Self {
             backend,
             model,
+            scheduler: Arc::new(ProviderScheduler::new(
+                config.scheduler.n_slots,
+                config.scheduler.queue_capacity,
+            )),
             config,
             session_state,
         }
@@ -518,10 +963,6 @@ impl LlamaCppProvider {
         }
     }
 
-    fn prepare_messages(&self, messages: &[ChatMessage]) -> Vec<ChatMessage> {
-        prepare_messages_with_system(&self.config, messages)
-    }
-
     fn prepare_fallback_messages(
         &self,
         messages: &[ChatMessage],
@@ -541,10 +982,14 @@ impl LlamaCppProvider {
         json_schema: Option<&StructuredOutputFormat>,
     ) -> Result<ChatPrompt, LLMError> {
         self.ensure_supported_messages(messages)?;
-        let template = match self.resolve_chat_template() {
+        let enabled_tools = enabled_tools_for_config(&self.config, tools);
+        let template = match self.resolve_chat_template_source(enabled_tools.is_some()) {
             Ok(template) => Some(template),
             Err(err) => {
-                if tools.is_some() || json_schema.is_some() || self.config.force_json_grammar {
+                if enabled_tools.is_some()
+                    || json_schema.is_some()
+                    || self.config.force_json_grammar
+                {
                     return Err(err);
                 }
                 None
@@ -552,95 +997,38 @@ impl LlamaCppProvider {
         };
 
         if let Some(template) = template {
-            let messages = self.prepare_messages(messages);
-            let messages_json = build_openai_messages_json(&messages).map_err(LLMError::from)?;
-            let tools_json = match tools {
-                Some(tools) if !tools.is_empty() => {
-                    Some(serde_json::to_string(tools).map_err(|err| {
-                        LLMError::ProviderError(format!("Failed to serialize tools: {err}"))
-                    })?)
-                }
-                _ => None,
+            let grammar_value = if let Some(tools) = enabled_tools {
+                let tool_call_format = detect_tool_call_grammar_format(&template.source);
+                Some(build_tool_response_grammar(
+                    tools,
+                    json_schema,
+                    self.config.force_json_grammar,
+                    self.config.tool_choice.clone(),
+                    self.config.parallel_tool_calls.unwrap_or(false),
+                    tool_call_format,
+                )?)
+            } else {
+                let tool_call_format = detect_tool_call_grammar_format(&template.source);
+                let (_, grammar_value) = select_template_schema_and_grammar(
+                    json_schema,
+                    self.config.force_json_grammar,
+                    Some(tool_call_format),
+                )?;
+                grammar_value
             };
 
-            let (json_schema_value, grammar_value) = select_template_schema_and_grammar(
-                tools_json.is_some(),
+            let rendered = render_chat_template(
+                &self.config,
+                &template,
+                messages,
+                enabled_tools,
                 json_schema,
-                self.config.force_json_grammar,
-            );
-            let chat_template_kwargs = self
-                .config
-                .extra_body
-                .as_ref()
-                .and_then(|body| body.get("chat_template_kwargs"))
-                .filter(|value| value.is_object())
-                .map(Value::to_string);
+                grammar_value,
+                &self.template_tokens()?,
+            )
+            .map_err(LLMError::from)?;
 
-            let parse_tool_calls =
-                tools_json.is_some() && json_schema_value.is_none() && grammar_value.is_none();
-            let params = OpenAIChatTemplateParams {
-                messages_json: messages_json.as_str(),
-                tools_json: tools_json.as_deref(),
-                tool_choice: None,
-                json_schema: json_schema_value.as_deref(),
-                grammar: grammar_value.as_deref(),
-                reasoning_format: self
-                    .config
-                    .reasoning_format
-                    .and_then(|format| format.as_str()),
-                chat_template_kwargs: chat_template_kwargs.as_deref(),
-                add_generation_prompt: true,
-                use_jinja: true,
-                parallel_tool_calls: false,
-                enable_thinking: self.config.enable_thinking.unwrap_or(false),
-                add_bos: false,
-                add_eos: false,
-                parse_tool_calls,
-            };
-
-            let mut result = self
-                .model
-                .apply_chat_template_oaicompat(&template, &params)
-                .map_err(|err| {
-                    LLMError::ProviderError(format!(
-                        "Failed to apply OpenAI-compatible chat template: {err}"
-                    ))
-                })?;
-
-            // When the request is grammar-constrained with no tools, the model
-            // output is itself the structured response — there is no envelope
-            // (reasoning_content, tool_calls, etc.) to extract, and no
-            // tool-call trigger tokens to wait for. The chat-format handler
-            // in `common_chat_templates_apply` configures both:
-            //   1. A parser string expecting an envelope shape — raises rc=-3
-            //      inside `chat_parse_to_oaicompat` when run against plain-JSON
-            //      output.
-            //   2. `grammar_lazy=true` (per `llama.cpp/common/chat.cpp:1059,1187`
-            //      pattern: `!(has_response_format || ...)`) — delays grammar
-            //      enforcement until a trigger token fires, leaving the model
-            //      free to emit markdown fences / preamble first.
-            // Both are wrong for the no-tools-grammar shape. We restore the
-            // correct routing: drop the parser (signals "no envelope"), force
-            // eager grammar enforcement (no triggers to wait for), and clear
-            // any trigger list (triggers are tool-call sentinels, irrelevant
-            // for plain JSON output).
-            //
-            // The unit-level fix in `select_template_schema_and_grammar`
-            // (#220 / #232) does not reach this configuration on its own —
-            // the parser + lazy flag + triggers are decided inside the C++
-            // template engine, not by the schema-vs-grammar slot routing.
-            //
-            // NOTE: the `tools.is_some() && grammar.is_some()` combination
-            // remains a known upstream limitation in llama.cpp's
-            // `common_chat_templates_apply` — the parser + lazy-grammar
-            // configuration intended for tool-calling conflicts with strict
-            // grammar enforcement on the structured-output payload. Fix
-            // belongs upstream; this branch only addresses the no-tools case.
-            if tools_json.is_none() && result.grammar.is_some() {
-                result.parser = None;
-                result.grammar_lazy = false;
-                result.grammar_triggers.clear();
-            }
+            let result = ChatTemplateResult::from(rendered);
 
             Ok(ChatPrompt::OpenAI(result))
         } else {
@@ -668,7 +1056,7 @@ impl LlamaCppProvider {
         &self,
         messages: &[ChatMessage],
     ) -> Result<(String, Vec<Vec<u8>>, String), LLMError> {
-        let template = self.resolve_chat_template()?;
+        let template = self.resolve_chat_template_source(false)?;
         let mut chat = Vec::new();
         let mut images = Vec::new();
         let default_marker = mtmd_default_marker().to_string();
@@ -679,7 +1067,7 @@ impl LlamaCppProvider {
             .unwrap_or(&default_marker)
             .to_string();
 
-        for message in self.prepare_messages(messages) {
+        for message in self.prepare_fallback_messages(messages, None) {
             let mut content = message.content.clone();
             match message.message_type {
                 MessageType::Text => {}
@@ -689,7 +1077,6 @@ impl LlamaCppProvider {
                         content.push_str(&marker);
                     }
                 }
-                //TODO: Get a FIX
                 MessageType::ToolUse(_) | MessageType::ToolResult(_) => {
                     return Err(LLMError::invalid_request(
                         "MTMD path does not support tool calls".to_string(),
@@ -702,37 +1089,72 @@ impl LlamaCppProvider {
                 }
             }
 
-            let role = match message.role {
-                autoagents_llm::chat::ChatRole::System => "system",
-                autoagents_llm::chat::ChatRole::User => "user",
-                autoagents_llm::chat::ChatRole::Assistant => "assistant",
-                autoagents_llm::chat::ChatRole::Tool => "tool",
-            };
-
-            let chat_msg = LlamaChatMessage::new(role.to_string(), content)
-                .map_err(|err| LLMError::ProviderError(format!("Invalid chat message: {err}")))?;
-            chat.push(chat_msg);
+            chat.push(ChatMessage {
+                role: message.role,
+                message_type: MessageType::Text,
+                content,
+            });
         }
 
-        let prompt = self
-            .model
-            .apply_chat_template(&template, &chat, true)
-            .map_err(|err| {
-                LLMError::ProviderError(format!("Failed to apply chat template: {err}"))
-            })?;
+        let prompt = render_chat_template(
+            &self.config,
+            &template,
+            &chat,
+            None,
+            None,
+            None,
+            &self.template_tokens()?,
+        )
+        .map_err(LLMError::from)?
+        .prompt;
 
         Ok((prompt, images, marker))
     }
 
-    fn resolve_chat_template(&self) -> Result<LlamaChatTemplate, LLMError> {
+    fn template_tokens(&self) -> Result<TemplateTokens, LLMError> {
+        Ok(TemplateTokens {
+            bos_token: decode_model_special_token(&self.model, self.model.token_bos(), "BOS")?,
+            eos_token: decode_model_special_token(&self.model, self.model.token_eos(), "EOS")?,
+            add_bos: self.config.tokenizer_add_bos,
+            add_eos: self.config.tokenizer_add_eos,
+        })
+    }
+
+    fn resolve_chat_template_source(&self, prefer_tools: bool) -> Result<TemplateSource, LLMError> {
         if let Some(template) = self.config.chat_template.as_deref() {
-            return LlamaChatTemplate::new(template)
-                .map_err(|err| LLMError::ProviderError(format!("Invalid chat template: {err}")));
+            if template.contains("{%") || template.contains("{{") || template == "chatml" {
+                return Ok(explicit_template_source(template));
+            }
+            if let Ok(template) = self.model.chat_template(Some(template)) {
+                return Ok(TemplateSource {
+                    source: normalize_template_source(&template.to_string().map_err(|err| {
+                        LLMError::ProviderError(format!("Invalid chat template utf-8: {err}"))
+                    })?),
+                });
+            }
+            return Ok(explicit_template_source(template));
         }
 
-        self.model.chat_template(None).map_err(|err| {
-            LLMError::ProviderError(format!("Model does not provide a chat template: {err}"))
-        })
+        if prefer_tools && let Ok(template) = self.model.chat_template(Some("tool_use")) {
+            return Ok(TemplateSource {
+                source: normalize_template_source(&template.to_string().map_err(|err| {
+                    LLMError::ProviderError(format!("Invalid tool chat template utf-8: {err}"))
+                })?),
+            });
+        }
+
+        self.model
+            .chat_template(None)
+            .map_err(|err| {
+                LLMError::ProviderError(format!("Model does not provide a chat template: {err}"))
+            })
+            .and_then(|template| {
+                Ok(TemplateSource {
+                    source: normalize_template_source(&template.to_string().map_err(|err| {
+                        LLMError::ProviderError(format!("Invalid chat template utf-8: {err}"))
+                    })?),
+                })
+            })
     }
 
     fn build_usage(prompt_tokens: u32, completion_tokens: u32) -> ChatUsage {
@@ -759,11 +1181,12 @@ impl LlamaCppProvider {
         top_p_override.or(self.config.top_p)
     }
 
-    async fn run_blocking_task<T, F>(task_name: &str, f: F) -> Result<T, LLMError>
+    async fn run_blocking_task<T, F>(&self, task_name: &str, f: F) -> Result<T, LLMError>
     where
         T: Send + 'static,
         F: FnOnce() -> Result<T, LlamaCppProviderError> + Send + 'static,
     {
+        let _permit = self.scheduler.acquire().await?;
         get_rt()
             .spawn_blocking(f)
             .await
@@ -787,23 +1210,24 @@ impl LlamaCppProvider {
         let top_p = self.resolve_top_p(top_p_override);
         let session = self.session_state.clone();
 
-        let mut result = Self::run_blocking_task("Generation", move || {
-            generate_text(
-                &model,
-                &backend,
-                &config,
-                GenerationParams {
-                    prompt: &prompt,
-                    use_json_grammar,
-                    max_tokens,
-                    temperature,
-                    top_p,
-                    on_token: None,
-                },
-                session.as_ref(),
-            )
-        })
-        .await?;
+        let mut result = self
+            .run_blocking_task("Generation", move || {
+                generate_text(
+                    &model,
+                    &backend,
+                    &config,
+                    GenerationParams {
+                        prompt: &prompt,
+                        use_json_grammar,
+                        max_tokens,
+                        temperature,
+                        top_p,
+                        on_token: None,
+                    },
+                    session.as_ref(),
+                )
+            })
+            .await?;
 
         if use_json_grammar && let Some(extracted) = extract_json_payload(&result.text) {
             result.text = extracted;
@@ -814,7 +1238,7 @@ impl LlamaCppProvider {
 
     async fn generate_chat_completion(
         &self,
-        template_result: llama_cpp_2::model::ChatTemplateResult,
+        template_result: ChatTemplateResult,
         max_tokens_override: Option<u32>,
         temperature_override: Option<f32>,
         top_p_override: Option<f32>,
@@ -827,7 +1251,7 @@ impl LlamaCppProvider {
         let top_p = self.resolve_top_p(top_p_override);
         let session = self.session_state.clone();
 
-        Self::run_blocking_task("Generation", move || {
+        self.run_blocking_task("Generation", move || {
             generate_chat_text(
                 &model,
                 &backend,
@@ -861,10 +1285,18 @@ impl LlamaCppProvider {
         let temperature = self.resolve_temperature(temperature_override);
         let top_p = self.resolve_top_p(top_p_override);
         let session = self.session_state.clone();
+        let scheduler = self.scheduler.clone();
         let emitted_any = Arc::new(std::sync::atomic::AtomicBool::new(false));
         let tx_tokens = tx.clone();
 
         get_rt().spawn(async move {
+            let _permit = match scheduler.acquire().await {
+                Ok(permit) => permit,
+                Err(err) => {
+                    let _ = tx.send(Err(err));
+                    return;
+                }
+            };
             let emitted_any = Arc::clone(&emitted_any);
             let emitted_any_for_blocking = Arc::clone(&emitted_any);
             let result = tokio::task::spawn_blocking(
@@ -975,9 +1407,17 @@ impl LlamaCppProvider {
         let max_tokens = self.resolve_max_tokens(max_tokens_override);
         let temperature = self.resolve_temperature(temperature_override);
         let top_p = self.resolve_top_p(top_p_override);
+        let scheduler = self.scheduler.clone();
         let tx_tokens = tx.clone();
 
         get_rt().spawn(async move {
+            let _permit = match scheduler.acquire().await {
+                Ok(permit) => permit,
+                Err(err) => {
+                    let _ = tx.send(Err(err));
+                    return;
+                }
+            };
             let result = tokio::task::spawn_blocking(
                 move || -> Result<GenerationResult, LlamaCppProviderError> {
                     let on_token: Option<TokenCallback> = Some(Box::new(move |token: &str| {
@@ -1041,7 +1481,7 @@ impl LlamaCppProvider {
 
     fn spawn_chat_stream(
         &self,
-        template_result: llama_cpp_2::model::ChatTemplateResult,
+        template_result: ChatTemplateResult,
         max_tokens_override: Option<u32>,
         temperature_override: Option<f32>,
         top_p_override: Option<f32>,
@@ -1054,21 +1494,68 @@ impl LlamaCppProvider {
         let temperature = self.resolve_temperature(temperature_override);
         let top_p = self.resolve_top_p(top_p_override);
         let session = self.session_state.clone();
-        let tx_deltas = tx.clone();
+        let scheduler = self.scheduler.clone();
+        let stream_final_message = should_stream_final_message(&template_result);
+        let tx_tokens = tx.clone();
+        let tx_final_delta = tx.clone();
+        let parsed_stream_emitted = Arc::new(AtomicBool::new(false));
 
         get_rt().spawn(async move {
+            let _permit = match scheduler.acquire().await {
+                Ok(permit) => permit,
+                Err(err) => {
+                    let _ = tx.send(Err(err));
+                    return;
+                }
+            };
             let result = tokio::task::spawn_blocking(
                 move || -> Result<(GenerationResult, String), LlamaCppProviderError> {
-                    let on_delta: Option<DeltaCallback> = Some(Box::new(move |delta: &str| {
-                        tx_deltas
-                            .send(Ok(StreamEvent::Delta(delta.to_string())))
-                            .map_err(|_| {
+                    let parsed_stream_state = Arc::new(Mutex::new(String::new()));
+                    let parsed_stream_emitted_for_callback = parsed_stream_emitted.clone();
+                    let on_delta: Option<DeltaCallback> = if stream_final_message {
+                        let template_result_for_callback = template_result.clone();
+                        let tx_parsed = tx_tokens.clone();
+                        Some(Box::new(move |delta: &str| {
+                            let mut buffer = parsed_stream_state.lock().map_err(|_| {
                                 LlamaCppProviderError::Inference(
-                                    "Stream receiver dropped".to_string(),
+                                    "Parsed stream state lock poisoned".to_string(),
                                 )
                             })?;
-                        Ok(())
-                    }));
+                            buffer.push_str(delta);
+                            match template_result_for_callback
+                                .parse_partial_response_oaicompat(&buffer)
+                            {
+                                Ok(Some(message_json)) => {
+                                    let delta_json = stream_delta_from_message_json(&message_json)?;
+                                    if !delta_json.is_empty() {
+                                        tx_parsed
+                                            .send(Ok(StreamEvent::Delta(delta_json)))
+                                            .map_err(|_| {
+                                                LlamaCppProviderError::Inference(
+                                                    "Stream receiver dropped".to_string(),
+                                                )
+                                            })?;
+                                        parsed_stream_emitted_for_callback
+                                            .store(true, Ordering::Relaxed);
+                                    }
+                                }
+                                Ok(None) => {}
+                                Err(_) => {}
+                            }
+                            Ok(())
+                        }))
+                    } else {
+                        Some(Box::new(move |delta: &str| {
+                            tx_tokens
+                                .send(Ok(StreamEvent::Token(delta.to_string())))
+                                .map_err(|_| {
+                                    LlamaCppProviderError::Inference(
+                                        "Stream receiver dropped".to_string(),
+                                    )
+                                })?;
+                            Ok(())
+                        }))
+                    };
 
                     let generation = generate_chat_text(
                         &model,
@@ -1085,12 +1572,10 @@ impl LlamaCppProvider {
                     )?;
 
                     let message_json = template_result
-                        .parse_response_oaicompat(&generation.text, false)
+                        .parse_response_oaicompat(&generation.text)
                         .map_err(|err| {
-                            LlamaCppProviderError::Template(format!(
-                                "Failed to parse response: {err}"
-                            ))
-                        })?;
+                        LlamaCppProviderError::Template(format!("Failed to parse response: {err}"))
+                    })?;
                     let message: OpenAICompatMessage = serde_json::from_str(&message_json)
                         .map_err(|err| {
                             LlamaCppProviderError::Template(format!(
@@ -1110,6 +1595,20 @@ impl LlamaCppProvider {
                     } else {
                         "end_turn".to_string()
                     };
+
+                    if stream_final_message {
+                        let delta_json = stream_delta_from_message_json(&message_json)?;
+                        if !delta_json.is_empty() && !parsed_stream_emitted.load(Ordering::Relaxed)
+                        {
+                            tx_final_delta
+                                .send(Ok(StreamEvent::Delta(delta_json)))
+                                .map_err(|_| {
+                                    LlamaCppProviderError::Inference(
+                                        "Stream receiver dropped".to_string(),
+                                    )
+                                })?;
+                        }
+                    }
 
                     Ok((generation, stop_reason))
                 },
@@ -1185,8 +1684,8 @@ impl LlamaCppProvider {
                 let max_tokens = self.resolve_max_tokens(max_tokens_override);
                 let temperature = self.resolve_temperature(temperature_override);
                 let top_p = self.resolve_top_p(top_p_override);
-                let result = get_rt()
-                    .spawn_blocking(move || {
+                let result = self
+                    .run_blocking_task("MTMD generation", move || {
                         generate_mtmd_text(
                             &model,
                             &backend,
@@ -1202,11 +1701,7 @@ impl LlamaCppProvider {
                             },
                         )
                     })
-                    .await
-                    .map_err(|err| {
-                        LLMError::ProviderError(format!("Generation task failed: {err}"))
-                    })?
-                    .map_err(LLMError::from)?;
+                    .await?;
 
                 let usage = Some(Self::build_usage(
                     result.prompt_tokens,
@@ -1270,7 +1765,7 @@ impl LlamaCppProvider {
                     )
                     .await?;
                 let message_json = template_result
-                    .parse_response_oaicompat(&result.text, false)
+                    .parse_response_oaicompat(&result.text)
                     .map_err(|err| {
                         LLMError::ProviderError(format!("Failed to parse response: {err}"))
                     })?;
@@ -1446,12 +1941,9 @@ impl LlamaCppProvider {
         };
 
         let struct_stream = response_stream
-            .scan(
-                HashMap::<usize, ToolCallState>::new(),
-                |tool_states, event| {
-                    futures::future::ready(Some(map_struct_stream_event(event, tool_states)))
-                },
-            )
+            .scan(StreamMappingState::default(), |stream_state, event| {
+                futures::future::ready(Some(map_struct_stream_event(event, stream_state)))
+            })
             .flat_map(futures::stream::iter);
 
         Ok(Box::pin(struct_stream))
@@ -1524,12 +2016,9 @@ impl LlamaCppProvider {
         };
 
         let stream = response_stream
-            .scan(
-                HashMap::<usize, ToolCallState>::new(),
-                |tool_states, event| {
-                    futures::future::ready(Some(map_tool_stream_event(event, tool_states)))
-                },
-            )
+            .scan(StreamMappingState::default(), |stream_state, event| {
+                futures::future::ready(Some(map_tool_stream_event(event, stream_state)))
+            })
             .flat_map(futures::stream::iter);
 
         Ok(Box::pin(stream))
@@ -1665,6 +2154,1855 @@ fn prepare_fallback_messages_with_schema(
     all_messages
 }
 
+fn parse_tool_response_message(text: &str) -> Result<Option<Value>, LlamaCppProviderError> {
+    parse_tool_response_message_with_allowed_tools(text, None)
+}
+
+fn parse_tool_response_message_with_allowed_tools(
+    text: &str,
+    allowed_tools: Option<&[String]>,
+) -> Result<Option<Value>, LlamaCppProviderError> {
+    if let Some(message) = parse_native_channel_tool_calls(text)? {
+        return Ok(filter_tool_message_by_allowed_tools(message, allowed_tools));
+    }
+    if let Some(message) = parse_tool_calls_args_tag(text)? {
+        return Ok(filter_tool_message_by_allowed_tools(message, allowed_tools));
+    }
+    if let Some(message) = parse_gemma4_tool_calls(text)? {
+        return Ok(filter_tool_message_by_allowed_tools(message, allowed_tools));
+    }
+    if let Some(message) = parse_generic_function_tag_tool_calls(text)? {
+        return Ok(filter_tool_message_by_allowed_tools(message, allowed_tools));
+    }
+    if let Some(message) = parse_functionary_tool_calls(text)? {
+        return Ok(filter_tool_message_by_allowed_tools(message, allowed_tools));
+    }
+    if let Some(message) = parse_kimi_k2_tool_calls(text)? {
+        return Ok(filter_tool_message_by_allowed_tools(message, allowed_tools));
+    }
+    if let Some(message) = parse_lfm2_tool_calls(text)? {
+        return Ok(filter_tool_message_by_allowed_tools(message, allowed_tools));
+    }
+    if let Some(message) = parse_gigachat_v3_tool_calls(text)? {
+        return Ok(filter_tool_message_by_allowed_tools(message, allowed_tools));
+    }
+    if let Some(message) = parse_deepseek_dsml_tool_calls(text)? {
+        return Ok(filter_tool_message_by_allowed_tools(message, allowed_tools));
+    }
+
+    let Some(json_text) = extract_json_payload(text) else {
+        return Ok(None);
+    };
+    let value: Value = serde_json::from_str(&json_text)
+        .map_err(|err| LlamaCppProviderError::Template(format!("Invalid tool JSON: {err}")))?;
+
+    if let Some(calls) = value.get("tool_calls").and_then(Value::as_array) {
+        let normalized = normalize_tool_calls(calls)?;
+        if normalized.is_empty() || !normalized_tool_calls_allowed(&normalized, allowed_tools) {
+            return Ok(None);
+        }
+        let mut message = json!({ "tool_calls": normalized });
+        merge_openai_compat_envelope_fields(&mut message, &value);
+        return Ok(Some(message));
+    }
+
+    if let Some(calls) = value.as_array() {
+        if !calls
+            .iter()
+            .all(|call| is_json_tool_call_candidate(call, allowed_tools))
+        {
+            return Ok(None);
+        }
+        let normalized = normalize_tool_calls(calls)?;
+        if normalized.is_empty() {
+            return Ok(None);
+        }
+        return Ok(Some(json!({ "tool_calls": normalized })));
+    }
+
+    if let Some(calls) = normalize_function_key_tool_calls(&value, allowed_tools)? {
+        return Ok(Some(json!({ "tool_calls": calls })));
+    }
+
+    if is_openai_compat_single_tool_call(&value, allowed_tools) {
+        let normalized = normalize_tool_calls(std::slice::from_ref(&value))?;
+        return Ok(Some(json!({ "tool_calls": normalized })));
+    }
+
+    Ok(None)
+}
+
+fn is_openai_compat_single_tool_call(value: &Value, allowed_tools: Option<&[String]>) -> bool {
+    let Some(object) = value.as_object() else {
+        return false;
+    };
+    if object.get("function").is_some() {
+        let function_name = object
+            .get("function")
+            .and_then(Value::as_object)
+            .and_then(|function| function.get("name"))
+            .and_then(Value::as_str);
+        return function_name
+            .map(|name| tool_name_allowed(name, allowed_tools))
+            .unwrap_or(true);
+    }
+    if object
+        .get("name")
+        .and_then(Value::as_str)
+        .is_none_or(|name| name.trim().is_empty())
+    {
+        return false;
+    }
+    let name = object
+        .get("name")
+        .and_then(Value::as_str)
+        .expect("name checked above");
+    if !tool_name_allowed(name, allowed_tools) {
+        return false;
+    }
+    if object
+        .get("type")
+        .and_then(Value::as_str)
+        .is_some_and(|call_type| call_type == "function")
+    {
+        return true;
+    }
+    tool_arguments_payload_from_object(object).is_some()
+        || tool_call_id_from_object(object).is_some()
+}
+
+fn is_json_tool_call_candidate(value: &Value, allowed_tools: Option<&[String]>) -> bool {
+    is_openai_compat_single_tool_call(value, allowed_tools)
+        || is_function_key_tool_call_candidate(value, allowed_tools)
+        || is_wrapped_nested_tool_call_candidate(value, allowed_tools)
+}
+
+fn is_function_key_tool_call_candidate(value: &Value, allowed_tools: Option<&[String]>) -> bool {
+    let Some(object) = value.as_object() else {
+        return false;
+    };
+    if object.len() != 1 {
+        return false;
+    }
+    let Some((name, payload)) = object.iter().next() else {
+        return false;
+    };
+    !is_reserved_tool_envelope_key(name)
+        && !name.is_empty()
+        && name.chars().all(is_native_tool_name_char)
+        && tool_name_allowed(name, allowed_tools)
+        && payload.is_object()
+        && payload
+            .get("name")
+            .and_then(Value::as_str)
+            .is_none_or(|name| name.trim().is_empty())
+}
+
+fn is_wrapped_nested_tool_call_candidate(value: &Value, allowed_tools: Option<&[String]>) -> bool {
+    value.as_object().is_some_and(|object| {
+        object
+            .values()
+            .any(|value| is_nested_function_payload(value, allowed_tools))
+    })
+}
+
+fn is_nested_function_payload(value: &Value, allowed_tools: Option<&[String]>) -> bool {
+    value.as_object().is_some_and(|nested| {
+        nested
+            .get("name")
+            .and_then(Value::as_str)
+            .is_some_and(|name| !name.trim().is_empty() && tool_name_allowed(name, allowed_tools))
+            && tool_arguments_payload_from_object(nested).is_some()
+    })
+}
+
+fn tool_name_allowed(name: &str, allowed_tools: Option<&[String]>) -> bool {
+    allowed_tools
+        .is_none_or(|allowed| allowed.is_empty() || allowed.iter().any(|tool| tool == name))
+}
+
+fn normalized_tool_calls_allowed(calls: &[Value], allowed_tools: Option<&[String]>) -> bool {
+    calls.iter().all(|call| {
+        call.get("function")
+            .and_then(Value::as_object)
+            .and_then(|function| function.get("name"))
+            .and_then(Value::as_str)
+            .is_some_and(|name| tool_name_allowed(name, allowed_tools))
+    })
+}
+
+fn filter_tool_message_by_allowed_tools(
+    message: Value,
+    allowed_tools: Option<&[String]>,
+) -> Option<Value> {
+    let calls = message.get("tool_calls").and_then(Value::as_array);
+    if calls.is_none_or(|calls| normalized_tool_calls_allowed(calls, allowed_tools)) {
+        Some(message)
+    } else {
+        None
+    }
+}
+
+fn merge_openai_compat_envelope_fields(message: &mut Value, source: &Value) {
+    let Some(message_object) = message.as_object_mut() else {
+        return;
+    };
+    let Some(source_object) = source.as_object() else {
+        return;
+    };
+
+    if let Some(content) = source_object
+        .get("content")
+        .and_then(Value::as_str)
+        .filter(|content| !content.is_empty())
+    {
+        message_object.insert("content".to_string(), Value::String(content.to_string()));
+    }
+
+    let reasoning_content = source_object
+        .get("reasoning_content")
+        .or_else(|| source_object.get("thinking"))
+        .and_then(Value::as_str)
+        .filter(|reasoning_content| !reasoning_content.is_empty());
+    if let Some(reasoning_content) = reasoning_content {
+        message_object.insert(
+            "reasoning_content".to_string(),
+            Value::String(reasoning_content.to_string()),
+        );
+    }
+}
+
+fn normalized_tool_message(calls: &[Value]) -> Result<Option<Value>, LlamaCppProviderError> {
+    if calls.is_empty() {
+        return Ok(None);
+    }
+
+    let normalized = normalize_tool_calls(calls)?;
+    Ok(Some(json!({ "tool_calls": normalized })))
+}
+
+fn normalized_tool_message_with_content(
+    calls: &[Value],
+    content: Option<String>,
+) -> Result<Option<Value>, LlamaCppProviderError> {
+    if calls.is_empty() {
+        return Ok(content
+            .filter(|content| !content.is_empty())
+            .map(|content| json!({ "content": content })));
+    }
+
+    let Some(mut message) = normalized_tool_message(calls)? else {
+        return Ok(None);
+    };
+    if let Some(content) = content
+        && !content.is_empty()
+        && let Some(object) = message.as_object_mut()
+    {
+        object.insert("content".to_string(), Value::String(content));
+    }
+    Ok(Some(message))
+}
+
+fn content_before_marker(text: &str, marker: &str) -> Option<String> {
+    text.find(marker)
+        .map(|index| text[..index].trim().to_string())
+        .filter(|content| !content.is_empty())
+}
+
+fn parse_native_channel_tool_calls(text: &str) -> Result<Option<Value>, LlamaCppProviderError> {
+    let mut calls = Vec::new();
+    let mut search_start = 0;
+    const RECIPIENT: &str = "to=functions.";
+    const MESSAGE_MARKER: &str = "<|message|>";
+
+    while let Some(relative_pos) = text[search_start..].find(RECIPIENT) {
+        let recipient_pos = search_start + relative_pos;
+        let name_start = recipient_pos + RECIPIENT.len();
+        let name_end = text[name_start..]
+            .find(|ch: char| !is_native_tool_name_char(ch))
+            .map_or(text.len(), |offset| name_start + offset);
+        let name = text[name_start..name_end].trim();
+        if name.is_empty() {
+            search_start = name_start;
+            continue;
+        }
+
+        let Some(message_relative_pos) = text[name_end..].find(MESSAGE_MARKER) else {
+            search_start = name_end;
+            continue;
+        };
+        let arguments_start = name_end + message_relative_pos + MESSAGE_MARKER.len();
+        let arguments_end = text[arguments_start..]
+            .find("<|end|>")
+            .map_or(text.len(), |offset| arguments_start + offset);
+        let arguments_text = text[arguments_start..arguments_end].trim();
+        if arguments_text.is_empty() {
+            search_start = arguments_end;
+            continue;
+        }
+
+        let arguments = extract_json_payload(arguments_text).ok_or_else(|| {
+            LlamaCppProviderError::Template(format!(
+                "Tool call arguments for `{name}` are not valid JSON"
+            ))
+        })?;
+        calls.push(json!({
+            "name": name,
+            "arguments": serde_json::from_str::<Value>(&arguments).map_err(|err| {
+                LlamaCppProviderError::Template(format!(
+                    "Tool call arguments for `{name}` are not valid JSON: {err}"
+                ))
+            })?
+        }));
+        search_start = arguments_end;
+    }
+
+    let Some(mut message) = normalized_tool_message(&calls)? else {
+        return Ok(None);
+    };
+    let (content, reasoning_content) = parse_native_non_tool_channels(text);
+    if let Some(object) = message.as_object_mut() {
+        if let Some(content) = content.filter(|content| !content.is_empty()) {
+            object.insert("content".to_string(), Value::String(content));
+        }
+        if let Some(reasoning_content) =
+            reasoning_content.filter(|reasoning_content| !reasoning_content.is_empty())
+        {
+            object.insert(
+                "reasoning_content".to_string(),
+                Value::String(reasoning_content),
+            );
+        }
+    }
+    Ok(Some(message))
+}
+
+fn parse_native_non_tool_channels(text: &str) -> (Option<String>, Option<String>) {
+    const START_MARKER: &str = "<|start|>assistant";
+    const CHANNEL_MARKER: &str = "<|channel|>";
+    const MESSAGE_MARKER: &str = "<|message|>";
+    const END_MARKER: &str = "<|end|>";
+
+    let mut content_parts = Vec::new();
+    let mut reasoning_parts = Vec::new();
+    let mut search_start = 0;
+
+    while let Some(relative_pos) = text[search_start..].find(CHANNEL_MARKER) {
+        let channel_marker_pos = search_start + relative_pos;
+        let channel_pos = channel_marker_pos + CHANNEL_MARKER.len();
+        let Some(channel_end_relative) = text[channel_pos..].find(MESSAGE_MARKER) else {
+            break;
+        };
+        let channel_end = channel_pos + channel_end_relative;
+        let header = native_effective_channel_header(&text[channel_pos..channel_end]);
+        let content_start = channel_end + MESSAGE_MARKER.len();
+        let content_end = text[content_start..]
+            .find(END_MARKER)
+            .map_or(text.len(), |offset| content_start + offset);
+        let payload = text[content_start..content_end].trim();
+
+        let start_header = text[..channel_marker_pos]
+            .rfind(START_MARKER)
+            .map(|start| &text[start + START_MARKER.len()..channel_marker_pos])
+            .unwrap_or_default();
+        let is_tool_channel = header.contains("to=functions.")
+            || start_header.contains("to=functions.")
+            || header.starts_with("to=");
+
+        if !is_tool_channel && !payload.is_empty() {
+            if header.starts_with("commentary") || header.starts_with("final") {
+                content_parts.push(payload.to_string());
+            } else if header.starts_with("analysis") {
+                reasoning_parts.push(payload.to_string());
+            }
+        }
+
+        search_start = content_end.saturating_add(END_MARKER.len()).min(text.len());
+    }
+
+    let content = if content_parts.is_empty() {
+        None
+    } else {
+        Some(content_parts.join("\n"))
+    };
+    let reasoning_content = if reasoning_parts.is_empty() {
+        None
+    } else {
+        Some(reasoning_parts.join("\n"))
+    };
+    (content, reasoning_content)
+}
+
+fn parse_tool_calls_args_tag(text: &str) -> Result<Option<Value>, LlamaCppProviderError> {
+    const START: &str = "[TOOL_CALLS]";
+    const ARGS: &str = "[ARGS]";
+
+    let mut calls = Vec::new();
+    let content = content_before_marker(text, START);
+    let mut search_start = 0;
+    while let Some(relative_pos) = text[search_start..].find(START) {
+        let name_start = search_start + relative_pos + START.len();
+        let Some(args_relative_pos) = text[name_start..].find(ARGS) else {
+            search_start = name_start;
+            continue;
+        };
+        let args_marker = name_start + args_relative_pos;
+        let name = text[name_start..args_marker].trim();
+        if name.is_empty() || !name.chars().all(is_native_tool_name_char) {
+            search_start = args_marker + ARGS.len();
+            continue;
+        }
+
+        let args_start = args_marker + ARGS.len();
+        let args_end = text[args_start..]
+            .find(START)
+            .map_or(text.len(), |offset| args_start + offset);
+        let arguments_text = text[args_start..args_end].trim();
+        let Some(arguments_json) = extract_json_payload(arguments_text) else {
+            search_start = args_end;
+            continue;
+        };
+        let arguments = serde_json::from_str::<Value>(&arguments_json).map_err(|err| {
+            LlamaCppProviderError::Template(format!(
+                "Ministral/Magistral tool call arguments for `{name}` are not valid JSON: {err}"
+            ))
+        })?;
+        calls.push(json!({
+            "name": name,
+            "arguments": arguments,
+        }));
+        search_start = args_end;
+    }
+
+    normalized_tool_message_with_content(&calls, content)
+}
+
+fn is_native_tool_name_char(ch: char) -> bool {
+    ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-' | '.')
+}
+
+fn parse_native_channel_content_partial(text: &str) -> Option<(String, Option<String>)> {
+    const CHANNEL_MARKER: &str = "<|channel|>";
+    const MESSAGE_MARKER: &str = "<|message|>";
+    const END_MARKER: &str = "<|end|>";
+
+    if !text.contains(CHANNEL_MARKER) || !text.contains(MESSAGE_MARKER) {
+        return None;
+    }
+
+    let mut final_content = None;
+    let mut reasoning_parts = Vec::new();
+    let mut search_start = 0;
+
+    while let Some(relative_pos) = text[search_start..].find(CHANNEL_MARKER) {
+        let channel_pos = search_start + relative_pos + CHANNEL_MARKER.len();
+        let channel_end = text[channel_pos..]
+            .find(MESSAGE_MARKER)
+            .map(|offset| channel_pos + offset)?;
+        let header = native_effective_channel_header(&text[channel_pos..channel_end]);
+        let content_start = channel_end + MESSAGE_MARKER.len();
+        let content_end = text[content_start..]
+            .find(END_MARKER)
+            .map_or(text.len(), |offset| content_start + offset);
+        let content = text[content_start..content_end].trim();
+
+        if header.starts_with("analysis") && !content.is_empty() {
+            reasoning_parts.push(content.to_string());
+        } else if header.starts_with("final") {
+            final_content = Some(content.to_string());
+        }
+
+        search_start = content_end.saturating_add(END_MARKER.len()).min(text.len());
+    }
+
+    if final_content.is_none() && reasoning_parts.is_empty() {
+        return None;
+    }
+
+    Some({
+        let reasoning = if reasoning_parts.is_empty() {
+            None
+        } else {
+            Some(reasoning_parts.join("\n"))
+        };
+        (final_content.unwrap_or_default(), reasoning)
+    })
+}
+
+fn native_effective_channel_header(header: &str) -> &str {
+    const CHANNEL_MARKER: &str = "<|channel|>";
+    header
+        .rsplit_once(CHANNEL_MARKER)
+        .map_or(header, |(_, effective)| effective)
+        .trim()
+}
+
+fn parse_gemma4_tool_calls(text: &str) -> Result<Option<Value>, LlamaCppProviderError> {
+    const PREFIX: &str = "<|turn>model\n";
+    const START: &str = "<|tool_call>call:";
+    const END: &str = "<tool_call|>";
+
+    let text = text.strip_prefix(PREFIX).unwrap_or(text);
+    let mut calls = Vec::new();
+    let content = content_before_marker(text, START);
+    let mut search_start = 0;
+    while let Some(relative_pos) = text[search_start..].find(START) {
+        let call_start = search_start + relative_pos + START.len();
+        let Some(name_end_relative) = text[call_start..].find('{') else {
+            search_start = call_start;
+            continue;
+        };
+        let name_end = call_start + name_end_relative;
+        let name = text[call_start..name_end].trim();
+        if name.is_empty() {
+            search_start = name_end;
+            continue;
+        }
+        let call_end = text[name_end..]
+            .find(END)
+            .map_or(text.len(), |offset| name_end + offset);
+        let arguments_text = &text[name_end..call_end];
+        let arguments = extract_first_balanced(arguments_text, '{', '}').ok_or_else(|| {
+            LlamaCppProviderError::Template(format!(
+                "Gemma4 tool call arguments for `{name}` are not valid JSON"
+            ))
+        })?;
+        let arguments = parse_gemma4_arguments(&arguments).map_err(|err| {
+            LlamaCppProviderError::Template(format!(
+                "Gemma4 tool call arguments for `{name}` are not valid JSON: {err}"
+            ))
+        })?;
+        calls.push(json!({
+            "name": name,
+            "arguments": arguments
+        }));
+        search_start = call_end.saturating_add(END.len()).min(text.len());
+    }
+
+    normalized_tool_message_with_content(&calls, content)
+}
+
+fn parse_gemma4_arguments(text: &str) -> Result<Value, serde_json::Error> {
+    match serde_json::from_str::<Value>(text) {
+        Ok(value) => Ok(value),
+        Err(err) => {
+            let normalized = normalize_gemma4_argument_syntax(text);
+            serde_json::from_str::<Value>(&normalized).map_err(|_| err)
+        }
+    }
+}
+
+fn normalize_gemma4_argument_syntax(text: &str) -> String {
+    let normalized_strings = normalize_gemma4_quoted_strings(text);
+    quote_unquoted_object_keys(&normalized_strings)
+}
+
+fn parse_generic_function_tag_tool_calls(
+    text: &str,
+) -> Result<Option<Value>, LlamaCppProviderError> {
+    const START: &str = "<function=";
+    const END: &str = "</function>";
+
+    let mut calls = Vec::new();
+    let content = content_before_marker(text, START);
+    let mut search_start = 0;
+
+    while let Some(relative_pos) = text[search_start..].find(START) {
+        let name_start = search_start + relative_pos + START.len();
+        let Some(name_end_relative) = text[name_start..].find('>') else {
+            search_start = name_start;
+            continue;
+        };
+        let name_end = name_start + name_end_relative;
+        let name = text[name_start..name_end].trim();
+        if name.is_empty() || !name.chars().all(is_native_tool_name_char) {
+            search_start = name_end + 1;
+            continue;
+        }
+
+        let arguments_start = name_end + 1;
+        let arguments_end = text[arguments_start..]
+            .find(END)
+            .map_or(text.len(), |offset| arguments_start + offset);
+        let arguments_text = text[arguments_start..arguments_end].trim();
+        let arguments = if let Some(arguments_json) = extract_json_payload(arguments_text) {
+            serde_json::from_str::<Value>(&arguments_json).map_err(|err| {
+                LlamaCppProviderError::Template(format!(
+                    "Generic function-tag arguments for `{name}` are not valid JSON: {err}"
+                ))
+            })?
+        } else if let Some(arguments) = parse_generic_tagged_arguments(name, arguments_text)? {
+            arguments
+        } else {
+            search_start = arguments_end.saturating_add(END.len()).min(text.len());
+            continue;
+        };
+
+        calls.push(json!({
+            "name": name,
+            "arguments": arguments,
+        }));
+        search_start = arguments_end.saturating_add(END.len()).min(text.len());
+    }
+
+    normalized_tool_message_with_content(&calls, content)
+}
+
+fn parse_generic_tagged_arguments(
+    _function_name: &str,
+    text: &str,
+) -> Result<Option<Value>, LlamaCppProviderError> {
+    let mut arguments = serde_json::Map::new();
+    let mut search_start = 0;
+
+    while let Some((tag, tag_pos)) = find_next_generic_argument_tag(text, search_start) {
+        let name_start = tag_pos + tag.open.len();
+        let Some(name_end_relative) = text[name_start..].find('"') else {
+            break;
+        };
+        let name_end = name_start + name_end_relative;
+        let name = text[name_start..name_end].trim();
+        if name.is_empty() || !name.chars().all(is_native_tool_name_char) {
+            search_start = name_end;
+            continue;
+        }
+
+        let Some(open_end_relative) = text[name_end..].find('>') else {
+            break;
+        };
+        let value_start = name_end + open_end_relative + 1;
+        let value_end = text[value_start..]
+            .find(tag.close)
+            .map_or(text.len(), |offset| value_start + offset);
+        let value_text = text[value_start..value_end].trim();
+        let value = if value_text.is_empty() {
+            Value::String(String::new())
+        } else if let Ok(value) = serde_json::from_str::<Value>(value_text) {
+            value
+        } else {
+            Value::String(value_text.to_string())
+        };
+        arguments.insert(name.to_string(), value);
+        search_start = value_end.saturating_add(tag.close.len()).min(text.len());
+    }
+
+    if arguments.is_empty() {
+        return Ok(None);
+    }
+
+    Ok(Some(Value::Object(arguments)))
+}
+
+#[derive(Clone, Copy)]
+struct GenericArgumentTag {
+    open: &'static str,
+    close: &'static str,
+}
+
+fn find_next_generic_argument_tag(
+    text: &str,
+    search_start: usize,
+) -> Option<(GenericArgumentTag, usize)> {
+    const TAGS: [GenericArgumentTag; 3] = [
+        GenericArgumentTag {
+            open: "<parameter name=\"",
+            close: "</parameter>",
+        },
+        GenericArgumentTag {
+            open: "<param name=\"",
+            close: "</param>",
+        },
+        GenericArgumentTag {
+            open: "<arg name=\"",
+            close: "</arg>",
+        },
+    ];
+
+    TAGS.iter()
+        .filter_map(|tag| {
+            text[search_start..]
+                .find(tag.open)
+                .map(|offset| (*tag, search_start + offset))
+        })
+        .min_by_key(|(_, index)| *index)
+}
+
+fn normalize_gemma4_quoted_strings(text: &str) -> String {
+    const MARKER: &str = "<|\"|>";
+
+    let mut output = String::with_capacity(text.len());
+    let mut rest = text;
+
+    while let Some(marker_start) = rest.find(MARKER) {
+        output.push_str(&rest[..marker_start]);
+        let content_start = marker_start + MARKER.len();
+        let Some(content_end_relative) = rest[content_start..].find(MARKER) else {
+            output.push_str(&rest[marker_start..]);
+            return output;
+        };
+        let content_end = content_start + content_end_relative;
+        let content = &rest[content_start..content_end];
+        match serde_json::to_string(content) {
+            Ok(quoted) => output.push_str(&quoted),
+            Err(_) => output.push_str(content),
+        }
+        rest = &rest[content_end + MARKER.len()..];
+    }
+
+    output.push_str(rest);
+    output
+}
+
+fn extract_first_balanced(text: &str, open: char, close: char) -> Option<String> {
+    let mut in_string = None;
+    let mut escape = false;
+    let mut depth = 0i32;
+    let mut start = None;
+
+    for (idx, ch) in text.char_indices() {
+        if let Some(quote) = in_string {
+            if escape {
+                escape = false;
+                continue;
+            }
+            match ch {
+                '\\' => escape = true,
+                current if current == quote => in_string = None,
+                _ => {}
+            }
+            continue;
+        }
+
+        match ch {
+            '"' | '\'' => in_string = Some(ch),
+            current if current == open => {
+                if depth == 0 {
+                    start = Some(idx);
+                }
+                depth += 1;
+            }
+            current if current == close && depth > 0 => {
+                depth -= 1;
+                if depth == 0 {
+                    if let Some(start_idx) = start {
+                        return Some(text[start_idx..=idx].trim().to_string());
+                    }
+                    start = None;
+                }
+            }
+            _ => {}
+        }
+    }
+
+    None
+}
+
+fn quote_unquoted_object_keys(text: &str) -> String {
+    let mut output = String::with_capacity(text.len() + 8);
+    let mut chars = text.chars().peekable();
+    let mut in_string = None;
+    let mut escaped = false;
+    let mut expecting_key = false;
+
+    while let Some(ch) = chars.next() {
+        if let Some(quote) = in_string {
+            output.push(ch);
+            if escaped {
+                escaped = false;
+            } else if ch == '\\' {
+                escaped = true;
+            } else if ch == quote {
+                in_string = None;
+            }
+            continue;
+        }
+
+        match ch {
+            '"' | '\'' => {
+                in_string = Some(ch);
+                output.push(ch);
+            }
+            '{' | ',' => {
+                expecting_key = true;
+                output.push(ch);
+            }
+            ':' => {
+                expecting_key = false;
+                output.push(ch);
+            }
+            ch if expecting_key && ch.is_whitespace() => output.push(ch),
+            ch if expecting_key && is_gemma4_unquoted_key_start(ch) => {
+                let mut key = String::new();
+                key.push(ch);
+                while let Some(next) = chars.peek().copied() {
+                    if is_gemma4_unquoted_key_char(next) {
+                        key.push(next);
+                        chars.next();
+                    } else {
+                        break;
+                    }
+                }
+                output.push('"');
+                output.push_str(&key);
+                output.push('"');
+                expecting_key = false;
+            }
+            _ => output.push(ch),
+        }
+    }
+
+    output
+}
+
+fn is_gemma4_unquoted_key_start(ch: char) -> bool {
+    ch.is_ascii_alphabetic() || ch == '_' || ch == '-'
+}
+
+fn is_gemma4_unquoted_key_char(ch: char) -> bool {
+    ch.is_ascii_alphanumeric() || matches!(ch, '_' | '-' | '.')
+}
+
+fn parse_functionary_tool_calls(text: &str) -> Result<Option<Value>, LlamaCppProviderError> {
+    const START: &str = ">>>";
+    let normalized_text;
+    let implicit_generation_prompt = !text.contains(START);
+    let text = if implicit_generation_prompt {
+        let Some((recipient, payload)) = text.split_once('\n') else {
+            return Ok(None);
+        };
+        let recipient = recipient.trim();
+        if recipient != "all" && !payload.trim_start().starts_with(['{', '[']) {
+            return Ok(None);
+        }
+        normalized_text = format!("{START}{text}");
+        normalized_text.as_str()
+    } else {
+        text
+    };
+    let mut calls = Vec::new();
+    let mut content = None;
+    let mut search_start = 0;
+
+    while let Some(relative_pos) = text[search_start..].find(START) {
+        let recipient_start = search_start + relative_pos + START.len();
+        let Some(line_end_relative) = text[recipient_start..].find('\n') else {
+            break;
+        };
+        let line_end = recipient_start + line_end_relative;
+        let recipient = text[recipient_start..line_end].trim();
+        let payload_start = line_end + 1;
+        let payload_end = text[payload_start..]
+            .find(START)
+            .map_or(text.len(), |offset| payload_start + offset);
+        let payload = text[payload_start..payload_end].trim();
+
+        if recipient.is_empty() || recipient == "all" {
+            if recipient == "all" && !payload.is_empty() {
+                append_content_segment(&mut content, payload);
+            }
+            search_start = payload_end;
+            continue;
+        }
+
+        let Some(arguments) = extract_json_payload(payload) else {
+            if implicit_generation_prompt {
+                return Ok(None);
+            }
+            return Err(LlamaCppProviderError::Template(format!(
+                "Functionary tool call arguments for `{recipient}` are not valid JSON"
+            )));
+        };
+        let arguments = match serde_json::from_str::<Value>(&arguments) {
+            Ok(arguments) => arguments,
+            Err(err) if implicit_generation_prompt => {
+                let _ = err;
+                return Ok(None);
+            }
+            Err(err) => {
+                return Err(LlamaCppProviderError::Template(format!(
+                    "Functionary tool call arguments for `{recipient}` are not valid JSON: {err}"
+                )));
+            }
+        };
+        calls.push(json!({
+            "name": recipient,
+            "arguments": arguments,
+        }));
+        search_start = payload_end;
+    }
+
+    normalized_tool_message_with_content(&calls, content)
+}
+
+fn append_content_segment(content: &mut Option<String>, segment: &str) {
+    match content {
+        Some(existing) if !existing.is_empty() => {
+            existing.push('\n');
+            existing.push_str(segment);
+        }
+        Some(existing) => existing.push_str(segment),
+        None => *content = Some(segment.to_string()),
+    }
+}
+
+fn parse_kimi_k2_tool_calls(text: &str) -> Result<Option<Value>, LlamaCppProviderError> {
+    const PREFIX: &str = "<|im_assistant|>assistant<|im_middle|>";
+    const START: &str = "<|tool_call_begin|>functions.";
+    const SECTION_BEGIN: &str = "<|tool_calls_section_begin|>";
+    const ARGS: &str = "<|tool_call_argument_begin|>";
+    const END: &str = "<|tool_call_end|>";
+
+    let text = text.strip_prefix(PREFIX).unwrap_or(text);
+    let mut calls = Vec::new();
+    let content_marker = match (text.find(SECTION_BEGIN), text.find(START)) {
+        (Some(section), Some(start)) => {
+            if section < start {
+                SECTION_BEGIN
+            } else {
+                START
+            }
+        }
+        (Some(_), None) => SECTION_BEGIN,
+        _ => START,
+    };
+    let content = content_before_marker(text, content_marker);
+    let mut search_start = 0;
+    while let Some(relative_pos) = text[search_start..].find(START) {
+        let name_start = search_start + relative_pos + START.len();
+        let Some(name_end_relative) = text[name_start..].find(':') else {
+            search_start = name_start;
+            continue;
+        };
+        let name_end = name_start + name_end_relative;
+        let name = text[name_start..name_end].trim();
+        let Some(args_marker_relative) = text[name_end..].find(ARGS) else {
+            search_start = name_end;
+            continue;
+        };
+        let args_marker = name_end + args_marker_relative;
+        let id_start = name_start - "functions.".len();
+        let id = text[id_start..args_marker].trim();
+        let args_start = args_marker + ARGS.len();
+        let args_end = text[args_start..]
+            .find(END)
+            .map_or(text.len(), |offset| args_start + offset);
+        let arguments_text = text[args_start..args_end].trim();
+        let arguments = extract_json_payload(arguments_text).ok_or_else(|| {
+            LlamaCppProviderError::Template(format!(
+                "Kimi K2 tool call arguments for `{name}` are not valid JSON"
+            ))
+        })?;
+        calls.push(json!({
+            "id": id,
+            "name": name,
+            "arguments": serde_json::from_str::<Value>(&arguments).map_err(|err| {
+                LlamaCppProviderError::Template(format!(
+                    "Kimi K2 tool call arguments for `{name}` are not valid JSON: {err}"
+                ))
+            })?
+        }));
+        search_start = args_end.saturating_add(END.len()).min(text.len());
+    }
+
+    normalized_tool_message_with_content(&calls, content)
+}
+
+fn parse_deepseek_dsml_tool_calls(text: &str) -> Result<Option<Value>, LlamaCppProviderError> {
+    const PREFIX: &str = "<｜Assistant｜>";
+    const FC_START: &str = "<｜DSML｜function_calls>";
+    const INVOKE_START: &str = "<｜DSML｜invoke name=\"";
+    const INVOKE_END: &str = "</｜DSML｜invoke>";
+    const PARAM_START: &str = "<｜DSML｜parameter name=\"";
+    const PARAM_END: &str = "</｜DSML｜parameter>";
+
+    let text = text.strip_prefix(PREFIX).unwrap_or(text);
+    let mut calls = Vec::new();
+    let content = content_before_marker(text, FC_START);
+    let mut search_start = 0;
+    while let Some(relative_pos) = text[search_start..].find(INVOKE_START) {
+        let name_start = search_start + relative_pos + INVOKE_START.len();
+        let Some(name_end_relative) = text[name_start..].find("\">") else {
+            search_start = name_start;
+            continue;
+        };
+        let name_end = name_start + name_end_relative;
+        let name = text[name_start..name_end].trim();
+        let body_start = name_end + "\">".len();
+        let body_end = text[body_start..]
+            .find(INVOKE_END)
+            .map_or(text.len(), |offset| body_start + offset);
+        let body = &text[body_start..body_end];
+        let arguments = parse_deepseek_dsml_parameters(name, body, PARAM_START, PARAM_END)?;
+        calls.push(json!({
+            "name": name,
+            "arguments": arguments,
+        }));
+        search_start = body_end.saturating_add(INVOKE_END.len()).min(text.len());
+    }
+
+    normalized_tool_message_with_content(&calls, content)
+}
+
+fn parse_lfm2_tool_calls(text: &str) -> Result<Option<Value>, LlamaCppProviderError> {
+    const PREFIX: &str = "<|im_start|>assistant\n";
+    const START: &str = "<|tool_call_start|>";
+    const END: &str = "<|tool_call_end|>";
+
+    let text = text.strip_prefix(PREFIX).unwrap_or(text);
+    let mut calls = Vec::new();
+    let content = content_before_marker(text, START);
+    let mut search_start = 0;
+    while let Some(relative_pos) = text[search_start..].find(START) {
+        let body_start = search_start + relative_pos + START.len();
+        let body_end = text[body_start..]
+            .find(END)
+            .map_or(text.len(), |offset| body_start + offset);
+        let body = text[body_start..body_end].trim();
+        for call in parse_lfm2_python_call_list(body)? {
+            calls.push(call);
+        }
+        search_start = body_end.saturating_add(END.len()).min(text.len());
+    }
+
+    normalized_tool_message_with_content(&calls, content)
+}
+
+fn parse_gigachat_v3_tool_calls(text: &str) -> Result<Option<Value>, LlamaCppProviderError> {
+    const PREFIX: &str = "assistant<|role_sep|>\n";
+    const START: &str = "<|message_sep|>\n\nfunction call<|role_sep|>\n";
+    const END: &str = "<|message_sep|>\n\n";
+
+    let had_prefix = text.starts_with(PREFIX);
+    let text = text.strip_prefix(PREFIX).unwrap_or(text);
+    let mut calls = Vec::new();
+    let content = if text.contains(START) {
+        content_before_marker(text, START)
+    } else if had_prefix {
+        Some(text.strip_suffix(END).unwrap_or(text).trim().to_string())
+            .filter(|content| !content.is_empty())
+    } else {
+        None
+    };
+    let mut search_start = 0;
+    while let Some(relative_pos) = text[search_start..].find(START) {
+        let call_start = search_start + relative_pos + START.len();
+        let call_end = text[call_start..]
+            .find(END)
+            .map_or(text.len(), |offset| call_start + offset);
+        let payload = text[call_start..call_end].trim();
+        let Some(json_text) = extract_json_payload(payload) else {
+            search_start = call_end;
+            continue;
+        };
+        let value = serde_json::from_str::<Value>(&json_text).map_err(|err| {
+            LlamaCppProviderError::Template(format!(
+                "GigaChat V3 tool call is not valid JSON: {err}"
+            ))
+        })?;
+        calls.push(value);
+        search_start = call_end.saturating_add(END.len()).min(text.len());
+    }
+
+    normalized_tool_message_with_content(&calls, content)
+}
+
+fn parse_lfm2_python_call_list(text: &str) -> Result<Vec<Value>, LlamaCppProviderError> {
+    let trimmed = text.trim();
+    let inner = trimmed
+        .strip_prefix('[')
+        .and_then(|value| value.strip_suffix(']'))
+        .unwrap_or(trimmed)
+        .trim();
+    if inner.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    split_top_level(inner, ',')
+        .into_iter()
+        .map(|call| parse_lfm2_python_call(&call))
+        .collect()
+}
+
+fn parse_lfm2_python_call(text: &str) -> Result<Value, LlamaCppProviderError> {
+    let call = text.trim();
+    let Some(open) = call.find('(') else {
+        return Err(LlamaCppProviderError::Template(format!(
+            "LFM2 tool call is missing argument list: {call}"
+        )));
+    };
+    let Some(close) = call.rfind(')') else {
+        return Err(LlamaCppProviderError::Template(format!(
+            "LFM2 tool call is missing closing parenthesis: {call}"
+        )));
+    };
+    if close < open {
+        return Err(LlamaCppProviderError::Template(format!(
+            "LFM2 tool call has invalid parentheses: {call}"
+        )));
+    }
+
+    let name = call[..open].trim();
+    if name.is_empty() || !name.chars().all(is_native_tool_name_char) {
+        return Err(LlamaCppProviderError::Template(format!(
+            "LFM2 tool call has invalid function name: {name}"
+        )));
+    }
+    let mut arguments = serde_json::Map::new();
+    let args = call[open + 1..close].trim();
+    if !args.is_empty() {
+        for item in split_top_level(args, ',') {
+            let Some((key, value)) = split_once_top_level(&item, '=') else {
+                return Err(LlamaCppProviderError::Template(format!(
+                    "LFM2 tool call argument is missing `=`: {item}"
+                )));
+            };
+            let key = key.trim();
+            if key.is_empty() || !key.chars().all(is_native_tool_name_char) {
+                return Err(LlamaCppProviderError::Template(format!(
+                    "LFM2 tool call has invalid argument name: {key}"
+                )));
+            }
+            arguments.insert(key.to_string(), parse_lfm2_python_value(value.trim())?);
+        }
+    }
+
+    Ok(json!({
+        "name": name,
+        "arguments": Value::Object(arguments),
+    }))
+}
+
+fn parse_lfm2_python_value(text: &str) -> Result<Value, LlamaCppProviderError> {
+    if let Some(value) = parse_python_quoted_string(text, '\'')? {
+        return Ok(Value::String(value));
+    }
+    if let Some(value) = parse_python_quoted_string(text, '"')? {
+        return Ok(Value::String(value));
+    }
+    let json_text = normalize_lfm2_python_literal(text)?;
+    serde_json::from_str::<Value>(&json_text).map_err(|err| {
+        LlamaCppProviderError::Template(format!(
+            "LFM2 tool call value is not valid JSON/Python literal: {err}"
+        ))
+    })
+}
+
+fn normalize_lfm2_python_literal(text: &str) -> Result<String, LlamaCppProviderError> {
+    let mut output = String::with_capacity(text.len());
+    let mut chars = text.chars().peekable();
+    let mut in_double_string = false;
+    let mut escaped = false;
+
+    while let Some(ch) = chars.next() {
+        if in_double_string {
+            output.push(ch);
+            if escaped {
+                escaped = false;
+            } else if ch == '\\' {
+                escaped = true;
+            } else if ch == '"' {
+                in_double_string = false;
+            }
+            continue;
+        }
+
+        match ch {
+            '"' => {
+                in_double_string = true;
+                output.push(ch);
+            }
+            '\'' => {
+                let mut quoted = String::new();
+                let mut escaped = false;
+                let mut closed = false;
+                for inner in chars.by_ref() {
+                    if escaped {
+                        match inner {
+                            '\\' => quoted.push('\\'),
+                            '\'' => quoted.push('\''),
+                            '"' => quoted.push('"'),
+                            'n' => quoted.push('\n'),
+                            'r' => quoted.push('\r'),
+                            't' => quoted.push('\t'),
+                            other => {
+                                quoted.push('\\');
+                                quoted.push(other);
+                            }
+                        }
+                        escaped = false;
+                    } else if inner == '\\' {
+                        escaped = true;
+                    } else if inner == '\'' {
+                        closed = true;
+                        break;
+                    } else {
+                        quoted.push(inner);
+                    }
+                }
+                if escaped {
+                    return Err(LlamaCppProviderError::Template(
+                        "LFM2 quoted string ends with an escape".to_string(),
+                    ));
+                }
+                if !closed {
+                    return Err(LlamaCppProviderError::Template(
+                        "LFM2 quoted string is missing a closing quote".to_string(),
+                    ));
+                }
+                let encoded = serde_json::to_string(&quoted).map_err(|err| {
+                    LlamaCppProviderError::Template(format!(
+                        "LFM2 quoted string could not be encoded as JSON: {err}"
+                    ))
+                })?;
+                output.push_str(&encoded);
+            }
+            ch if ch.is_ascii_alphabetic() || ch == '_' => {
+                let mut ident = String::new();
+                ident.push(ch);
+                while let Some(next) = chars.peek().copied() {
+                    if next.is_ascii_alphanumeric() || next == '_' {
+                        ident.push(next);
+                        chars.next();
+                    } else {
+                        break;
+                    }
+                }
+                match ident.as_str() {
+                    "True" => output.push_str("true"),
+                    "False" => output.push_str("false"),
+                    "None" => output.push_str("null"),
+                    _ => output.push_str(&ident),
+                }
+            }
+            _ => output.push(ch),
+        }
+    }
+
+    Ok(remove_lfm2_json_trailing_commas(&output))
+}
+
+fn remove_lfm2_json_trailing_commas(text: &str) -> String {
+    let mut output = String::with_capacity(text.len());
+    let mut chars = text.chars().peekable();
+    let mut in_string = false;
+    let mut escaped = false;
+
+    while let Some(ch) = chars.next() {
+        if in_string {
+            output.push(ch);
+            if escaped {
+                escaped = false;
+            } else if ch == '\\' {
+                escaped = true;
+            } else if ch == '"' {
+                in_string = false;
+            }
+            continue;
+        }
+
+        match ch {
+            '"' => {
+                in_string = true;
+                output.push(ch);
+            }
+            ',' => {
+                let mut lookahead = chars.clone();
+                while matches!(lookahead.peek(), Some(next) if next.is_whitespace()) {
+                    lookahead.next();
+                }
+                if matches!(lookahead.peek(), Some(']' | '}')) {
+                    continue;
+                }
+                output.push(ch);
+            }
+            _ => output.push(ch),
+        }
+    }
+
+    output
+}
+
+fn parse_python_quoted_string(
+    text: &str,
+    quote: char,
+) -> Result<Option<String>, LlamaCppProviderError> {
+    let Some(inner) = text
+        .strip_prefix(quote)
+        .and_then(|value| value.strip_suffix(quote))
+    else {
+        return Ok(None);
+    };
+    let mut value = String::with_capacity(inner.len());
+    let mut chars = inner.chars();
+    while let Some(ch) = chars.next() {
+        if ch != '\\' {
+            value.push(ch);
+            continue;
+        }
+        let Some(escaped) = chars.next() else {
+            return Err(LlamaCppProviderError::Template(
+                "LFM2 quoted string ends with an escape".to_string(),
+            ));
+        };
+        match escaped {
+            '\\' => value.push('\\'),
+            '\'' if quote == '\'' => value.push('\''),
+            '"' if quote == '"' => value.push('"'),
+            'n' => value.push('\n'),
+            'r' => value.push('\r'),
+            't' => value.push('\t'),
+            other => {
+                value.push('\\');
+                value.push(other);
+            }
+        }
+    }
+    Ok(Some(value))
+}
+
+fn split_top_level(text: &str, delimiter: char) -> Vec<String> {
+    let mut parts = Vec::new();
+    let mut start = 0;
+    let mut depth = 0_i32;
+    let mut in_string = None;
+    let mut escaped = false;
+
+    for (index, ch) in text.char_indices() {
+        if let Some(quote) = in_string {
+            if escaped {
+                escaped = false;
+            } else if ch == '\\' {
+                escaped = true;
+            } else if ch == quote {
+                in_string = None;
+            }
+            continue;
+        }
+
+        match ch {
+            '"' | '\'' => in_string = Some(ch),
+            '(' | '[' | '{' => depth += 1,
+            ')' | ']' | '}' => depth -= 1,
+            _ if ch == delimiter && depth == 0 => {
+                parts.push(text[start..index].trim().to_string());
+                start = index + ch.len_utf8();
+            }
+            _ => {}
+        }
+    }
+
+    parts.push(text[start..].trim().to_string());
+    parts.into_iter().filter(|part| !part.is_empty()).collect()
+}
+
+fn split_once_top_level(text: &str, delimiter: char) -> Option<(&str, &str)> {
+    let mut depth = 0_i32;
+    let mut in_string = None;
+    let mut escaped = false;
+
+    for (index, ch) in text.char_indices() {
+        if let Some(quote) = in_string {
+            if escaped {
+                escaped = false;
+            } else if ch == '\\' {
+                escaped = true;
+            } else if ch == quote {
+                in_string = None;
+            }
+            continue;
+        }
+
+        match ch {
+            '"' | '\'' => in_string = Some(ch),
+            '(' | '[' | '{' => depth += 1,
+            ')' | ']' | '}' => depth -= 1,
+            _ if ch == delimiter && depth == 0 => {
+                return Some((&text[..index], &text[index + ch.len_utf8()..]));
+            }
+            _ => {}
+        }
+    }
+
+    None
+}
+
+fn parse_deepseek_dsml_parameters(
+    function_name: &str,
+    body: &str,
+    param_start: &str,
+    param_end: &str,
+) -> Result<Value, LlamaCppProviderError> {
+    let mut arguments = serde_json::Map::new();
+    let mut search_start = 0;
+
+    while let Some(relative_pos) = body[search_start..].find(param_start) {
+        let name_start = search_start + relative_pos + param_start.len();
+        let Some(name_end_relative) = body[name_start..].find('"') else {
+            break;
+        };
+        let name_end = name_start + name_end_relative;
+        let param_name = body[name_start..name_end].trim();
+        let Some(open_end_relative) = body[name_end..].find('>') else {
+            break;
+        };
+        let value_start = name_end + open_end_relative + 1;
+        let value_end = body[value_start..]
+            .find(param_end)
+            .map_or(body.len(), |offset| value_start + offset);
+        let value_text = body[value_start..value_end].trim();
+        let is_string = body[name_end..value_start].contains("string=\"true\"");
+        let value = if is_string {
+            Value::String(value_text.to_string())
+        } else {
+            serde_json::from_str::<Value>(value_text).map_err(|err| {
+                LlamaCppProviderError::Template(format!(
+                    "DeepSeek tool call argument `{param_name}` for `{function_name}` is not valid JSON: {err}"
+                ))
+            })?
+        };
+        arguments.insert(param_name.to_string(), value);
+        search_start = value_end.saturating_add(param_end.len()).min(body.len());
+    }
+
+    Ok(Value::Object(arguments))
+}
+
+fn normalize_tool_calls(calls: &[Value]) -> Result<Vec<Value>, LlamaCppProviderError> {
+    calls
+        .iter()
+        .enumerate()
+        .map(|(index, call)| normalize_tool_call(index, call))
+        .collect()
+}
+
+fn normalize_function_key_tool_calls(
+    value: &Value,
+    allowed_tools: Option<&[String]>,
+) -> Result<Option<Vec<Value>>, LlamaCppProviderError> {
+    let Some(object) = value.as_object() else {
+        return Ok(None);
+    };
+    if object.is_empty() {
+        return Ok(None);
+    }
+
+    let mut calls = Vec::new();
+    for (index, (name, payload)) in object.iter().enumerate() {
+        if is_reserved_tool_envelope_key(name) {
+            return Ok(None);
+        }
+        if name.is_empty()
+            || !name.chars().all(is_native_tool_name_char)
+            || !tool_name_allowed(name, allowed_tools)
+        {
+            return Ok(None);
+        }
+        if !payload.is_object() {
+            return Ok(None);
+        }
+        let call = json!({ name: payload });
+        let Some(normalized) = normalize_function_key_tool_call(index, &call)? else {
+            return Ok(None);
+        };
+        calls.push(normalized);
+    }
+
+    Ok(Some(calls))
+}
+
+fn is_reserved_tool_envelope_key(key: &str) -> bool {
+    matches!(
+        key,
+        "content"
+            | "reasoning_content"
+            | "tool_calls"
+            | "function"
+            | "name"
+            | "arguments"
+            | "args"
+            | "parameters"
+            | "id"
+            | "call_id"
+            | "tool_call_id"
+            | "callId"
+            | "type"
+    )
+}
+
+fn normalize_tool_call(index: usize, call: &Value) -> Result<Value, LlamaCppProviderError> {
+    if let Some(normalized) = normalize_function_key_tool_call(index, call)? {
+        return Ok(normalized);
+    }
+    if let Some(normalized) = normalize_nested_json_tool_call(index, call)? {
+        return Ok(normalized);
+    }
+
+    let function = call.get("function").unwrap_or(call);
+    let function = function.as_object().ok_or_else(|| {
+        LlamaCppProviderError::Template("Tool call function must be a JSON object".to_string())
+    })?;
+
+    let name = function
+        .get("name")
+        .and_then(Value::as_str)
+        .filter(|name| !name.trim().is_empty())
+        .ok_or_else(|| {
+            LlamaCppProviderError::Template("Tool call missing function name".to_string())
+        })?;
+
+    let arguments =
+        normalize_arguments_payload(name, tool_arguments_payload_from_object(function))?;
+
+    let id = tool_call_id(call)
+        .or_else(|| tool_call_id_from_object(function))
+        .unwrap_or_else(|| format!("call_{}", index + 1));
+
+    Ok(json!({
+        "id": id,
+        "type": call
+            .get("type")
+            .or_else(|| call.get("call_type"))
+            .and_then(Value::as_str)
+            .filter(|call_type| !call_type.trim().is_empty())
+            .unwrap_or("function"),
+        "function": {
+            "name": name,
+            "arguments": arguments,
+        }
+    }))
+}
+
+fn normalize_function_key_tool_call(
+    index: usize,
+    call: &Value,
+) -> Result<Option<Value>, LlamaCppProviderError> {
+    let Some(object) = call.as_object() else {
+        return Ok(None);
+    };
+    if object.len() != 1 {
+        return Ok(None);
+    }
+    let Some((name, payload)) = object.iter().next() else {
+        return Ok(None);
+    };
+    if is_reserved_tool_envelope_key(name)
+        || name.is_empty()
+        || !name.chars().all(is_native_tool_name_char)
+        || !payload.is_object()
+    {
+        return Ok(None);
+    }
+    if payload
+        .get("name")
+        .and_then(Value::as_str)
+        .is_some_and(|name| !name.trim().is_empty())
+    {
+        return Ok(None);
+    }
+
+    let arguments =
+        normalize_arguments_payload(name, tool_arguments_payload(payload).or(Some(payload)))?;
+    let id = tool_call_id(payload).unwrap_or_else(|| format!("call_{}", index + 1));
+
+    let normalized = json!({
+        "id": id,
+        "type": "function",
+        "function": {
+            "name": name,
+            "arguments": arguments,
+        }
+    });
+    Ok(Some(normalized))
+}
+
+fn normalize_nested_json_tool_call(
+    index: usize,
+    call: &Value,
+) -> Result<Option<Value>, LlamaCppProviderError> {
+    let Some(object) = call.as_object() else {
+        return Ok(None);
+    };
+    let nested = object
+        .iter()
+        .find_map(|(_, value)| value.as_object())
+        .filter(|nested| {
+            nested
+                .get("name")
+                .and_then(Value::as_str)
+                .is_some_and(|name| !name.trim().is_empty())
+                && tool_arguments_payload_from_object(nested).is_some()
+        });
+    let Some(function) = nested else {
+        return Ok(None);
+    };
+
+    let name = function
+        .get("name")
+        .and_then(Value::as_str)
+        .filter(|name| !name.trim().is_empty())
+        .expect("nested function name checked above");
+    let arguments =
+        normalize_arguments_payload(name, tool_arguments_payload_from_object(function))?;
+    let id = tool_call_id(call)
+        .or_else(|| tool_call_id(&Value::Object(function.clone())))
+        .unwrap_or_else(|| format!("call_{}", index + 1));
+
+    Ok(Some(json!({
+        "id": id,
+        "type": "function",
+        "function": {
+            "name": name,
+            "arguments": arguments,
+        }
+    })))
+}
+
+fn tool_arguments_payload(payload: &Value) -> Option<&Value> {
+    let object = payload.as_object()?;
+    tool_arguments_payload_from_object(object)
+}
+
+fn tool_arguments_payload_from_object(object: &serde_json::Map<String, Value>) -> Option<&Value> {
+    for key in ["arguments", "args", "parameters"] {
+        if let Some(arguments) = object.get(key) {
+            return Some(arguments);
+        }
+    }
+    None
+}
+
+fn normalize_arguments_payload(
+    name: &str,
+    arguments: Option<&Value>,
+) -> Result<String, LlamaCppProviderError> {
+    match arguments {
+        Some(Value::String(arguments)) => {
+            let trimmed = arguments.trim();
+            if trimmed.is_empty() {
+                Ok("{}".to_string())
+            } else {
+                serde_json::from_str::<Value>(trimmed).map_err(|err| {
+                    LlamaCppProviderError::Template(format!(
+                        "Tool call arguments for `{name}` are not valid JSON: {err}"
+                    ))
+                })?;
+                Ok(trimmed.to_string())
+            }
+        }
+        Some(arguments) => Ok(arguments.to_string()),
+        None => Ok("{}".to_string()),
+    }
+}
+
+fn tool_call_id(payload: &Value) -> Option<String> {
+    let object = payload.as_object()?;
+    tool_call_id_from_object(object)
+}
+
+fn tool_call_id_from_object(object: &serde_json::Map<String, Value>) -> Option<String> {
+    for key in ["id", "call_id", "tool_call_id", "callId"] {
+        if let Some(id) = object.get(key) {
+            if let Some(id) = id.as_str().filter(|id| !id.trim().is_empty()) {
+                return Some(id.to_string());
+            }
+            if id.is_number() {
+                return Some(id.to_string());
+            }
+        }
+    }
+    None
+}
+
+fn stream_delta_from_message_json(message_json: &str) -> Result<String, LlamaCppProviderError> {
+    let mut value: Value = serde_json::from_str(message_json).map_err(|err| {
+        LlamaCppProviderError::Template(format!("Invalid parsed stream message: {err}"))
+    })?;
+
+    let Some(object) = value.as_object_mut() else {
+        return Err(LlamaCppProviderError::Template(
+            "Parsed stream message must be a JSON object".to_string(),
+        ));
+    };
+
+    if let Some(Value::Array(calls)) = object.get_mut("tool_calls") {
+        for (index, call) in calls.iter_mut().enumerate() {
+            let Some(call_object) = call.as_object_mut() else {
+                continue;
+            };
+            call_object.insert("index".to_string(), Value::from(index));
+        }
+    }
+
+    let mut delta = serde_json::Map::new();
+    for key in ["content", "reasoning_content", "tool_calls"] {
+        if let Some(value) = object.remove(key) {
+            let keep = match &value {
+                Value::Null => false,
+                Value::String(text) => !text.is_empty(),
+                Value::Array(items) => !items.is_empty(),
+                _ => true,
+            };
+            if keep {
+                delta.insert(key.to_string(), value);
+            }
+        }
+    }
+
+    if delta.is_empty() {
+        return Ok(String::new());
+    }
+    serde_json::to_string(&Value::Object(delta))
+        .map_err(|err| LlamaCppProviderError::Template(err.to_string()))
+}
+
+fn extract_reasoning_content(
+    content: &mut String,
+    reasoning_format: Option<crate::config::LlamaCppReasoningFormat>,
+    start_tag: Option<&str>,
+    end_tag: Option<&str>,
+) -> Option<String> {
+    let format = reasoning_format?;
+    if matches!(format, crate::config::LlamaCppReasoningFormat::None) {
+        return None;
+    }
+
+    extract_tagged_reasoning(
+        content,
+        start_tag.unwrap_or("<think>"),
+        end_tag.unwrap_or("</think>"),
+    )
+}
+
+fn extract_tagged_reasoning(
+    content: &mut String,
+    start_tag: &str,
+    end_tag: &str,
+) -> Option<String> {
+    let start = content.find(start_tag)?;
+    let reasoning_start = start + start_tag.len();
+    let relative_end = content[reasoning_start..].find(end_tag)?;
+    let end = reasoning_start + relative_end;
+    let reasoning = content[reasoning_start..end].trim().to_string();
+    let after_end = end + end_tag.len();
+    content.replace_range(start..after_end, "");
+    if start_tag == "<|channel>thought" && end_tag == "<channel|>" {
+        cleanup_gemma4_channel_controls(content);
+    }
+    *content = content.trim().to_string();
+    Some(reasoning)
+}
+
+fn extract_tagged_reasoning_partial(
+    content: &mut String,
+    start_tag: &str,
+    end_tag: &str,
+) -> Option<String> {
+    let start = content.find(start_tag)?;
+    let reasoning_start = start + start_tag.len();
+    let (reasoning, remove_end) =
+        if let Some(relative_end) = content[reasoning_start..].find(end_tag) {
+            let end = reasoning_start + relative_end;
+            (
+                content[reasoning_start..end].trim().to_string(),
+                end + end_tag.len(),
+            )
+        } else {
+            (
+                strip_trailing_partial_tag_prefix(content[reasoning_start..].trim(), end_tag)
+                    .trim()
+                    .to_string(),
+                content.len(),
+            )
+        };
+    content.replace_range(start..remove_end, "");
+    if start_tag == "<|channel>thought" && end_tag == "<channel|>" {
+        cleanup_gemma4_channel_controls(content);
+    }
+    *content = content.trim().to_string();
+    if reasoning.is_empty() {
+        None
+    } else {
+        Some(reasoning)
+    }
+}
+
+fn extract_prefilled_reasoning(
+    content: &mut String,
+    start_tag: &str,
+    end_tag: &str,
+    allow_open: bool,
+) -> Option<String> {
+    let first_non_ws = content
+        .char_indices()
+        .find_map(|(index, ch)| (!ch.is_whitespace()).then_some(index))
+        .unwrap_or(content.len());
+    let visible = &content[first_non_ws..];
+    if visible_is_partial_tag(visible, start_tag) || visible_is_partial_tag(visible, end_tag) {
+        return None;
+    }
+    if visible.starts_with('{')
+        || visible.starts_with('[')
+        || visible.starts_with("<tool_call>")
+        || visible.starts_with("<function=")
+        || visible.starts_with("<|tool_call")
+        || visible.starts_with("<|start|>")
+    {
+        return None;
+    }
+
+    let (reasoning, remove_end) = if let Some(relative_end) = content[first_non_ws..].find(end_tag)
+    {
+        let end = first_non_ws + relative_end;
+        (content[..end].trim().to_string(), end + end_tag.len())
+    } else if allow_open {
+        (
+            strip_trailing_partial_tag_prefix(content.trim(), end_tag)
+                .trim()
+                .to_string(),
+            content.len(),
+        )
+    } else {
+        return None;
+    };
+    content.replace_range(..remove_end, "");
+    *content = content.trim().to_string();
+    if reasoning.is_empty() {
+        None
+    } else {
+        Some(reasoning)
+    }
+}
+
+fn visible_is_partial_tag(visible: &str, tag: &str) -> bool {
+    !visible.is_empty() && visible.len() < tag.len() && tag.starts_with(visible)
+}
+
+fn strip_trailing_partial_tag_prefix<'a>(text: &'a str, tag: &str) -> &'a str {
+    for len in (1..tag.len()).rev() {
+        let prefix = &tag[..len];
+        if text.ends_with(prefix) {
+            return &text[..text.len() - len];
+        }
+    }
+    text
+}
+
+fn cleanup_gemma4_channel_controls(content: &mut String) {
+    const CHANNEL_START: &str = "<|channel>";
+    const CHANNEL_END: &str = "<channel|>";
+
+    while content.starts_with(CHANNEL_START) {
+        content.replace_range(..CHANNEL_START.len(), "");
+    }
+
+    if let Some(index) = content.find(CHANNEL_START) {
+        content.truncate(index);
+    }
+    if let Some(index) = content.find(CHANNEL_END) {
+        content.truncate(index);
+    }
+}
+
 fn sanitize_chat_template_schema(schema: &StructuredOutputFormat) -> Option<Value> {
     let mut schema = schema.schema.clone()?;
     if schema.get("additionalProperties").is_none()
@@ -1675,29 +4013,1727 @@ fn sanitize_chat_template_schema(schema: &StructuredOutputFormat) -> Option<Valu
     Some(schema)
 }
 
-fn select_template_schema_and_grammar(
-    tools_present: bool,
+fn build_tool_response_grammar(
+    tools: &[Tool],
     json_schema: Option<&StructuredOutputFormat>,
     force_json_grammar: bool,
-) -> (Option<String>, Option<String>) {
-    // llama.cpp's OpenAI-compatible template API treats `json_schema` as part of grammar
-    // generation AND configures a schema-bound parser for the generated response. When
-    // tools are present, passing the agent response schema produces invalid grammar and
-    // breaks tool-calling requests entirely. When tools are absent, the schema-bound
-    // parser expects a structured-output envelope that plain-JSON generations don't
-    // provide, surfacing as `ffi error -3` from `chat_parse_to_oaicompat`
-    // (https://github.com/liquidos-ai/AutoAgents/issues/220). In both cases we compile
-    // the schema to grammar at our boundary and pass it via the `grammar` slot, leaving
-    // the parser in its generic (text) mode.
-    if tools_present {
-        return (None, None);
+    tool_choice: LlamaCppToolChoice,
+    parallel_tool_calls: bool,
+    tool_call_format: ToolCallGrammarFormat,
+) -> Result<String, LLMError> {
+    let (selected_tools, effective_tool_choice) = select_tools_for_tool_choice(tools, tool_choice)?;
+    let tools = selected_tools.as_slice();
+    let tool_choice = effective_tool_choice;
+
+    match tool_call_format {
+        ToolCallGrammarFormat::OpenAiEnvelope => {
+            let schema = build_tool_response_schema(
+                tools,
+                json_schema,
+                force_json_grammar,
+                tool_choice,
+                parallel_tool_calls,
+            )
+            .map_err(|err| {
+                LLMError::ProviderError(format!("Failed to build tool schema: {err}"))
+            })?;
+            compile_json_schema_grammar(&schema, "tool")
+        }
+        ToolCallGrammarFormat::NativeChannelToolCall => build_native_channel_tool_response_grammar(
+            tools,
+            json_schema,
+            force_json_grammar,
+            tool_choice,
+        ),
+        ToolCallGrammarFormat::KimiK2ToolCall => build_kimi_k2_tool_response_grammar(
+            tools,
+            json_schema,
+            force_json_grammar,
+            tool_choice,
+            parallel_tool_calls,
+        ),
+        ToolCallGrammarFormat::Lfm2ToolCall => build_lfm2_tool_response_grammar(
+            tools,
+            json_schema,
+            force_json_grammar,
+            tool_choice,
+            parallel_tool_calls,
+        ),
+        ToolCallGrammarFormat::GigaChatV3ToolCall => build_gigachat_v3_tool_response_grammar(
+            tools,
+            json_schema,
+            force_json_grammar,
+            tool_choice,
+        ),
+        ToolCallGrammarFormat::FunctionaryV32 => build_functionary_v32_tool_response_grammar(
+            tools,
+            json_schema,
+            force_json_grammar,
+            tool_choice,
+            parallel_tool_calls,
+        ),
+        ToolCallGrammarFormat::DeepSeekDsmlToolCall => build_deepseek_dsml_tool_response_grammar(
+            tools,
+            json_schema,
+            force_json_grammar,
+            tool_choice,
+            parallel_tool_calls,
+        ),
+        ToolCallGrammarFormat::GenericFunctionTag => build_generic_function_tag_response_grammar(
+            tools,
+            json_schema,
+            force_json_grammar,
+            tool_choice,
+            parallel_tool_calls,
+        ),
+        ToolCallGrammarFormat::XmlToolCall
+        | ToolCallGrammarFormat::ToolCallsArrayTag
+        | ToolCallGrammarFormat::ToolCallsArgsTag
+        | ToolCallGrammarFormat::Gemma4ToolCall => build_native_tool_response_grammar(
+            tools,
+            json_schema,
+            force_json_grammar,
+            tool_choice,
+            parallel_tool_calls,
+            tool_call_format,
+        ),
+    }
+}
+
+fn select_tools_for_tool_choice(
+    tools: &[Tool],
+    tool_choice: LlamaCppToolChoice,
+) -> Result<(Vec<Tool>, LlamaCppToolChoice), LLMError> {
+    match tool_choice {
+        LlamaCppToolChoice::Function { name } => {
+            let Some(tool) = tools.iter().find(|tool| tool.function.name == name) else {
+                return Err(LLMError::invalid_request(format!(
+                    "tool_choice selected function `{name}`, but no matching tool was provided"
+                )));
+            };
+            Ok((vec![tool.clone()], LlamaCppToolChoice::Required))
+        }
+        other => Ok((tools.to_vec(), other)),
+    }
+}
+
+fn compile_json_schema_grammar(schema: &Value, label: &str) -> Result<String, LLMError> {
+    let schema_str = schema.to_string();
+    llama_cpp_2::json_schema_to_grammar(&schema_str).map_err(|err| {
+        LLMError::ProviderError(format!(
+            "Failed to compile llama.cpp {label} grammar: {err}"
+        ))
+    })
+}
+
+fn wrap_structured_response_grammar(
+    grammar: &str,
+    tool_call_format: ToolCallGrammarFormat,
+) -> String {
+    match tool_call_format {
+        ToolCallGrammarFormat::ToolCallsArgsTag => {
+            let renamed = rename_root_rule(grammar, "response-format");
+            format!("root ::= \"```json\" response-format \"```\"\n\n{renamed}")
+        }
+        ToolCallGrammarFormat::Gemma4ToolCall => {
+            let renamed = rename_root_rule(grammar, "response-format");
+            format!(
+                "root ::= gemma4-response-start gemma4-response-thought? \"```json\" response-format \"```\"\ngemma4-response-start ::= \"<|turn>model\\n\"?\ngemma4-response-thought ::= gemma4-response-empty-channels \"<|channel>thought\" [ \\t\\n\\r]+ gemma4-response-thought-content \"<channel|>\"\ngemma4-response-empty-channels ::= (\"<|channel>\" gemma4-response-non-thought-channel)*\ngemma4-response-non-thought-channel ::= [^t] | \"t\" [^h] | \"th\" [^o] | \"tho\" [^u] | \"thou\" [^g] | \"thoug\" [^h] | \"though\" [^t]\ngemma4-response-thought-content ::= gemma4-response-thought-char*\ngemma4-response-thought-char ::= [^<] | \"<\" [^c] | \"<c\" [^h] | \"<ch\" [^a] | \"<cha\" [^n] | \"<chan\" [^n] | \"<chann\" [^e] | \"<channe\" [^l] | \"<channel\" [^|]\n\n{renamed}"
+            )
+        }
+        ToolCallGrammarFormat::NativeChannelToolCall => {
+            let renamed = rename_root_rule(grammar, "response-format");
+            format!(
+                "root ::= \"<|start|>assistant\" \"<|channel|>final\" native-response-constraint \"<|message|>\" response-format\nnative-response-ws ::= [ \\t\\n\\r]*\nnative-response-constraint-type ::= [A-Za-z0-9_-]+\nnative-response-constraint ::= (native-response-ws (\"<|constrain|>\" native-response-ws)? native-response-constraint-type)?\n\n{renamed}"
+            )
+        }
+        ToolCallGrammarFormat::DeepSeekDsmlToolCall => {
+            let renamed = rename_root_rule(grammar, "response-format");
+            format!(
+                "root ::= \"```json\" deepseek-response-ws response-format deepseek-response-ws \"```\"\ndeepseek-response-ws ::= [ \\t\\n\\r]*\n\n{renamed}"
+            )
+        }
+        ToolCallGrammarFormat::GenericFunctionTag => {
+            let renamed = rename_root_rule(grammar, "response-format");
+            format!(
+                "root ::= \"```json\" generic-response-ws response-format generic-response-ws \"```\" | response-format\ngeneric-response-ws ::= [ \\t\\n\\r]*\n\n{renamed}"
+            )
+        }
+        _ => grammar.to_string(),
+    }
+}
+
+fn build_tool_response_schema(
+    tools: &[Tool],
+    json_schema: Option<&StructuredOutputFormat>,
+    _force_json_grammar: bool,
+    tool_choice: LlamaCppToolChoice,
+    parallel_tool_calls: bool,
+) -> Result<Value, LlamaCppProviderError> {
+    if tools.is_empty() {
+        return Err(LlamaCppProviderError::Template(
+            "Cannot build tool response schema without tools".to_string(),
+        ));
     }
 
+    let tool_call_variants = tools
+        .iter()
+        .map(build_single_tool_call_schema)
+        .collect::<Result<Vec<_>, _>>()?;
+
+    let final_response_schema = json_schema
+        .and_then(sanitize_chat_template_schema)
+        .unwrap_or_else(|| {
+            json!({
+                "type": "object",
+                "properties": {
+                    "content": { "type": "string" }
+                },
+                "required": ["content"],
+                "additionalProperties": false
+            })
+        });
+
+    let mut tool_calls_schema = json!({
+        "type": "array",
+        "minItems": 1,
+        "items": { "oneOf": tool_call_variants }
+    });
+    if !parallel_tool_calls {
+        tool_calls_schema["maxItems"] = Value::from(1);
+    }
+
+    let tool_response_schema = json!({
+        "type": "object",
+        "properties": {
+            "tool_calls": tool_calls_schema
+        },
+        "required": ["tool_calls"],
+        "additionalProperties": false
+    });
+
+    if matches!(tool_choice, LlamaCppToolChoice::Required) {
+        Ok(tool_response_schema)
+    } else {
+        Ok(json!({
+            "oneOf": [
+                final_response_schema,
+                tool_response_schema
+            ]
+        }))
+    }
+}
+
+fn build_native_tool_response_grammar(
+    tools: &[Tool],
+    json_schema: Option<&StructuredOutputFormat>,
+    force_json_grammar: bool,
+    tool_choice: LlamaCppToolChoice,
+    parallel_tool_calls: bool,
+    tool_call_format: ToolCallGrammarFormat,
+) -> Result<String, LLMError> {
+    if matches!(tool_call_format, ToolCallGrammarFormat::ToolCallsArgsTag) {
+        return build_tool_calls_args_response_grammar(
+            tools,
+            json_schema,
+            force_json_grammar,
+            tool_choice,
+            parallel_tool_calls,
+        );
+    }
+    if matches!(tool_call_format, ToolCallGrammarFormat::Gemma4ToolCall) {
+        return build_gemma4_tool_response_grammar(
+            tools,
+            json_schema,
+            force_json_grammar,
+            tool_choice,
+            parallel_tool_calls,
+        );
+    }
+
+    let tool_schema =
+        build_native_tool_payload_schema(tools, tool_call_format, parallel_tool_calls).map_err(
+            |err| LLMError::ProviderError(format!("Failed to build native tool schema: {err}")),
+        )?;
+    let tool_grammar = compile_json_schema_grammar(&tool_schema, "native tool")?;
+
+    let lazy_tool_payload_only = matches!(tool_choice, LlamaCppToolChoice::Auto)
+        && json_schema.is_none()
+        && !force_json_grammar;
+    if lazy_tool_payload_only {
+        return Ok(wrap_native_tool_payload_grammar(
+            &tool_grammar,
+            tool_call_format,
+            false,
+        ));
+    }
+
+    let include_tool_markers = native_tool_markers_are_safe_in_grammar(tool_call_format);
+    let tool_call_grammar =
+        wrap_native_tool_payload_grammar(&tool_grammar, tool_call_format, include_tool_markers);
+    if matches!(tool_choice, LlamaCppToolChoice::Required) {
+        return Ok(tool_call_grammar);
+    }
+
+    let final_schema = json_schema
+        .and_then(sanitize_chat_template_schema)
+        .unwrap_or_else(|| {
+            json!({
+                "type": "object",
+                "properties": {
+                    "content": { "type": "string" }
+                },
+                "required": ["content"],
+                "additionalProperties": false
+            })
+        });
+    let mut final_grammar = compile_json_schema_grammar(&final_schema, "final response")?;
+    if json_schema.is_some() {
+        final_grammar = wrap_structured_response_grammar(&final_grammar, tool_call_format);
+    }
+    Ok(combine_final_and_native_tool_grammars(
+        &final_grammar,
+        &tool_call_grammar,
+    ))
+}
+
+fn build_native_channel_tool_response_grammar(
+    tools: &[Tool],
+    json_schema: Option<&StructuredOutputFormat>,
+    force_json_grammar: bool,
+    tool_choice: LlamaCppToolChoice,
+) -> Result<String, LLMError> {
+    if tools.is_empty() {
+        return Err(LLMError::ProviderError(
+            "Cannot build native channel tool grammar without tools".to_string(),
+        ));
+    }
+
+    let lazy_tool_suffix_only = matches!(tool_choice, LlamaCppToolChoice::Auto)
+        && json_schema.is_none()
+        && !force_json_grammar;
+    let tool_call_grammar = if lazy_tool_suffix_only {
+        build_native_channel_tool_suffix_grammar(tools)?
+    } else {
+        build_native_channel_tool_call_grammar(tools)?
+    };
+
+    if matches!(tool_choice, LlamaCppToolChoice::Required) || lazy_tool_suffix_only {
+        return Ok(tool_call_grammar);
+    }
+
+    let final_schema = json_schema
+        .and_then(sanitize_chat_template_schema)
+        .unwrap_or_else(|| {
+            json!({
+                "type": "object",
+                "properties": {
+                    "content": { "type": "string" }
+                },
+                "required": ["content"],
+                "additionalProperties": false
+            })
+        });
+    let mut final_grammar = compile_json_schema_grammar(&final_schema, "final response")?;
+    if json_schema.is_some() {
+        final_grammar = wrap_structured_response_grammar(
+            &final_grammar,
+            ToolCallGrammarFormat::NativeChannelToolCall,
+        );
+    }
+    Ok(combine_final_and_native_tool_grammars(
+        &final_grammar,
+        &tool_call_grammar,
+    ))
+}
+
+fn build_native_channel_tool_call_grammar(tools: &[Tool]) -> Result<String, LLMError> {
+    let mut rules = vec![
+        "native-channel-ws ::= [ \\t\\n\\r]*".to_string(),
+        "native-channel-name ::= \"commentary\" | \"analysis\"".to_string(),
+        "native-channel ::= \"<|channel|>\" native-channel-name".to_string(),
+        "native-constraint-type ::= [A-Za-z0-9_-]+".to_string(),
+        "native-constraint ::= (native-channel-ws (\"<|constrain|>\" native-channel-ws)? native-constraint-type)?".to_string(),
+    ];
+    let mut alternatives = Vec::new();
+
+    for (index, tool) in tools.iter().enumerate() {
+        let name = tool.function.name.trim();
+        if name.is_empty() {
+            return Err(LLMError::ProviderError(
+                "Tool name must not be empty".to_string(),
+            ));
+        }
+        let schema = sanitize_tool_parameters_schema(&tool.function.parameters);
+        let args_grammar = compile_json_schema_grammar(&schema, name)?;
+        let args_rule = format!("native-channel-tool-{index}-args");
+        rules.push(rename_root_rule(&args_grammar, &args_rule));
+
+        let role_rule = format!("native-channel-tool-{index}-role");
+        let channel_rule = format!("native-channel-tool-{index}-channel");
+        rules.push(format!(
+            "{role_rule} ::= \" to=functions.\" {} native-channel native-constraint \"<|message|>\" {args_rule}",
+            gbnf_literal(name)
+        ));
+        rules.push(format!(
+            "{channel_rule} ::= native-channel \" to=functions.\" {} native-constraint \"<|message|>\" {args_rule}",
+            gbnf_literal(name)
+        ));
+        alternatives.push(role_rule);
+        alternatives.push(channel_rule);
+    }
+
+    Ok(format!(
+        "root ::= \"<|start|>assistant\" ({})\n\n{}",
+        alternatives.join(" | "),
+        rules.join("\n")
+    ))
+}
+
+fn build_native_channel_tool_suffix_grammar(tools: &[Tool]) -> Result<String, LLMError> {
+    let mut rules = vec![
+        "native-channel-ws ::= [ \\t\\n\\r]*".to_string(),
+        "native-channel-name ::= \"commentary\" | \"analysis\"".to_string(),
+        "native-channel ::= \"<|channel|>\" native-channel-name".to_string(),
+        "native-constraint-type ::= [A-Za-z0-9_-]+".to_string(),
+        "native-constraint ::= (native-channel-ws (\"<|constrain|>\" native-channel-ws)? native-constraint-type)?".to_string(),
+    ];
+    let mut role_tails = Vec::new();
+    let mut channel_tails = Vec::new();
+
+    for (index, tool) in tools.iter().enumerate() {
+        let name = tool.function.name.trim();
+        if name.is_empty() {
+            return Err(LLMError::ProviderError(
+                "Tool name must not be empty".to_string(),
+            ));
+        }
+        let schema = sanitize_tool_parameters_schema(&tool.function.parameters);
+        let args_grammar = compile_json_schema_grammar(&schema, name)?;
+        let args_rule = format!("native-channel-tool-{index}-args");
+        rules.push(rename_root_rule(&args_grammar, &args_rule));
+
+        let role_tail = format!("native-channel-tool-{index}-role-tail");
+        let channel_tail = format!("native-channel-tool-{index}-channel-tail");
+        rules.push(format!(
+            "{role_tail} ::= {} native-channel native-constraint \"<|message|>\" {args_rule}",
+            gbnf_literal(name)
+        ));
+        rules.push(format!(
+            "{channel_tail} ::= {} native-constraint \"<|message|>\" {args_rule}",
+            gbnf_literal(name)
+        ));
+        role_tails.push(role_tail);
+        channel_tails.push(channel_tail);
+    }
+
+    Ok(format!(
+        "root ::= \"=functions.\" ({}) | \".\" ({})\n\n{}",
+        role_tails.join(" | "),
+        channel_tails.join(" | "),
+        rules.join("\n")
+    ))
+}
+
+fn build_kimi_k2_tool_response_grammar(
+    tools: &[Tool],
+    json_schema: Option<&StructuredOutputFormat>,
+    force_json_grammar: bool,
+    tool_choice: LlamaCppToolChoice,
+    parallel_tool_calls: bool,
+) -> Result<String, LLMError> {
+    let lazy_tool_suffix_only = matches!(tool_choice, LlamaCppToolChoice::Auto)
+        && json_schema.is_none()
+        && !force_json_grammar;
+    let tool_call_grammar =
+        build_kimi_k2_tool_call_grammar(tools, parallel_tool_calls, lazy_tool_suffix_only)?;
+    combine_native_family_tool_response_grammar(
+        tool_call_grammar,
+        json_schema,
+        force_json_grammar,
+        tool_choice,
+        lazy_tool_suffix_only,
+        ToolCallGrammarFormat::KimiK2ToolCall,
+    )
+}
+
+fn build_kimi_k2_tool_call_grammar(
+    tools: &[Tool],
+    parallel_tool_calls: bool,
+    lazy_suffix_only: bool,
+) -> Result<String, LLMError> {
+    let mut rules = vec![
+        "kimi-ws ::= [ \\t\\n\\r]*".to_string(),
+        "kimi-index ::= [0-9]+".to_string(),
+    ];
+    let mut alternatives = Vec::new();
+
+    for (index, tool) in tools.iter().enumerate() {
+        let name = tool.function.name.trim();
+        if name.is_empty() {
+            return Err(LLMError::ProviderError(
+                "Tool name must not be empty".to_string(),
+            ));
+        }
+        let schema = sanitize_tool_parameters_schema(&tool.function.parameters);
+        let args_grammar = compile_json_schema_grammar(&schema, name)?;
+        let args_rule = format!("kimi-tool-{index}-args");
+        rules.push(rename_root_rule(&args_grammar, &args_rule));
+        let call_rule = format!("kimi-tool-{index}");
+        rules.push(format!(
+            "{call_rule} ::= \"functions.\" {} \":\" kimi-index \"<|tool_call_argument_begin|>\" {args_rule} \"<|tool_call_end|>\"?",
+            gbnf_literal(name)
+        ));
+        alternatives.push(call_rule);
+    }
+
+    let call = alternatives.join(" | ");
+    let root = if lazy_suffix_only {
+        if parallel_tool_calls {
+            format!(
+                "root ::= ({call}) (kimi-ws \"<|tool_call_begin|>\" kimi-ws ({call}))* \"<|tool_calls_section_end|>\"?"
+            )
+        } else {
+            format!("root ::= ({call}) \"<|tool_calls_section_end|>\"?")
+        }
+    } else if parallel_tool_calls {
+        format!(
+            "root ::= \"<|tool_calls_section_begin|>\"? kimi-ws (\"<|tool_call_begin|>\" kimi-ws ({call}))+ kimi-ws \"<|tool_calls_section_end|>\"?"
+        )
+    } else {
+        format!(
+            "root ::= \"<|tool_calls_section_begin|>\"? kimi-ws \"<|tool_call_begin|>\" kimi-ws ({call}) kimi-ws \"<|tool_calls_section_end|>\"?"
+        )
+    };
+
+    Ok(format!("{root}\n\n{}", rules.join("\n")))
+}
+
+fn build_lfm2_tool_response_grammar(
+    tools: &[Tool],
+    json_schema: Option<&StructuredOutputFormat>,
+    force_json_grammar: bool,
+    tool_choice: LlamaCppToolChoice,
+    parallel_tool_calls: bool,
+) -> Result<String, LLMError> {
+    let lazy_tool_suffix_only = matches!(tool_choice, LlamaCppToolChoice::Auto)
+        && json_schema.is_none()
+        && !force_json_grammar;
+    let tool_call_grammar =
+        build_lfm2_tool_call_grammar(tools, parallel_tool_calls, lazy_tool_suffix_only)?;
+    combine_native_family_tool_response_grammar(
+        tool_call_grammar,
+        json_schema,
+        force_json_grammar,
+        tool_choice,
+        lazy_tool_suffix_only,
+        ToolCallGrammarFormat::Lfm2ToolCall,
+    )
+}
+
+fn build_lfm2_tool_call_grammar(
+    tools: &[Tool],
+    parallel_tool_calls: bool,
+    lazy_suffix_only: bool,
+) -> Result<String, LLMError> {
+    let mut alternatives = Vec::new();
+    for (index, tool) in tools.iter().enumerate() {
+        let name = tool.function.name.trim();
+        if name.is_empty() {
+            return Err(LLMError::ProviderError(
+                "Tool name must not be empty".to_string(),
+            ));
+        }
+        alternatives.push(format!("lfm-tool-{index}"));
+    }
+
+    let mut rules = vec![
+        "lfm-ws ::= [ \\t\\n\\r]*".to_string(),
+        "lfm-json-literal ::= \"true\" | \"false\" | \"null\" | \"True\" | \"False\" | \"None\"".to_string(),
+        "lfm-bool ::= \"true\" | \"false\" | \"True\" | \"False\"".to_string(),
+        "lfm-null ::= \"null\" | \"None\"".to_string(),
+        "lfm-string ::= lfm-single-string | lfm-double-string".to_string(),
+        "lfm-single-string ::= \"'\" lfm-single-string-char* \"'\"".to_string(),
+        "lfm-single-string-char ::= [^'\\\\] | \"\\\\\" .".to_string(),
+        "lfm-double-string ::= \"\\\"\" lfm-double-string-char* \"\\\"\"".to_string(),
+        "lfm-double-string-char ::= [^\"\\\\] | \"\\\\\" .".to_string(),
+        "lfm-number ::= \"-\"? ([0-9] | [1-9] [0-9]*) (\".\" [0-9]+)? ([eE] [-+]? [0-9]+)?"
+            .to_string(),
+        "lfm-value ::= lfm-string | lfm-number | lfm-json-literal | lfm-list | lfm-object".to_string(),
+        "lfm-list ::= \"[\" lfm-ws (lfm-value (lfm-ws \",\" lfm-ws lfm-value)* (lfm-ws \",\")?)? lfm-ws \"]\"".to_string(),
+        "lfm-object ::= \"{\" lfm-ws (lfm-pair (lfm-ws \",\" lfm-ws lfm-pair)* (lfm-ws \",\")?)? lfm-ws \"}\"".to_string(),
+        "lfm-pair ::= lfm-string lfm-ws \":\" lfm-ws lfm-value".to_string(),
+        "lfm-key ::= [A-Za-z_][A-Za-z0-9_\\-.]*".to_string(),
+        "lfm-arg ::= lfm-key lfm-ws \"=\" lfm-ws lfm-value".to_string(),
+        "lfm-args ::= (lfm-arg (lfm-ws \",\" lfm-ws lfm-arg)*)?".to_string(),
+    ];
+    for (index, tool) in tools.iter().enumerate() {
+        let name = tool.function.name.trim();
+        let call_rule = format!("lfm-tool-{index}");
+        let schema = sanitize_tool_parameters_schema(&tool.function.parameters);
+        let args_rule = build_lfm2_tool_args_grammar(index, &schema, &mut rules);
+        rules.push(format!(
+            "{call_rule} ::= {} lfm-ws \"(\" lfm-ws {args_rule} lfm-ws \")\"",
+            gbnf_literal(name)
+        ));
+    }
+
+    let call = alternatives.join(" | ");
+    let root = if lazy_suffix_only {
+        if parallel_tool_calls {
+            format!(
+                "root ::= \"[\" lfm-ws ({call}) (lfm-ws \",\" lfm-ws ({call}))* lfm-ws \"]\" \"<|tool_call_end|>\""
+            )
+        } else {
+            format!("root ::= \"[\" lfm-ws ({call}) lfm-ws \"]\" \"<|tool_call_end|>\"")
+        }
+    } else if parallel_tool_calls {
+        format!(
+            "root ::= \"<|tool_call_start|>\" \"[\" lfm-ws ({call}) (lfm-ws \",\" lfm-ws ({call}))* lfm-ws \"]\" \"<|tool_call_end|>\""
+        )
+    } else {
+        format!(
+            "root ::= \"<|tool_call_start|>\" \"[\" lfm-ws ({call}) lfm-ws \"]\" \"<|tool_call_end|>\""
+        )
+    };
+
+    Ok(format!("{root}\n\n{}", rules.join("\n")))
+}
+
+fn build_lfm2_tool_args_grammar(
+    tool_index: usize,
+    schema: &Value,
+    rules: &mut Vec<String>,
+) -> String {
+    let properties = schema
+        .get("properties")
+        .and_then(Value::as_object)
+        .cloned()
+        .unwrap_or_default();
+    if properties.is_empty() {
+        return "lfm-args".to_string();
+    }
+
+    let required = schema
+        .get("required")
+        .and_then(Value::as_array)
+        .map(|values| {
+            values
+                .iter()
+                .filter_map(Value::as_str)
+                .map(ToOwned::to_owned)
+                .collect::<HashSet<_>>()
+        })
+        .unwrap_or_default();
+
+    let mut required_args = Vec::new();
+    let mut optional_args = Vec::new();
+    let mut allowed_args = Vec::new();
+    for (param_index, (param_name, param_schema)) in properties.iter().enumerate() {
+        let value_rule = lfm2_value_rule_for_schema(param_schema);
+        let arg_rule = format!("lfm-tool-{tool_index}-arg-{param_index}");
+        rules.push(format!(
+            "{arg_rule} ::= {} lfm-ws \"=\" lfm-ws {value_rule}",
+            gbnf_literal(param_name)
+        ));
+        if required.contains(param_name) {
+            required_args.push(arg_rule.clone());
+        } else {
+            optional_args.push(arg_rule.clone());
+        }
+        allowed_args.push(arg_rule);
+    }
+
+    let args_rule = format!("lfm-tool-{tool_index}-args");
+    let allowed = allowed_args.join(" | ");
+    let optional = optional_args.join(" | ");
+    let body = if required_args.is_empty() {
+        format!("(({allowed}) (lfm-ws \",\" lfm-ws ({allowed}))*)?")
+    } else {
+        let required_sequence = required_args.join(" lfm-ws \",\" lfm-ws ");
+        if optional_args.is_empty() {
+            required_sequence
+        } else {
+            format!("{required_sequence} (lfm-ws \",\" lfm-ws ({optional}))*")
+        }
+    };
+    rules.push(format!("{args_rule} ::= {body}"));
+    args_rule
+}
+
+fn lfm2_value_rule_for_schema(schema: &Value) -> &'static str {
+    match schema.get("type").and_then(Value::as_str) {
+        Some("string") => "lfm-string",
+        Some("integer" | "number") => "lfm-number",
+        Some("boolean") => "lfm-bool",
+        Some("null") => "lfm-null",
+        Some("array") => "lfm-list",
+        Some("object") => "lfm-object",
+        _ => "lfm-value",
+    }
+}
+
+fn build_gigachat_v3_tool_response_grammar(
+    tools: &[Tool],
+    json_schema: Option<&StructuredOutputFormat>,
+    force_json_grammar: bool,
+    tool_choice: LlamaCppToolChoice,
+) -> Result<String, LLMError> {
+    let lazy_tool_suffix_only = matches!(tool_choice, LlamaCppToolChoice::Auto)
+        && json_schema.is_none()
+        && !force_json_grammar;
+    let tool_call_grammar = build_gigachat_v3_tool_call_grammar(tools, lazy_tool_suffix_only)?;
+    combine_native_family_tool_response_grammar(
+        tool_call_grammar,
+        json_schema,
+        force_json_grammar,
+        tool_choice,
+        lazy_tool_suffix_only,
+        ToolCallGrammarFormat::GigaChatV3ToolCall,
+    )
+}
+
+fn build_gigachat_v3_tool_call_grammar(
+    tools: &[Tool],
+    lazy_suffix_only: bool,
+) -> Result<String, LLMError> {
+    let mut rules = Vec::new();
+    let mut alternatives = Vec::new();
+    for (index, tool) in tools.iter().enumerate() {
+        let name = tool.function.name.trim();
+        if name.is_empty() {
+            return Err(LLMError::ProviderError(
+                "Tool name must not be empty".to_string(),
+            ));
+        }
+        let schema = sanitize_tool_parameters_schema(&tool.function.parameters);
+        let args_grammar = compile_json_schema_grammar(&schema, name)?;
+        let args_rule = format!("gigachat-tool-{index}-args");
+        rules.push(rename_root_rule(&args_grammar, &args_rule));
+        let call_rule = format!("gigachat-tool-{index}");
+        rules.push(format!(
+            "{call_rule} ::= \"{{\" [ \\t\\n\\r]* \"\\\"name\\\"\" [ \\t\\n\\r]* \":\" [ \\t\\n\\r]* {} [ \\t\\n\\r]* \",\" [ \\t\\n\\r]* \"\\\"arguments\\\"\" [ \\t\\n\\r]* \":\" [ \\t\\n\\r]* {args_rule} [ \\t\\n\\r]* \"}}\"",
+            gbnf_literal(&serde_json::to_string(name).map_err(|err| {
+                LLMError::ProviderError(format!("Failed to encode tool name: {err}"))
+            })?)
+        ));
+        alternatives.push(call_rule);
+    }
+
+    let call = alternatives.join(" | ");
+    let marker = gbnf_literal("<|message_sep|>\n\nfunction call<|role_sep|>\n");
+    let root = if lazy_suffix_only {
+        format!("root ::= ({call})")
+    } else {
+        format!("root ::= {marker} ({call})")
+    };
+    Ok(format!("{root}\n\n{}", rules.join("\n")))
+}
+
+fn build_deepseek_dsml_tool_response_grammar(
+    tools: &[Tool],
+    json_schema: Option<&StructuredOutputFormat>,
+    force_json_grammar: bool,
+    tool_choice: LlamaCppToolChoice,
+    parallel_tool_calls: bool,
+) -> Result<String, LLMError> {
+    let lazy_tool_suffix_only = matches!(tool_choice, LlamaCppToolChoice::Auto)
+        && json_schema.is_none()
+        && !force_json_grammar;
+    let tool_call_grammar =
+        build_deepseek_dsml_tool_call_grammar(tools, parallel_tool_calls, lazy_tool_suffix_only)?;
+    combine_native_family_tool_response_grammar(
+        tool_call_grammar,
+        json_schema,
+        force_json_grammar,
+        tool_choice,
+        lazy_tool_suffix_only,
+        ToolCallGrammarFormat::DeepSeekDsmlToolCall,
+    )
+}
+
+fn build_deepseek_dsml_tool_call_grammar(
+    tools: &[Tool],
+    parallel_tool_calls: bool,
+    lazy_suffix_only: bool,
+) -> Result<String, LLMError> {
+    let mut rules = vec![
+        "dsml-ws ::= [ \\t\\n\\r]*".to_string(),
+        "dsml-string ::= ([^<] | \"<\" [^/])*".to_string(),
+    ];
+    let mut alternatives = Vec::new();
+    for (index, tool) in tools.iter().enumerate() {
+        let name = tool.function.name.trim();
+        if name.is_empty() {
+            return Err(LLMError::ProviderError(
+                "Tool name must not be empty".to_string(),
+            ));
+        }
+        let schema = sanitize_tool_parameters_schema(&tool.function.parameters);
+        let required = schema
+            .get("required")
+            .and_then(Value::as_array)
+            .map(|values| {
+                values
+                    .iter()
+                    .filter_map(Value::as_str)
+                    .map(ToOwned::to_owned)
+                    .collect::<HashSet<_>>()
+            })
+            .unwrap_or_default();
+        let properties = schema
+            .get("properties")
+            .and_then(Value::as_object)
+            .cloned()
+            .unwrap_or_default();
+
+        let mut required_parsers = Vec::new();
+        let mut optional_parsers = Vec::new();
+        for (param_index, (param_name, param_schema)) in properties.iter().enumerate() {
+            let value_rule = if deepseek_dsml_param_is_string(param_schema) {
+                "dsml-string".to_string()
+            } else {
+                let value_rule = format!("dsml-tool-{index}-arg-{param_index}-value");
+                let param_grammar = compile_json_schema_grammar(param_schema, param_name)?;
+                rules.push(rename_root_rule(&param_grammar, &value_rule));
+                value_rule
+            };
+            let arg_rule = format!("dsml-tool-{index}-arg-{param_index}");
+            let string_flag = if deepseek_dsml_param_is_string(param_schema) {
+                "true"
+            } else {
+                "false"
+            };
+            rules.push(format!(
+                "{arg_rule} ::= \"<｜DSML｜parameter name=\\\"\" {} \"\\\" string=\\\"{string_flag}\\\">\" {value_rule} \"</｜DSML｜parameter>\"",
+                gbnf_literal(param_name)
+            ));
+            if required.contains(param_name) {
+                required_parsers.push(arg_rule);
+            } else {
+                optional_parsers.push(arg_rule);
+            }
+        }
+
+        let body_rule = format!("dsml-tool-{index}-body");
+        let required_body = if required_parsers.is_empty() {
+            "dsml-ws".to_string()
+        } else {
+            required_parsers.join(" dsml-ws ")
+        };
+        let body = if optional_parsers.is_empty() {
+            required_body
+        } else {
+            let optional = optional_parsers.join(" | ");
+            format!("{required_body} (dsml-ws ({optional}))*")
+        };
+        rules.push(format!("{body_rule} ::= {body}"));
+
+        let call_rule = format!("dsml-tool-{index}");
+        rules.push(format!(
+            "{call_rule} ::= \"<｜DSML｜invoke name=\\\"\" {} \"\\\">\" dsml-ws {body_rule} dsml-ws \"</｜DSML｜invoke>\"",
+            gbnf_literal(name)
+        ));
+        alternatives.push(call_rule);
+    }
+
+    let call = alternatives.join(" | ");
+    let body = if parallel_tool_calls {
+        format!("({call}) (dsml-ws ({call}))*")
+    } else {
+        format!("({call})")
+    };
+    let root = if lazy_suffix_only {
+        format!("root ::= dsml-ws {body} dsml-ws \"</｜DSML｜function_calls>\"")
+    } else {
+        format!(
+            "root ::= \"<｜DSML｜function_calls>\" dsml-ws {body} dsml-ws \"</｜DSML｜function_calls>\""
+        )
+    };
+    Ok(format!("{root}\n\n{}", rules.join("\n")))
+}
+
+fn deepseek_dsml_param_is_string(schema: &Value) -> bool {
+    schema.get("type").and_then(Value::as_str) == Some("string")
+}
+
+fn combine_native_family_tool_response_grammar(
+    tool_call_grammar: String,
+    json_schema: Option<&StructuredOutputFormat>,
+    force_json_grammar: bool,
+    tool_choice: LlamaCppToolChoice,
+    lazy_tool_suffix_only: bool,
+    tool_call_format: ToolCallGrammarFormat,
+) -> Result<String, LLMError> {
+    if matches!(tool_choice, LlamaCppToolChoice::Required) || lazy_tool_suffix_only {
+        return Ok(tool_call_grammar);
+    }
+
+    let final_schema = json_schema
+        .and_then(sanitize_chat_template_schema)
+        .unwrap_or_else(|| {
+            json!({
+                "type": "object",
+                "properties": {
+                    "content": { "type": "string" }
+                },
+                "required": ["content"],
+                "additionalProperties": false
+            })
+        });
+    let mut final_grammar = compile_json_schema_grammar(
+        &final_schema,
+        if force_json_grammar {
+            "forced final response"
+        } else {
+            "final response"
+        },
+    )?;
+    if json_schema.is_some() {
+        final_grammar = wrap_structured_response_grammar(&final_grammar, tool_call_format);
+    }
+    Ok(combine_final_and_native_tool_grammars(
+        &final_grammar,
+        &tool_call_grammar,
+    ))
+}
+
+fn build_functionary_v32_tool_response_grammar(
+    tools: &[Tool],
+    json_schema: Option<&StructuredOutputFormat>,
+    force_json_grammar: bool,
+    tool_choice: LlamaCppToolChoice,
+    parallel_tool_calls: bool,
+) -> Result<String, LLMError> {
+    if tools.is_empty() {
+        return Err(LLMError::ProviderError(
+            "Cannot build Functionary v3.2 tool grammar without tools".to_string(),
+        ));
+    }
+
+    let lazy_tool_suffix_only = matches!(tool_choice, LlamaCppToolChoice::Auto)
+        && json_schema.is_none()
+        && !force_json_grammar;
+    let tool_call_grammar =
+        build_functionary_v32_tool_call_grammar(tools, parallel_tool_calls, lazy_tool_suffix_only)?;
+
+    if lazy_tool_suffix_only || matches!(tool_choice, LlamaCppToolChoice::Required) {
+        return Ok(tool_call_grammar);
+    }
+
+    let final_grammar = build_functionary_v32_content_grammar();
+    Ok(combine_final_and_native_tool_grammars(
+        &final_grammar,
+        &tool_call_grammar,
+    ))
+}
+
+fn build_generic_function_tag_response_grammar(
+    tools: &[Tool],
+    json_schema: Option<&StructuredOutputFormat>,
+    force_json_grammar: bool,
+    tool_choice: LlamaCppToolChoice,
+    parallel_tool_calls: bool,
+) -> Result<String, LLMError> {
+    if tools.is_empty() {
+        return Err(LLMError::ProviderError(
+            "Cannot build generic function-tag tool grammar without tools".to_string(),
+        ));
+    }
+
+    let lazy_tool_suffix_only = matches!(tool_choice, LlamaCppToolChoice::Auto)
+        && json_schema.is_none()
+        && !force_json_grammar;
+    let tool_call_grammar = build_generic_function_tag_tool_call_grammar(
+        tools,
+        parallel_tool_calls,
+        lazy_tool_suffix_only,
+    )?;
+
+    combine_native_family_tool_response_grammar(
+        tool_call_grammar,
+        json_schema,
+        force_json_grammar,
+        tool_choice,
+        lazy_tool_suffix_only,
+        ToolCallGrammarFormat::GenericFunctionTag,
+    )
+}
+
+fn build_generic_function_tag_tool_call_grammar(
+    tools: &[Tool],
+    parallel_tool_calls: bool,
+    lazy_suffix_only: bool,
+) -> Result<String, LLMError> {
+    let mut rules = vec!["generic-function-ws ::= [ \\t\\n\\r]*".to_string()];
+    let mut alternatives = Vec::new();
+    let mut full_alternatives = Vec::new();
+
+    for (index, tool) in tools.iter().enumerate() {
+        let name = tool.function.name.trim();
+        if name.is_empty() {
+            return Err(LLMError::ProviderError(
+                "Tool name must not be empty".to_string(),
+            ));
+        }
+        let schema = sanitize_tool_parameters_schema(&tool.function.parameters);
+        let args_grammar = compile_json_schema_grammar(&schema, name)?;
+        let args_rule = format!("generic-function-tool-{index}-args");
+        rules.push(rename_root_rule(&args_grammar, &args_rule));
+        let tagged_args_rule =
+            build_generic_function_tagged_args_grammar(index, &schema, &mut rules)?;
+
+        let suffix_rule = format!("generic-function-tool-{index}-suffix");
+        rules.push(format!(
+            "{suffix_rule} ::= {} \">\" generic-function-ws ({args_rule} | {tagged_args_rule}) generic-function-ws \"</function>\"",
+            gbnf_literal(name)
+        ));
+        alternatives.push(suffix_rule.clone());
+
+        let full_rule = format!("generic-function-tool-{index}");
+        rules.push(format!("{full_rule} ::= \"<function=\" {suffix_rule}"));
+        full_alternatives.push(full_rule);
+    }
+
+    let suffix_call = alternatives.join(" | ");
+    let full_call = full_alternatives.join(" | ");
+    let root = if lazy_suffix_only {
+        if parallel_tool_calls {
+            format!(
+                "root ::= ({suffix_call}) (generic-function-ws \"<function=\" generic-function-ws ({suffix_call}))*"
+            )
+        } else {
+            format!("root ::= ({suffix_call})")
+        }
+    } else if parallel_tool_calls {
+        format!("root ::= ({full_call}) (generic-function-ws ({full_call}))*")
+    } else {
+        format!("root ::= ({full_call})")
+    };
+
+    Ok(format!("{root}\n\n{}", rules.join("\n")))
+}
+
+fn build_generic_function_tagged_args_grammar(
+    tool_index: usize,
+    schema: &Value,
+    rules: &mut Vec<String>,
+) -> Result<String, LLMError> {
+    if !rules
+        .iter()
+        .any(|rule| rule.starts_with("generic-function-string ::="))
+    {
+        rules.push("generic-function-string ::= ([^<] | \"<\" [^/])*".to_string());
+    }
+    let required = schema
+        .get("required")
+        .and_then(Value::as_array)
+        .map(|values| {
+            values
+                .iter()
+                .filter_map(Value::as_str)
+                .map(ToOwned::to_owned)
+                .collect::<HashSet<_>>()
+        })
+        .unwrap_or_default();
+    let properties = schema
+        .get("properties")
+        .and_then(Value::as_object)
+        .cloned()
+        .unwrap_or_default();
+
+    let mut required_parsers = Vec::new();
+    let mut optional_parsers = Vec::new();
+    for (param_index, (param_name, param_schema)) in properties.iter().enumerate() {
+        let value_rule = if generic_tagged_param_is_string(param_schema) {
+            "generic-function-string".to_string()
+        } else {
+            let value_rule = format!("generic-function-tool-{tool_index}-arg-{param_index}-value");
+            let param_grammar = compile_json_schema_grammar(param_schema, param_name)?;
+            rules.push(rename_root_rule(&param_grammar, &value_rule));
+            value_rule
+        };
+
+        let arg_rule = format!("generic-function-tool-{tool_index}-arg-{param_index}");
+        let name = gbnf_literal(param_name);
+        rules.push(format!(
+            "{arg_rule} ::= \"<parameter name=\\\"\" {name} \"\\\">\" {value_rule} \"</parameter>\" | \"<param name=\\\"\" {name} \"\\\">\" {value_rule} \"</param>\" | \"<arg name=\\\"\" {name} \"\\\">\" {value_rule} \"</arg>\""
+        ));
+        if required.contains(param_name) {
+            required_parsers.push(arg_rule);
+        } else {
+            optional_parsers.push(arg_rule);
+        }
+    }
+
+    let body_rule = format!("generic-function-tool-{tool_index}-tagged-args");
+    let required_body = if required_parsers.is_empty() {
+        "generic-function-ws".to_string()
+    } else {
+        required_parsers.join(" generic-function-ws ")
+    };
+    let body = if optional_parsers.is_empty() {
+        required_body
+    } else {
+        let optional = optional_parsers.join(" | ");
+        format!("{required_body} (generic-function-ws ({optional}))*")
+    };
+    rules.push(format!("{body_rule} ::= {body}"));
+    Ok(body_rule)
+}
+
+fn generic_tagged_param_is_string(schema: &Value) -> bool {
+    schema.get("type").and_then(Value::as_str) == Some("string")
+}
+
+fn build_functionary_v32_content_grammar() -> String {
+    [
+        "root ::= \">>>all\\n\" functionary-content",
+        "functionary-content ::= ([^>] | \">\" [^>] | \">>\" [^>])*",
+    ]
+    .join("\n")
+}
+
+fn build_functionary_v32_tool_call_grammar(
+    tools: &[Tool],
+    parallel_tool_calls: bool,
+    lazy_suffix_only: bool,
+) -> Result<String, LLMError> {
+    let mut rules = vec!["functionary-ws ::= [ \\t\\n\\r]*".to_string()];
+    let mut alternatives = Vec::new();
+
+    for (index, tool) in tools.iter().enumerate() {
+        let name = tool.function.name.trim();
+        if name.is_empty() {
+            return Err(LLMError::ProviderError(
+                "Tool name must not be empty".to_string(),
+            ));
+        }
+        let schema = sanitize_tool_parameters_schema(&tool.function.parameters);
+        let args_grammar = compile_json_schema_grammar(&schema, name)?;
+        let args_rule = format!("functionary-tool-{index}-args");
+        rules.push(rename_root_rule(&args_grammar, &args_rule));
+        let call_rule = format!("functionary-tool-{index}");
+        rules.push(format!(
+            "{call_rule} ::= {} \"\\n\" {args_rule}",
+            gbnf_literal(name)
+        ));
+        alternatives.push(call_rule);
+    }
+
+    let call = alternatives.join(" | ");
+    let root = if lazy_suffix_only {
+        if parallel_tool_calls {
+            format!("root ::= ({call}) (functionary-ws \">>>\" functionary-ws ({call}))*")
+        } else {
+            format!("root ::= {call}")
+        }
+    } else if parallel_tool_calls {
+        format!(
+            "root ::= \">>>\" functionary-ws ({call}) (functionary-ws \">>>\" functionary-ws ({call}))*"
+        )
+    } else {
+        format!("root ::= \">>>\" functionary-ws ({call})")
+    };
+
+    Ok(format!("{root}\n\n{}", rules.join("\n")))
+}
+
+fn build_tool_calls_args_response_grammar(
+    tools: &[Tool],
+    json_schema: Option<&StructuredOutputFormat>,
+    force_json_grammar: bool,
+    tool_choice: LlamaCppToolChoice,
+    parallel_tool_calls: bool,
+) -> Result<String, LLMError> {
+    if tools.is_empty() {
+        return Err(LLMError::ProviderError(
+            "Cannot build Ministral tool grammar without tools".to_string(),
+        ));
+    }
+
+    let tool_call_grammar = build_tool_calls_args_grammar(tools, parallel_tool_calls)?;
+    if matches!(tool_choice, LlamaCppToolChoice::Required) {
+        return Ok(tool_call_grammar);
+    }
+
+    if matches!(tool_choice, LlamaCppToolChoice::Auto)
+        && json_schema.is_none()
+        && !force_json_grammar
+    {
+        return build_tool_calls_args_payload_grammar(tools, parallel_tool_calls);
+    }
+
+    let final_schema = json_schema
+        .and_then(sanitize_chat_template_schema)
+        .unwrap_or_else(|| {
+            json!({
+                "type": "object",
+                "properties": {
+                    "content": { "type": "string" }
+                },
+                "required": ["content"],
+                "additionalProperties": false
+            })
+        });
+    let mut final_grammar = compile_json_schema_grammar(&final_schema, "final response")?;
+    if json_schema.is_some() {
+        final_grammar = wrap_structured_response_grammar(
+            &final_grammar,
+            ToolCallGrammarFormat::ToolCallsArgsTag,
+        );
+    }
+    Ok(combine_final_and_native_tool_grammars(
+        &final_grammar,
+        &tool_call_grammar,
+    ))
+}
+
+fn build_tool_calls_args_grammar(
+    tools: &[Tool],
+    parallel_tool_calls: bool,
+) -> Result<String, LLMError> {
+    let payload = build_tool_calls_args_payload_grammar(tools, parallel_tool_calls)?;
+    let payload = rename_root_rule(&payload, "tool-payload");
+    let prefix = gbnf_literal("[TOOL_CALLS]");
+    Ok(format!(
+        "root ::= {prefix} [ \\t\\n\\r]* tool-payload\n\n{payload}"
+    ))
+}
+
+fn build_tool_calls_args_payload_grammar(
+    tools: &[Tool],
+    parallel_tool_calls: bool,
+) -> Result<String, LLMError> {
+    let mut rules = Vec::new();
+    let mut alternatives = Vec::new();
+    for (index, tool) in tools.iter().enumerate() {
+        let name = tool.function.name.trim();
+        if name.is_empty() {
+            return Err(LLMError::ProviderError(
+                "Tool name must not be empty".to_string(),
+            ));
+        }
+        let schema = sanitize_tool_parameters_schema(&tool.function.parameters);
+        let args_grammar = compile_json_schema_grammar(&schema, name)?;
+        let args_rule = format!("tool-{index}-args");
+        let args_grammar = rename_root_rule(&args_grammar, &args_rule);
+        let call_rule = format!("tool-{index}");
+        rules.push(format!(
+            "{call_rule} ::= {} tool-ws {} tool-ws {args_rule}",
+            gbnf_literal(name),
+            gbnf_literal("[ARGS]")
+        ));
+        rules.push(args_grammar);
+        alternatives.push(call_rule);
+    }
+
+    let root = if parallel_tool_calls {
+        format!(
+            "root ::= ({}) (tool-ws {} tool-ws ({}))*",
+            alternatives.join(" | "),
+            gbnf_literal("[TOOL_CALLS]"),
+            alternatives.join(" | ")
+        )
+    } else {
+        format!("root ::= {}", alternatives.join(" | "))
+    };
+    Ok(format!(
+        "{root}\ntool-ws ::= [ \\t\\n\\r]*\n\n{}",
+        rules.join("\n")
+    ))
+}
+
+fn build_gemma4_tool_response_grammar(
+    tools: &[Tool],
+    json_schema: Option<&StructuredOutputFormat>,
+    force_json_grammar: bool,
+    tool_choice: LlamaCppToolChoice,
+    parallel_tool_calls: bool,
+) -> Result<String, LLMError> {
+    if tools.is_empty() {
+        return Err(LLMError::ProviderError(
+            "Cannot build Gemma4 tool grammar without tools".to_string(),
+        ));
+    }
+
+    let tool_call_grammar =
+        build_gemma4_tool_call_grammar(tools, tool_choice.clone(), parallel_tool_calls)?;
+    if matches!(tool_choice, LlamaCppToolChoice::Required) {
+        return Ok(tool_call_grammar);
+    }
+
+    if matches!(tool_choice, LlamaCppToolChoice::Auto)
+        && json_schema.is_none()
+        && !force_json_grammar
+    {
+        return build_gemma4_tool_payload_grammar(tools, parallel_tool_calls);
+    }
+
+    let final_schema = json_schema
+        .and_then(sanitize_chat_template_schema)
+        .unwrap_or_else(|| {
+            json!({
+                "type": "object",
+                "properties": {
+                    "content": { "type": "string" }
+                },
+                "required": ["content"],
+                "additionalProperties": false
+            })
+        });
+    let final_grammar = compile_json_schema_grammar(&final_schema, "final response")?;
+    let final_grammar = if json_schema.is_some() {
+        wrap_structured_response_grammar(&final_grammar, ToolCallGrammarFormat::Gemma4ToolCall)
+    } else {
+        final_grammar
+    };
+    Ok(combine_final_and_native_tool_grammars(
+        &final_grammar,
+        &tool_call_grammar,
+    ))
+}
+
+fn build_gemma4_tool_call_grammar(
+    tools: &[Tool],
+    tool_choice: LlamaCppToolChoice,
+    parallel_tool_calls: bool,
+) -> Result<String, LLMError> {
+    let payload = build_gemma4_tool_payload_grammar(tools, parallel_tool_calls)?;
+    let payload = rename_root_rule(&payload, "gemma4-tool-payload");
+    let min = if matches!(tool_choice, LlamaCppToolChoice::Required) {
+        ""
+    } else {
+        "?"
+    };
+    Ok(format!(
+        "root ::= ({} [ \\t\\n\\r]* gemma4-tool-payload [ \\t\\n\\r]* {}){min}\n\n{payload}",
+        gbnf_literal("<|tool_call>call:"),
+        gbnf_literal("<tool_call|>")
+    ))
+}
+
+fn build_gemma4_tool_payload_grammar(
+    tools: &[Tool],
+    parallel_tool_calls: bool,
+) -> Result<String, LLMError> {
+    let mut rules = Vec::new();
+    let mut alternatives = Vec::new();
+    for (index, tool) in tools.iter().enumerate() {
+        let name = tool.function.name.trim();
+        if name.is_empty() {
+            return Err(LLMError::ProviderError(
+                "Tool name must not be empty".to_string(),
+            ));
+        }
+        let call_rule = format!("gemma4-tool-{index}");
+        rules.push(format!(
+            "{call_rule} ::= {} gemma4-ws gemma4-dict",
+            gbnf_literal(name)
+        ));
+        alternatives.push(call_rule);
+    }
+
+    let root = if parallel_tool_calls {
+        format!(
+            "root ::= ({}) ([ \\t\\n\\r]* {} [ \\t\\n\\r]* ({}))*",
+            alternatives.join(" | "),
+            gbnf_literal("<tool_call|><|tool_call>call:"),
+            alternatives.join(" | ")
+        )
+    } else {
+        format!("root ::= {}", alternatives.join(" | "))
+    };
+    Ok(format!(
+        "{root}\n\n{}\n\n{}",
+        rules.join("\n"),
+        gemma4_native_value_grammar()
+    ))
+}
+
+fn gemma4_native_value_grammar() -> &'static str {
+    r#"gemma4-ws ::= [ \t\n\r]*
+gemma4-string ::= "<|\"|>" gemma4-string-char* "<|\"|>"
+gemma4-string-char ::= [^<] | "<" [^|] | "<|" [^\"] | "<|\"" [^|] | "<|\"|" [^>]
+gemma4-bool ::= "true" | "false"
+gemma4-null ::= "null"
+gemma4-number ::= "-"? ([0-9] | [1-9] [0-9]*) ("." [0-9]+)? ([eE] [-+]? [0-9]+)?
+gemma4-dict-key-name ::= [^:}]+
+gemma4-dict-key ::= gemma4-dict-key-name ":"
+gemma4-dict-kv ::= gemma4-dict-key gemma4-ws gemma4-value
+gemma4-dict ::= "{" gemma4-ws ("}" | gemma4-dict-kv ("," gemma4-ws gemma4-dict-kv)* gemma4-ws "}")
+gemma4-array ::= "[" gemma4-ws ("]" | gemma4-value ("," gemma4-ws gemma4-value)* gemma4-ws "]")
+gemma4-value ::= gemma4-string | gemma4-dict | gemma4-array | gemma4-number | gemma4-bool | gemma4-null"#
+}
+
+fn build_native_tool_payload_schema(
+    tools: &[Tool],
+    tool_call_format: ToolCallGrammarFormat,
+    parallel_tool_calls: bool,
+) -> Result<Value, LlamaCppProviderError> {
+    let variants = tools
+        .iter()
+        .map(build_native_single_tool_call_schema)
+        .collect::<Result<Vec<_>, _>>()?;
+
+    match tool_call_format {
+        ToolCallGrammarFormat::XmlToolCall => Ok(json!({ "oneOf": variants })),
+        ToolCallGrammarFormat::ToolCallsArrayTag => {
+            let mut schema = json!({
+            "type": "array",
+            "minItems": 1,
+            "items": { "oneOf": variants }
+            });
+            if !parallel_tool_calls {
+                schema["maxItems"] = Value::from(1);
+            }
+            Ok(schema)
+        }
+        ToolCallGrammarFormat::ToolCallsArgsTag => Err(LlamaCppProviderError::Template(
+            "Ministral [TOOL_CALLS]/[ARGS] payload uses per-tool grammars".to_string(),
+        )),
+        ToolCallGrammarFormat::FunctionaryV32 => Err(LlamaCppProviderError::Template(
+            "Functionary v3.2 payload uses per-tool grammars".to_string(),
+        )),
+        ToolCallGrammarFormat::GenericFunctionTag => Err(LlamaCppProviderError::Template(
+            "Generic function tag payload uses per-tool grammars".to_string(),
+        )),
+        ToolCallGrammarFormat::Gemma4ToolCall => Err(LlamaCppProviderError::Template(
+            "Gemma4 native payload uses per-tool grammars".to_string(),
+        )),
+        ToolCallGrammarFormat::NativeChannelToolCall => Err(LlamaCppProviderError::Template(
+            "Native channel tool payload uses per-tool grammars".to_string(),
+        )),
+        ToolCallGrammarFormat::KimiK2ToolCall => Err(LlamaCppProviderError::Template(
+            "Kimi K2 tool payload uses per-tool grammars".to_string(),
+        )),
+        ToolCallGrammarFormat::Lfm2ToolCall => Err(LlamaCppProviderError::Template(
+            "LFM2 tool payload uses per-tool grammars".to_string(),
+        )),
+        ToolCallGrammarFormat::GigaChatV3ToolCall => Err(LlamaCppProviderError::Template(
+            "GigaChat V3 tool payload uses per-tool grammars".to_string(),
+        )),
+        ToolCallGrammarFormat::DeepSeekDsmlToolCall => Err(LlamaCppProviderError::Template(
+            "DeepSeek DSML tool payload uses per-tool grammars".to_string(),
+        )),
+        ToolCallGrammarFormat::OpenAiEnvelope => Err(LlamaCppProviderError::Template(
+            "OpenAI envelope is not a native tool payload".to_string(),
+        )),
+    }
+}
+
+fn build_native_single_tool_call_schema(tool: &Tool) -> Result<Value, LlamaCppProviderError> {
+    let name = tool.function.name.trim();
+    if name.is_empty() {
+        return Err(LlamaCppProviderError::Template(
+            "Tool name must not be empty".to_string(),
+        ));
+    }
+
+    let parameters = sanitize_tool_parameters_schema(&tool.function.parameters);
+    Ok(json!({
+        "type": "object",
+        "properties": {
+            "id": { "type": "string" },
+            "name": { "enum": [name] },
+            "arguments": parameters
+        },
+        "required": ["name", "arguments"],
+        "additionalProperties": false
+    }))
+}
+
+fn wrap_native_tool_payload_grammar(
+    payload_grammar: &str,
+    tool_call_format: ToolCallGrammarFormat,
+    include_markers: bool,
+) -> String {
+    let payload = rename_root_rule(payload_grammar, "tool-payload");
+    let (start, end) = if include_markers {
+        match tool_call_format {
+            ToolCallGrammarFormat::XmlToolCall => ("<tool_call>", "</tool_call>"),
+            ToolCallGrammarFormat::ToolCallsArrayTag => ("[TOOL_CALLS]", "[/TOOL_CALLS]"),
+            ToolCallGrammarFormat::ToolCallsArgsTag => ("[TOOL_CALLS]", ""),
+            ToolCallGrammarFormat::FunctionaryV32 => ("", ""),
+            ToolCallGrammarFormat::GenericFunctionTag => ("", ""),
+            ToolCallGrammarFormat::Gemma4ToolCall => ("<|tool_call>call:", "<tool_call|>"),
+            ToolCallGrammarFormat::NativeChannelToolCall => ("", ""),
+            ToolCallGrammarFormat::KimiK2ToolCall
+            | ToolCallGrammarFormat::Lfm2ToolCall
+            | ToolCallGrammarFormat::GigaChatV3ToolCall
+            | ToolCallGrammarFormat::DeepSeekDsmlToolCall => ("", ""),
+            ToolCallGrammarFormat::OpenAiEnvelope => ("", ""),
+        }
+    } else {
+        ("", "")
+    };
+    let start = if include_markers {
+        gbnf_literal(start)
+    } else {
+        String::new()
+    };
+    let spacing = if include_markers { " tool-ws " } else { "" };
+
+    let end = if end.is_empty() {
+        String::new()
+    } else {
+        format!(" {}", gbnf_literal(end))
+    };
+
+    format!(
+        "root ::= {start}{spacing}tool-payload tool-ws{end}\ntool-ws ::= [ \\t\\n\\r]*\n\n{payload}"
+    )
+}
+
+fn native_tool_markers_are_safe_in_grammar(tool_call_format: ToolCallGrammarFormat) -> bool {
+    !matches!(tool_call_format, ToolCallGrammarFormat::XmlToolCall)
+}
+
+fn combine_final_and_native_tool_grammars(final_grammar: &str, tool_call_grammar: &str) -> String {
+    let final_grammar = prefix_gbnf_rules(final_grammar, "final");
+    let tool_grammar = prefix_gbnf_rules(tool_call_grammar, "tool");
+    format!(
+        "root ::= final-root | tool-root\n\n{}\n\n{}",
+        final_grammar, tool_grammar
+    )
+}
+
+fn maybe_wrap_grammar_with_reasoning(grammar: &str, result: &ChatTemplateResult) -> String {
+    if result.reasoning_format.is_none() {
+        return grammar.to_string();
+    }
+
+    let start_tag = result.reasoning_start_tag.as_deref().unwrap_or("<think>");
+    let end_tag = result.reasoning_end_tag.as_deref().unwrap_or("</think>");
+    wrap_grammar_with_tagged_reasoning(grammar, start_tag, end_tag)
+}
+
+fn wrap_grammar_with_tagged_reasoning(grammar: &str, start_tag: &str, end_tag: &str) -> String {
+    let renamed = rename_root_rule(grammar, "root-content");
+    format!(
+        "root ::= reasoning? root-content\nreasoning ::= {} reasoning-char* {}\nreasoning-char ::= [^<] | \"<\" [^/]\n\n{}",
+        gbnf_literal(start_tag),
+        gbnf_literal(end_tag),
+        renamed
+    )
+}
+
+fn rename_root_rule(grammar: &str, new_name: &str) -> String {
+    grammar
+        .lines()
+        .map(|line| {
+            if let Some(rest) = line.strip_prefix("root ") {
+                format!("{new_name} {rest}")
+            } else {
+                line.to_string()
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn prefix_gbnf_rules(grammar: &str, prefix: &str) -> String {
+    let rule_names = collect_gbnf_rule_names(grammar);
+    let renamed = grammar
+        .lines()
+        .map(|line| {
+            if let Some((name, rest)) = split_gbnf_rule_definition(line)
+                && rule_names.contains(name)
+            {
+                return format!("{prefix}-{name} ::={}", rest);
+            }
+            line.to_string()
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    replace_gbnf_rule_references(&renamed, &rule_names, prefix)
+}
+
+fn collect_gbnf_rule_names(grammar: &str) -> HashSet<String> {
+    grammar
+        .lines()
+        .filter_map(split_gbnf_rule_definition)
+        .map(|(name, _)| name.to_string())
+        .collect()
+}
+
+fn split_gbnf_rule_definition(line: &str) -> Option<(&str, &str)> {
+    let (name, rest) = line.split_once("::=")?;
+    let name = name.trim();
+    if !is_gbnf_identifier(name) {
+        return None;
+    }
+    Some((name, rest))
+}
+
+fn is_gbnf_identifier(value: &str) -> bool {
+    let mut chars = value.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    (first.is_ascii_alphabetic() || first == '_')
+        && chars.all(|ch| ch.is_ascii_alphanumeric() || ch == '-' || ch == '_')
+}
+
+fn replace_gbnf_rule_references(
+    grammar: &str,
+    rule_names: &HashSet<String>,
+    prefix: &str,
+) -> String {
+    let mut output = String::with_capacity(grammar.len());
+    let mut chars = grammar.char_indices().peekable();
+    let mut in_string = false;
+    let mut in_class = false;
+    let mut escape = false;
+
+    while let Some((idx, ch)) = chars.next() {
+        if in_string {
+            output.push(ch);
+            if escape {
+                escape = false;
+            } else if ch == '\\' {
+                escape = true;
+            } else if ch == '"' {
+                in_string = false;
+            }
+            continue;
+        }
+        if in_class {
+            output.push(ch);
+            if escape {
+                escape = false;
+            } else if ch == '\\' {
+                escape = true;
+            } else if ch == ']' {
+                in_class = false;
+            }
+            continue;
+        }
+
+        match ch {
+            '"' => {
+                in_string = true;
+                output.push(ch);
+            }
+            '[' => {
+                in_class = true;
+                output.push(ch);
+            }
+            ch if ch.is_ascii_alphabetic() || ch == '_' => {
+                let start = idx;
+                let mut end = idx + ch.len_utf8();
+                while let Some((next_idx, next)) = chars.peek().copied() {
+                    if next.is_ascii_alphanumeric() || next == '-' || next == '_' {
+                        chars.next();
+                        end = next_idx + next.len_utf8();
+                    } else {
+                        break;
+                    }
+                }
+                let ident = &grammar[start..end];
+                if rule_names.contains(ident) {
+                    output.push_str(prefix);
+                    output.push('-');
+                }
+                output.push_str(ident);
+            }
+            _ => output.push(ch),
+        }
+    }
+
+    output
+}
+
+fn gbnf_literal(value: &str) -> String {
+    let mut escaped = String::with_capacity(value.len() + 2);
+    escaped.push('"');
+    for ch in value.chars() {
+        match ch {
+            '\\' => escaped.push_str("\\\\"),
+            '"' => escaped.push_str("\\\""),
+            '\n' => escaped.push_str("\\n"),
+            '\r' => escaped.push_str("\\r"),
+            '\t' => escaped.push_str("\\t"),
+            _ => escaped.push(ch),
+        }
+    }
+    escaped.push('"');
+    escaped
+}
+
+fn build_single_tool_call_schema(tool: &Tool) -> Result<Value, LlamaCppProviderError> {
+    let name = tool.function.name.trim();
+    if name.is_empty() {
+        return Err(LlamaCppProviderError::Template(
+            "Tool name must not be empty".to_string(),
+        ));
+    }
+
+    let parameters = sanitize_tool_parameters_schema(&tool.function.parameters);
+    Ok(json!({
+        "type": "object",
+        "properties": {
+            "id": { "type": "string" },
+            "type": { "enum": ["function"] },
+            "function": {
+                "type": "object",
+                "properties": {
+                    "name": { "enum": [name] },
+                    "arguments": parameters
+                },
+                "required": ["name", "arguments"],
+                "additionalProperties": false
+            }
+        },
+        "required": ["function"],
+        "additionalProperties": false
+    }))
+}
+
+fn sanitize_tool_parameters_schema(schema: &Value) -> Value {
+    match schema {
+        Value::Object(object) => {
+            let mut value = Value::Object(object.clone());
+            if value.get("type").is_none() {
+                value["type"] = Value::String("object".to_string());
+            }
+            if matches!(value.get("type"), Some(Value::String(kind)) if kind == "object")
+                && value.get("additionalProperties").is_none()
+            {
+                value["additionalProperties"] = Value::Bool(false);
+            }
+            value
+        }
+        _ => json!({
+            "type": "object",
+            "additionalProperties": true
+        }),
+    }
+}
+
+fn select_template_schema_and_grammar(
+    json_schema: Option<&StructuredOutputFormat>,
+    force_json_grammar: bool,
+    tool_call_format: Option<ToolCallGrammarFormat>,
+) -> Result<(Option<String>, Option<String>), LLMError> {
+    // llama.cpp's OpenAI-compatible template API treats `json_schema` as part of grammar
+    // generation AND configures a schema-bound parser for the generated response. That
+    // parser expects a structured-output envelope that plain-JSON generations don't
+    // provide, surfacing as `ffi error -3` from `chat_parse_to_oaicompat`
+    // (https://github.com/liquidos-ai/AutoAgents/issues/220). We compile schemas to
+    // grammar at our boundary and pass them via the `grammar` slot, leaving parser
+    // normalization in AutoAgents-owned Rust code.
     if let Some(schema_value) = json_schema.and_then(sanitize_chat_template_schema) {
         let schema_str = schema_value.to_string();
-        let grammar = llama_cpp_2::json_schema_to_grammar(&schema_str)
-            .unwrap_or_else(|_| JSON_GRAMMAR.to_string());
-        return (None, Some(grammar));
+        let grammar = llama_cpp_2::json_schema_to_grammar(&schema_str).map_err(|err| {
+            LLMError::invalid_request(format!(
+                "invalid llama.cpp structured output JSON schema: {err}"
+            ))
+        })?;
+        let grammar = tool_call_format.map_or(grammar.clone(), |format| {
+            wrap_structured_response_grammar(&grammar, format)
+        });
+        return Ok((None, Some(grammar)));
     }
 
     let grammar_value = if force_json_grammar {
@@ -1705,7 +5741,39 @@ fn select_template_schema_and_grammar(
     } else {
         None
     };
-    (None, grammar_value)
+    Ok((None, grammar_value))
+}
+
+fn enabled_tools_for_config<'a>(
+    config: &LlamaCppConfig,
+    tools: Option<&'a [Tool]>,
+) -> Option<&'a [Tool]> {
+    tools.filter(|tools| {
+        !tools.is_empty() && !matches!(config.tool_choice, LlamaCppToolChoice::None)
+    })
+}
+
+fn should_stream_final_message(template_result: &ChatTemplateResult) -> bool {
+    template_result.parse_tool_calls
+        || template_result.grammar.is_some()
+        || template_result.reasoning_format.is_some()
+}
+
+fn decode_model_special_token(
+    model: &LlamaModel,
+    token: LlamaToken,
+    name: &str,
+) -> Result<String, LLMError> {
+    if token.0 < 0 {
+        return Ok(String::new());
+    }
+
+    let mut decoder = encoding_rs::UTF_8.new_decoder();
+    model
+        .token_to_piece(token, &mut decoder, true, None)
+        .map_err(|err| {
+            LLMError::ProviderError(format!("failed to decode llama.cpp {name} token: {err}"))
+        })
 }
 
 fn ensure_supported_messages_for_config(
@@ -1780,7 +5848,7 @@ fn mtmd_tool_stream(
     response_stream: Pin<Box<dyn Stream<Item = Result<StreamEvent, LLMError>> + Send>>,
 ) -> impl Stream<Item = Result<StreamChunk, LLMError>> {
     response_stream
-        .map(|event| {
+        .scan(StreamMappingState::default(), |stream_state, event| {
             let mut outputs = Vec::new();
             match event {
                 Ok(StreamEvent::Token(token)) => {
@@ -1799,6 +5867,7 @@ fn mtmd_tool_stream(
                             parsed
                                 .reasoning_content
                                 .and_then(StringOrJson::into_non_empty_string),
+                            stream_state,
                             &mut outputs,
                         );
                     }
@@ -1806,7 +5875,7 @@ fn mtmd_tool_stream(
                 },
                 Err(err) => outputs.push(Err(err)),
             }
-            outputs
+            futures::future::ready(Some(outputs))
         })
         .flat_map(futures::stream::iter)
 }
@@ -1831,7 +5900,7 @@ fn single_stream_response(
 
 fn map_struct_stream_event(
     event: Result<StreamEvent, LLMError>,
-    tool_states: &mut HashMap<usize, ToolCallState>,
+    stream_state: &mut StreamMappingState,
 ) -> Vec<Result<StreamResponse, LLMError>> {
     let mut outputs = Vec::new();
     match event {
@@ -1847,10 +5916,15 @@ fn map_struct_stream_event(
                     parsed
                         .reasoning_content
                         .and_then(StringOrJson::into_non_empty_string),
+                    stream_state,
                     &mut outputs,
                 );
                 if let Some(tool_calls) = parsed.tool_calls {
-                    push_struct_tool_call_updates(tool_calls, tool_states, &mut outputs);
+                    push_struct_tool_call_updates(
+                        tool_calls,
+                        &mut stream_state.tool_calls,
+                        &mut outputs,
+                    );
                 }
             }
             Err(err) => outputs.push(Err(err)),
@@ -1866,7 +5940,7 @@ fn map_struct_stream_event(
 
 fn map_tool_stream_event(
     event: Result<StreamEvent, LLMError>,
-    tool_states: &mut HashMap<usize, ToolCallState>,
+    stream_state: &mut StreamMappingState,
 ) -> Vec<Result<StreamChunk, LLMError>> {
     let mut outputs = Vec::new();
     match event {
@@ -1882,17 +5956,18 @@ fn map_tool_stream_event(
                     parsed
                         .reasoning_content
                         .and_then(StringOrJson::into_non_empty_string),
+                    stream_state,
                     &mut outputs,
                 );
                 if let Some(tool_calls) = parsed.tool_calls {
-                    push_tool_chunk_updates(tool_calls, tool_states, &mut outputs);
+                    push_tool_chunk_updates(tool_calls, &mut stream_state.tool_calls, &mut outputs);
                 }
             }
             Err(err) => outputs.push(Err(err)),
         },
         Ok(StreamEvent::Usage(usage)) => outputs.push(Ok(StreamChunk::Usage(usage))),
         Ok(StreamEvent::Done { stop_reason }) => {
-            push_tool_completions(tool_states, &mut outputs);
+            push_tool_completions(&mut stream_state.tool_calls, &mut outputs);
             outputs.push(Ok(StreamChunk::Done { stop_reason }));
         }
         Err(err) => outputs.push(Err(err)),
@@ -1903,22 +5978,22 @@ fn map_tool_stream_event(
 fn push_struct_content_and_reasoning(
     content: Option<String>,
     reasoning_content: Option<String>,
+    stream_state: &mut StreamMappingState,
     outputs: &mut Vec<Result<StreamResponse, LLMError>>,
 ) {
-    if let Some(content) = content
-        && !content.is_empty()
-    {
-        outputs.push(Ok(single_stream_response(Some(content), None, None, None)));
+    if let Some(content) = content {
+        let delta = append_or_diff_string(&stream_state.content, &content);
+        if !delta.is_empty() {
+            stream_state.content.push_str(&delta);
+            outputs.push(Ok(single_stream_response(Some(delta), None, None, None)));
+        }
     }
-    if let Some(reasoning_content) = reasoning_content
-        && !reasoning_content.is_empty()
-    {
-        outputs.push(Ok(single_stream_response(
-            None,
-            Some(reasoning_content),
-            None,
-            None,
-        )));
+    if let Some(reasoning_content) = reasoning_content {
+        let delta = append_or_diff_string(&stream_state.reasoning_content, &reasoning_content);
+        if !delta.is_empty() {
+            stream_state.reasoning_content.push_str(&delta);
+            outputs.push(Ok(single_stream_response(None, Some(delta), None, None)));
+        }
     }
 }
 
@@ -1940,8 +6015,9 @@ fn push_struct_tool_call_updates(
                 state.name = name;
             }
             let arguments = function.arguments.into_string();
-            if !arguments.is_empty() {
-                state.arguments.push_str(&arguments);
+            let argument_delta = append_or_diff_string(&state.arguments, &arguments);
+            if !argument_delta.is_empty() {
+                state.arguments.push_str(&argument_delta);
             }
         }
         if !state.id.is_empty() || !state.name.is_empty() || !state.arguments.is_empty() {
@@ -1990,11 +6066,12 @@ fn push_tool_chunk_updates(
                 }
             }
             let arguments = function.arguments.into_string();
-            if !arguments.is_empty() {
-                state.arguments.push_str(&arguments);
+            let argument_delta = append_or_diff_string(&state.arguments, &arguments);
+            if !argument_delta.is_empty() {
+                state.arguments.push_str(&argument_delta);
                 outputs.push(Ok(StreamChunk::ToolUseInputDelta {
                     index,
-                    partial_json: arguments,
+                    partial_json: argument_delta,
                 }));
             }
         }
@@ -2025,17 +6102,22 @@ fn push_tool_completions(
 fn push_text_and_reasoning_chunks(
     content: Option<String>,
     reasoning_content: Option<String>,
+    stream_state: &mut StreamMappingState,
     outputs: &mut Vec<Result<StreamChunk, LLMError>>,
 ) {
-    if let Some(content) = content
-        && !content.is_empty()
-    {
-        outputs.push(Ok(StreamChunk::Text(content)));
+    if let Some(content) = content {
+        let delta = append_or_diff_string(&stream_state.content, &content);
+        if !delta.is_empty() {
+            stream_state.content.push_str(&delta);
+            outputs.push(Ok(StreamChunk::Text(delta)));
+        }
     }
-    if let Some(reasoning_content) = reasoning_content
-        && !reasoning_content.is_empty()
-    {
-        outputs.push(Ok(StreamChunk::ReasoningContent(reasoning_content)));
+    if let Some(reasoning_content) = reasoning_content {
+        let delta = append_or_diff_string(&stream_state.reasoning_content, &reasoning_content);
+        if !delta.is_empty() {
+            stream_state.reasoning_content.push_str(&delta);
+            outputs.push(Ok(StreamChunk::ReasoningContent(delta)));
+        }
     }
 }
 
@@ -2072,7 +6154,7 @@ impl EmbeddingProvider for LlamaCppProvider {
         let model = self.model.clone();
         let backend = self.backend.clone();
 
-        Self::run_blocking_task("Embedding", move || {
+        self.run_blocking_task("Embedding", move || {
             let mut embeddings = Vec::with_capacity(input.len());
             for text in input {
                 let embedding = generate_embedding(&model, &backend, &config, &text)?;
@@ -2240,6 +6322,58 @@ fn build_sampler(
         samplers.push(sampler);
     }
 
+    append_sampling_chain(
+        model,
+        config,
+        temperature_override,
+        top_p_override,
+        seed_override,
+        &mut samplers,
+    );
+
+    Ok(LlamaSampler::chain_simple(samplers))
+}
+
+fn append_sampling_chain(
+    model: &LlamaModel,
+    config: &LlamaCppConfig,
+    temperature_override: Option<f32>,
+    top_p_override: Option<f32>,
+    seed_override: Option<u32>,
+    samplers: &mut Vec<LlamaSampler>,
+) {
+    if let Some(biases) = config.logit_bias.as_ref()
+        && !biases.is_empty()
+    {
+        let biases = biases
+            .iter()
+            .map(|(token, bias)| LlamaLogitBias::new(LlamaToken(*token), *bias))
+            .collect::<Vec<_>>();
+        samplers.push(LlamaSampler::logit_bias(model.n_vocab(), &biases));
+    }
+
+    if let Some(multiplier) = config.dry_multiplier
+        && multiplier != 0.0
+    {
+        samplers.push(LlamaSampler::dry(
+            model,
+            multiplier,
+            config.dry_base.unwrap_or(1.75),
+            config.dry_allowed_length.unwrap_or(2),
+            config
+                .dry_penalty_last_n
+                .unwrap_or_else(|| config.repeat_last_n.unwrap_or(64)),
+            config.dry_sequence_breakers.clone().unwrap_or_else(|| {
+                vec![
+                    "\n".to_string(),
+                    ":".to_string(),
+                    "\"".to_string(),
+                    "*".to_string(),
+                ]
+            }),
+        ));
+    }
+
     let penalty_repeat = config.repeat_penalty.unwrap_or(1.0);
     let penalty_freq = config.frequency_penalty.unwrap_or(0.0);
     let penalty_present = config.presence_penalty.unwrap_or(0.0);
@@ -2253,63 +6387,73 @@ fn build_sampler(
         ));
     }
 
+    let min_keep = config.min_keep.unwrap_or(1);
     if let Some(top_k) = config.top_k {
         samplers.push(LlamaSampler::top_k(top_k as i32));
     }
+    if let Some(typical_p) = config.typical_p {
+        samplers.push(LlamaSampler::typical(typical_p, min_keep));
+    }
     if let Some(top_p) = top_p_override.or(config.top_p) {
-        samplers.push(LlamaSampler::top_p(top_p, 1));
+        samplers.push(LlamaSampler::top_p(top_p, min_keep));
+    }
+    if let Some(min_p) = config.min_p {
+        samplers.push(LlamaSampler::min_p(min_p, min_keep));
+    }
+    if let Some(top_n_sigma) = config.top_n_sigma {
+        samplers.push(LlamaSampler::top_n_sigma(top_n_sigma));
+    }
+
+    let seed = seed_override.or(config.seed).unwrap_or_else(rand::random);
+    if let (Some(probability), Some(threshold)) = (config.xtc_probability, config.xtc_threshold)
+        && probability > 0.0
+    {
+        samplers.push(LlamaSampler::xtc(probability, threshold, min_keep, seed));
     }
 
     let temperature = temperature_override.or(config.temperature);
-    if let Some(temp) = temperature {
-        if temp > 0.0 {
-            samplers.push(LlamaSampler::temp(temp));
-            let seed = seed_override.or(config.seed).unwrap_or_else(rand::random);
-            samplers.push(LlamaSampler::dist(seed));
-        } else {
-            samplers.push(LlamaSampler::greedy());
+    match config.mirostat {
+        Some(1) => {
+            samplers.push(LlamaSampler::mirostat(
+                model.n_vocab(),
+                seed,
+                config.mirostat_tau.unwrap_or(5.0),
+                config.mirostat_eta.unwrap_or(0.1),
+                100,
+            ));
+            return;
         }
+        Some(2) => {
+            samplers.push(LlamaSampler::mirostat_v2(
+                seed,
+                config.mirostat_tau.unwrap_or(5.0),
+                config.mirostat_eta.unwrap_or(0.1),
+            ));
+            return;
+        }
+        _ => {}
+    }
+
+    if let Some(temp) = temperature
+        && temp > 0.0
+    {
+        if let (Some(delta), Some(exponent)) = (config.dynatemp_range, config.dynatemp_exponent) {
+            samplers.push(LlamaSampler::temp_ext(temp, delta, exponent));
+        } else {
+            samplers.push(LlamaSampler::temp(temp));
+        }
+        samplers.push(LlamaSampler::dist(seed));
+    } else if temperature == Some(0.0) {
+        samplers.push(LlamaSampler::greedy());
     } else {
-        let seed = seed_override.or(config.seed).unwrap_or_else(rand::random);
         samplers.push(LlamaSampler::dist(seed));
     }
-
-    Ok(LlamaSampler::chain_simple(samplers))
-}
-
-fn regex_escape(value: &str) -> String {
-    let mut escaped = String::with_capacity(value.len());
-    for ch in value.chars() {
-        match ch {
-            '.' | '^' | '$' | '|' | '(' | ')' | '*' | '+' | '?' | '[' | ']' | '{' | '}' | '\\' => {
-                escaped.push('\\');
-                escaped.push(ch);
-            }
-            _ => escaped.push(ch),
-        }
-    }
-    escaped
-}
-
-fn anchor_pattern(pattern: &str) -> String {
-    if pattern.is_empty() {
-        return "^$".to_string();
-    }
-    let mut anchored = String::default();
-    if !pattern.starts_with('^') {
-        anchored.push('^');
-    }
-    anchored.push_str(pattern);
-    if !pattern.ends_with('$') {
-        anchored.push('$');
-    }
-    anchored
 }
 
 fn build_chat_sampler(
     model: &LlamaModel,
     config: &LlamaCppConfig,
-    result: &llama_cpp_2::model::ChatTemplateResult,
+    result: &ChatTemplateResult,
     temperature_override: Option<f32>,
     top_p_override: Option<f32>,
 ) -> Result<(LlamaSampler, HashSet<LlamaToken>), LlamaCppProviderError> {
@@ -2324,62 +6468,22 @@ fn build_chat_sampler(
     }
 
     let grammar_sampler = if let Some(grammar) = result.grammar.as_deref() {
-        if result.grammar_lazy {
-            if result.grammar_triggers.is_empty() {
-                return Err(LlamaCppProviderError::Template(
-                    "grammar_lazy enabled but no triggers were provided".to_string(),
-                ));
-            }
-            let mut trigger_patterns = Vec::new();
-            let mut trigger_tokens = Vec::new();
-            for trigger in &result.grammar_triggers {
-                match trigger.trigger_type {
-                    GrammarTriggerType::Token => {
-                        if let Some(token) = trigger.token {
-                            trigger_tokens.push(token);
-                        }
-                    }
-                    GrammarTriggerType::Word => {
-                        let tokens = model
-                            .str_to_token(&trigger.value, AddBos::Never)
-                            .map_err(|err| LlamaCppProviderError::Tokenization(err.to_string()))?;
-                        if tokens.len() == 1 {
-                            if !preserved.contains(&tokens[0]) {
-                                return Err(LlamaCppProviderError::Template(format!(
-                                    "grammar trigger word not preserved: {}",
-                                    trigger.value
-                                )));
-                            }
-                            trigger_tokens.push(tokens[0]);
-                        } else {
-                            trigger_patterns.push(regex_escape(&trigger.value));
-                        }
-                    }
-                    GrammarTriggerType::Pattern => {
-                        trigger_patterns.push(trigger.value.clone());
-                    }
-                    GrammarTriggerType::PatternFull => {
-                        trigger_patterns.push(anchor_pattern(&trigger.value));
-                    }
-                }
-            }
-
-            Some(
-                LlamaSampler::grammar_lazy_patterns(
-                    model,
-                    grammar,
-                    "root",
-                    &trigger_patterns,
-                    &trigger_tokens,
-                )
-                .map_err(|err| LlamaCppProviderError::Template(err.to_string()))?,
+        Some(if result.grammar_lazy {
+            let (trigger_patterns, trigger_tokens) =
+                grammar_trigger_patterns(&result.grammar_triggers);
+            LlamaSampler::grammar_lazy_patterns(
+                model,
+                grammar,
+                "root",
+                &trigger_patterns,
+                &trigger_tokens,
             )
+            .map_err(|err| LlamaCppProviderError::Template(err.to_string()))?
         } else {
-            Some(
-                LlamaSampler::grammar(model, grammar, "root")
-                    .map_err(|err| LlamaCppProviderError::Template(err.to_string()))?,
-            )
-        }
+            let grammar = maybe_wrap_grammar_with_reasoning(grammar, result);
+            LlamaSampler::grammar(model, &grammar, "root")
+                .map_err(|err| LlamaCppProviderError::Template(err.to_string()))?
+        })
     } else {
         None
     };
@@ -2389,41 +6493,126 @@ fn build_chat_sampler(
         samplers.push(grammar_sampler);
     }
 
-    let penalty_repeat = config.repeat_penalty.unwrap_or(1.0);
-    let penalty_freq = config.frequency_penalty.unwrap_or(0.0);
-    let penalty_present = config.presence_penalty.unwrap_or(0.0);
-    let penalty_last_n = config.repeat_last_n.unwrap_or(64);
-    if penalty_repeat != 1.0 || penalty_freq != 0.0 || penalty_present != 0.0 {
-        samplers.push(LlamaSampler::penalties(
-            penalty_last_n,
-            penalty_repeat,
-            penalty_freq,
-            penalty_present,
-        ));
+    append_sampling_chain(
+        model,
+        config,
+        temperature_override,
+        top_p_override,
+        None,
+        &mut samplers,
+    );
+
+    let mut sampler = LlamaSampler::chain_simple(samplers);
+    if let Some(generation_prompt_prefill) = generation_prompt_grammar_prefill(result) {
+        let generation_prompt_tokens = model
+            .str_to_token(generation_prompt_prefill, AddBos::Never)
+            .map_err(|err| LlamaCppProviderError::Tokenization(err.to_string()))?;
+        sampler.accept_many(generation_prompt_tokens.iter());
     }
 
-    if let Some(top_k) = config.top_k {
-        samplers.push(LlamaSampler::top_k(top_k as i32));
+    Ok((sampler, preserved))
+}
+
+fn generation_prompt_grammar_prefill(result: &ChatTemplateResult) -> Option<&str> {
+    let grammar = result.grammar.as_deref()?;
+    if result.grammar_lazy || result.generation_prompt.is_empty() {
+        return None;
     }
-    if let Some(top_p) = top_p_override.or(config.top_p) {
-        samplers.push(LlamaSampler::top_p(top_p, 1));
+    generation_prompt_grammar_prefill_for(
+        &result.generation_prompt,
+        grammar,
+        result.reasoning_start_tag.as_deref().unwrap_or("<think>"),
+    )
+}
+
+fn generation_prompt_grammar_prefill_for<'a>(
+    generation_prompt: &'a str,
+    grammar: &str,
+    reasoning_start_tag: &str,
+) -> Option<&'a str> {
+    let trimmed_prompt = generation_prompt.trim_end_matches(['\n', '\r']);
+    if !trimmed_prompt.is_empty() && grammar.contains(&gbnf_literal(trimmed_prompt)) {
+        return Some(trimmed_prompt);
     }
 
-    let temperature = temperature_override.or(config.temperature);
-    if let Some(temp) = temperature {
-        if temp > 0.0 {
-            samplers.push(LlamaSampler::temp(temp));
-            let seed = config.seed.unwrap_or_else(rand::random);
-            samplers.push(LlamaSampler::dist(seed));
-        } else {
-            samplers.push(LlamaSampler::greedy());
+    if grammar.contains(&gbnf_literal(reasoning_start_tag))
+        && let Some(index) = generation_prompt.find(reasoning_start_tag)
+    {
+        return Some(&generation_prompt[index..]);
+    }
+
+    const SERVER_RESPONSE_MARKERS: &[&str] = &[
+        "<|start|>assistant",
+        "<|channel|>",
+        "<|message|>",
+        "<|turn>model",
+        "<|tool_call>",
+        "<tool_call>",
+        "[TOOL_CALLS]",
+        "<function=",
+        ">>>",
+        "｜DSML｜",
+    ];
+
+    SERVER_RESPONSE_MARKERS
+        .iter()
+        .filter(|marker| grammar.contains(&gbnf_literal(marker)))
+        .filter_map(|marker| {
+            generation_prompt
+                .find(marker)
+                .map(|index| &generation_prompt[index..])
+        })
+        .next()
+}
+
+fn grammar_trigger_patterns(triggers: &[GrammarTrigger]) -> (Vec<String>, Vec<LlamaToken>) {
+    let mut patterns = Vec::new();
+    let mut tokens = Vec::new();
+
+    for trigger in triggers {
+        match trigger {
+            GrammarTrigger::Word(word) => patterns.push(regex_escape(word)),
+            GrammarTrigger::Pattern(pattern) => patterns.push(pattern.clone()),
+            GrammarTrigger::PatternFull(pattern) => patterns.push(anchor_full_pattern(pattern)),
+            GrammarTrigger::Token(token) => tokens.push(LlamaToken(*token)),
         }
-    } else {
-        let seed = config.seed.unwrap_or_else(rand::random);
-        samplers.push(LlamaSampler::dist(seed));
     }
 
-    Ok((LlamaSampler::chain_simple(samplers), preserved))
+    (patterns, tokens)
+}
+
+fn anchor_full_pattern(pattern: &str) -> String {
+    if pattern.is_empty() {
+        return "^$".to_string();
+    }
+
+    let mut anchored = String::with_capacity(pattern.len() + 2);
+    if !pattern.starts_with('^') {
+        anchored.push('^');
+    }
+    anchored.push_str(pattern);
+    if !pattern.ends_with('$') {
+        anchored.push('$');
+    }
+    anchored
+}
+
+fn regex_escape(value: &str) -> String {
+    let mut escaped = String::with_capacity(value.len());
+    for ch in value.chars() {
+        match ch {
+            '\\' | '.' | '+' | '*' | '?' | '(' | ')' | '|' | '[' | ']' | '{' | '}' | '^' | '$'
+            | '#' | '&' | '-' | '~' => {
+                escaped.push('\\');
+                escaped.push(ch);
+            }
+            '\n' => escaped.push_str("\\n"),
+            '\r' => escaped.push_str("\\r"),
+            '\t' => escaped.push_str("\\t"),
+            _ => escaped.push(ch),
+        }
+    }
+    escaped
 }
 
 /// Acquire an inference context: either from persistent session state (with
@@ -2480,7 +6669,11 @@ fn acquire_context<'a>(
                     n_ctx,
                     n_batch,
                 )?);
-                let state = guard.as_mut().unwrap();
+                let state = guard.as_mut().ok_or_else(|| {
+                    LlamaCppProviderError::Inference(
+                        "session reset did not create an active context".to_string(),
+                    )
+                })?;
                 state.decode_tokens(prompt_tokens, n_batch as usize)?;
             } else {
                 // Prefix reuse: evict stale tail, decode only new tokens.
@@ -2552,7 +6745,14 @@ fn generate_chat_text(
     } = params;
 
     let mut prompt_tokens = model
-        .str_to_token(&template_result.prompt, AddBos::Always)
+        .str_to_token(
+            &template_result.prompt,
+            if template_result.add_bos {
+                AddBos::Always
+            } else {
+                AddBos::Never
+            },
+        )
         .map_err(|err| LlamaCppProviderError::Tokenization(err.to_string()))?;
 
     if prompt_tokens.is_empty() {
@@ -2591,14 +6791,6 @@ fn generate_chat_text(
     let (mut sampler, preserved) =
         build_chat_sampler(model, config, template_result, temperature, top_p)?;
     let additional_stops = template_result.additional_stops.clone();
-    let mut stream_state = if on_delta.is_some() {
-        Some(template_result.streaming_state_oaicompat().map_err(|err| {
-            LlamaCppProviderError::Template(format!("Failed to init streaming state: {err}"))
-        })?)
-    } else {
-        None
-    };
-
     // We need a LlamaBatch for generation steps. Size 1 per step.
     let mut gen_batch = LlamaBatch::new(1, 1);
 
@@ -2633,16 +6825,13 @@ fn generate_chat_text(
             .iter()
             .any(|stop| !stop.is_empty() && generated_text.ends_with(stop));
 
-        if let (Some(state), Some(ref mut on_delta)) = (stream_state.as_mut(), on_delta.as_mut()) {
-            let deltas = state.update(&output_string, !stop_now).map_err(|err| {
-                LlamaCppProviderError::Template(format!("Streaming delta update failed: {err}"))
-            })?;
-            for delta in deltas {
-                on_delta(&delta)?;
-            }
+        if let Some(ref mut on_delta) = on_delta {
+            on_delta(&output_string)?;
         }
 
-        if stop_now {
+        let response_complete =
+            should_stop_after_complete_chat_response(template_result, &generated_text)?;
+        if stop_now || response_complete {
             break;
         }
 
@@ -2682,7 +6871,6 @@ fn generate_chat_text(
             break;
         }
     }
-
     Ok(GenerationResult {
         text,
         prompt_tokens: prompt_len as u32,
@@ -2718,6 +6906,8 @@ fn generate_mtmd_text(
         n_threads: config.n_threads.unwrap_or(4),
         media_marker: CString::new(marker)
             .map_err(|err| LlamaCppProviderError::Config(err.to_string()))?,
+        image_min_tokens: -1,
+        image_max_tokens: -1,
     };
 
     let mtmd_ctx = MtmdContext::init_from_file(mmproj_path, model, &mtmd_params)
@@ -2734,7 +6924,7 @@ fn generate_mtmd_text(
 
     let mut bitmaps = Vec::with_capacity(images.len());
     for image in images {
-        let bitmap = MtmdBitmap::from_buffer(&mtmd_ctx, image)
+        let bitmap = MtmdBitmap::from_buffer(&mtmd_ctx, image, false)
             .map_err(|err| LlamaCppProviderError::Inference(err.to_string()))?;
         bitmaps.push(bitmap);
     }
@@ -2767,7 +6957,6 @@ fn generate_mtmd_text(
 
     while n_cur < max_tokens_total {
         let token = sampler.sample(&ctx, -1);
-        sampler.accept(token);
         if model.is_eog_token(token) {
             break;
         }
@@ -2855,7 +7044,6 @@ fn generate_text(
 
     // First token: sample from last logits position after prefill.
     let mut next_token = active_ctx.with_ctx(|ctx| sampler.sample(ctx, -1));
-    sampler.accept(next_token);
 
     let mut position = batch_start_pos as usize;
     let mut gen_batch = LlamaBatch::new(1, 1);
@@ -2877,6 +7065,10 @@ fn generate_text(
             on_token(&token_str)?;
         }
 
+        if should_stop_after_complete_json_response(use_json_grammar, &generated_text) {
+            break;
+        }
+
         gen_batch.clear();
         gen_batch
             .add(next_token, position as i32, &[0], true)
@@ -2892,7 +7084,6 @@ fn generate_text(
         }
 
         next_token = active_ctx.with_ctx(|ctx| sampler.sample(ctx, gen_batch.n_tokens() - 1));
-        sampler.accept(next_token);
     }
 
     // Session cleanup: reset to prompt tokens only.
@@ -2981,7 +7172,48 @@ fn extract_json_payload(text: &str) -> Option<String> {
         return Some(candidate);
     }
 
-    extract_first_json_object(trimmed)
+    extract_first_json_array(trimmed).or_else(|| extract_first_json_object(trimmed))
+}
+
+fn should_stop_after_complete_chat_response(
+    result: &ChatTemplateResult,
+    generated_text: &str,
+) -> Result<bool, LlamaCppProviderError> {
+    if result.grammar.is_none() {
+        return Ok(false);
+    }
+
+    if result.parse_tool_calls
+        && let Some(message) = parse_tool_response_message(generated_text)?
+        && message
+            .get("tool_calls")
+            .and_then(Value::as_array)
+            .is_some_and(|calls| !calls.is_empty())
+    {
+        return Ok(true);
+    }
+
+    Ok(is_complete_structured_payload(generated_text))
+}
+
+fn should_stop_after_complete_json_response(use_json_grammar: bool, generated_text: &str) -> bool {
+    use_json_grammar && is_complete_structured_payload(generated_text)
+}
+
+fn is_complete_structured_payload(text: &str) -> bool {
+    let Some(payload) = extract_json_payload(text) else {
+        return false;
+    };
+    let trimmed = text.trim();
+    if trimmed == payload {
+        return true;
+    }
+
+    if trimmed.starts_with("```") || trimmed.contains("```json") {
+        return trimmed.ends_with("```") && trimmed.contains(&payload);
+    }
+
+    trimmed.ends_with(&payload)
 }
 
 fn is_valid_json(candidate: &str) -> bool {
@@ -3025,6 +7257,14 @@ fn extract_from_code_fence(text: &str) -> Option<String> {
 }
 
 fn extract_first_json_object(text: &str) -> Option<String> {
+    extract_first_json_balanced(text, '{', '}')
+}
+
+fn extract_first_json_array(text: &str) -> Option<String> {
+    extract_first_json_balanced(text, '[', ']')
+}
+
+fn extract_first_json_balanced(text: &str, open: char, close: char) -> Option<String> {
     let mut in_string = false;
     let mut escape = false;
     let mut depth = 0i32;
@@ -3046,13 +7286,13 @@ fn extract_first_json_object(text: &str) -> Option<String> {
 
         match ch {
             '"' => in_string = true,
-            '{' => {
+            current if current == open => {
                 if depth == 0 {
                     start = Some(idx);
                 }
                 depth += 1;
             }
-            '}' if depth > 0 => {
+            current if current == close && depth > 0 => {
                 depth -= 1;
                 if depth == 0 {
                     if let Some(start_idx) = start {
@@ -3075,7 +7315,7 @@ fn extract_first_json_object(text: &str) -> Option<String> {
 mod tests {
     use super::*;
     const TEST_GGUF_MODEL_PATH: &str = "fixtures/model.gguf";
-    use autoagents_llm::chat::ImageMime;
+    use autoagents_llm::chat::{FunctionTool, ImageMime};
     use serde_json::json;
 
     fn chunk_count(total: usize, batch: usize) -> usize {
@@ -3083,6 +7323,65 @@ mod tests {
             return 0;
         }
         total.div_ceil(batch)
+    }
+
+    fn sample_lookup_tool() -> Tool {
+        Tool {
+            tool_type: "function".to_string(),
+            function: FunctionTool {
+                name: "lookup".to_string(),
+                description: "Look up a value".to_string(),
+                parameters: json!({
+                    "type": "object",
+                    "properties": {
+                        "q": { "type": "string" },
+                        "limit": { "type": "integer" }
+                    },
+                    "required": ["q"]
+                }),
+            },
+        }
+    }
+
+    fn sample_search_tool() -> Tool {
+        Tool {
+            tool_type: "function".to_string(),
+            function: FunctionTool {
+                name: "search".to_string(),
+                description: "Search indexed data".to_string(),
+                parameters: json!({
+                    "type": "object",
+                    "properties": {
+                        "query": { "type": "string" }
+                    },
+                    "required": ["query"]
+                }),
+            },
+        }
+    }
+
+    fn sample_structured_output_schema() -> StructuredOutputFormat {
+        StructuredOutputFormat {
+            name: "Answer".to_string(),
+            description: None,
+            schema: Some(json!({
+                "type": "object",
+                "properties": {
+                    "value": {"type": "integer"}
+                },
+                "required": ["value"]
+            })),
+            strict: Some(true),
+        }
+    }
+
+    fn parsed_arguments(call: &Value) -> Value {
+        serde_json::from_str(
+            call["function"]["arguments"]
+                .as_str()
+                .expect("arguments should be a string"),
+        )
+        .expect("arguments should be valid JSON")
     }
 
     #[test]
@@ -3214,12 +7513,1763 @@ mod tests {
     }
 
     #[test]
-    fn test_regex_escape_and_anchor_pattern() {
-        let escaped = regex_escape("a.b[c]");
-        assert_eq!(escaped, "a\\.b\\[c\\]");
-        assert_eq!(anchor_pattern("foo"), "^foo$");
-        assert_eq!(anchor_pattern("^foo$"), "^foo$");
-        assert_eq!(anchor_pattern(""), "^$");
+    fn test_chat_template_result_parses_content_and_tool_json() {
+        let content_result = ChatTemplateResult {
+            prompt: "prompt".to_string(),
+            generation_prompt: String::new(),
+            force_pure_content: false,
+            is_continuation: false,
+            add_bos: true,
+            grammar: Some(JSON_GRAMMAR.to_string()),
+            grammar_lazy: false,
+            grammar_triggers: Vec::new(),
+            preserved_tokens: Vec::new(),
+            additional_stops: Vec::new(),
+            parse_tool_calls: false,
+            tool_names: Vec::new(),
+            reasoning_format: None,
+            reasoning_start_tag: None,
+            reasoning_end_tag: None,
+        };
+        let parsed = content_result
+            .parse_response_oaicompat("prefix {\"answer\":42} suffix")
+            .expect("content response should parse");
+        let value: Value = serde_json::from_str(&parsed).expect("valid content envelope");
+        assert_eq!(value["content"], "{\"answer\":42}");
+
+        let tool_result = ChatTemplateResult {
+            prompt: "prompt".to_string(),
+            generation_prompt: String::new(),
+            force_pure_content: false,
+            is_continuation: false,
+            add_bos: true,
+            grammar: Some(JSON_GRAMMAR.to_string()),
+            grammar_lazy: false,
+            grammar_triggers: Vec::new(),
+            preserved_tokens: Vec::new(),
+            additional_stops: Vec::new(),
+            parse_tool_calls: true,
+            tool_names: Vec::new(),
+            reasoning_format: None,
+            reasoning_start_tag: None,
+            reasoning_end_tag: None,
+        };
+        let parsed = tool_result
+            .parse_response_oaicompat(r#"{"function":{"name":"lookup","arguments":{"q":"rust"}}}"#)
+            .expect("tool response should parse");
+        let value: Value = serde_json::from_str(&parsed).expect("valid tool envelope");
+        assert!(value["tool_calls"].is_array());
+        assert_eq!(value["tool_calls"][0]["id"], "call_1");
+        assert_eq!(value["tool_calls"][0]["type"], "function");
+        assert_eq!(value["tool_calls"][0]["function"]["name"], "lookup");
+        assert_eq!(
+            value["tool_calls"][0]["function"]["arguments"],
+            "{\"q\":\"rust\"}"
+        );
+
+        let parsed = tool_result
+            .parse_response_oaicompat(r#"{"content":"done"}"#)
+            .expect("content envelope should parse");
+        let value: Value = serde_json::from_str(&parsed).expect("valid content envelope");
+        assert_eq!(value["content"], "done");
+
+        let parsed = tool_result
+            .parse_response_oaicompat(r#"{"name":"Alice","score":42}"#)
+            .expect("structured content with name should not be mistaken for a tool call");
+        let value: Value =
+            serde_json::from_str(&parsed).expect("valid structured content envelope");
+        assert_eq!(value["content"], r#"{"name":"Alice","score":42}"#);
+        assert!(value.get("tool_calls").is_none());
+
+        let parsed = tool_result
+            .parse_response_oaicompat(r#"[{"name":"Alice","score":42},{"name":"Bob","score":7}]"#)
+            .expect("structured array content with name should not be mistaken for tool calls");
+        let value: Value =
+            serde_json::from_str(&parsed).expect("valid structured array content envelope");
+        assert_eq!(
+            value["content"],
+            r#"[{"name":"Alice","score":42},{"name":"Bob","score":7}]"#
+        );
+        assert!(value.get("tool_calls").is_none());
+
+        let constrained_tool_result = ChatTemplateResult {
+            tool_names: vec!["lookup".to_string()],
+            ..tool_result.clone()
+        };
+        let parsed = constrained_tool_result
+            .parse_response_oaicompat(r#"{"lookup":{"q":"rust"}}"#)
+            .expect("known function-name-key tool call should parse");
+        let value: Value = serde_json::from_str(&parsed).expect("valid known tool envelope");
+        assert_eq!(value["tool_calls"][0]["function"]["name"], "lookup");
+        assert_eq!(
+            parsed_arguments(&value["tool_calls"][0]),
+            json!({"q": "rust"})
+        );
+
+        let parsed = constrained_tool_result
+            .parse_response_oaicompat(
+                r#"{"tool_calls":[{"function":{"name":"lookup","arguments":{"q":"rust"}}}]}"#,
+            )
+            .expect("known explicit tool_calls envelope should parse");
+        let value: Value = serde_json::from_str(&parsed).expect("valid known tool envelope");
+        assert_eq!(value["tool_calls"][0]["function"]["name"], "lookup");
+        assert_eq!(
+            parsed_arguments(&value["tool_calls"][0]),
+            json!({"q": "rust"})
+        );
+
+        let parsed = constrained_tool_result
+            .parse_response_oaicompat(r#"{"profile":{"name":"Alice","score":42}}"#)
+            .expect("unknown function-name-key structured output should remain content");
+        let value: Value =
+            serde_json::from_str(&parsed).expect("valid constrained structured content envelope");
+        assert_eq!(
+            value["content"],
+            r#"{"profile":{"name":"Alice","score":42}}"#
+        );
+        assert!(value.get("tool_calls").is_none());
+
+        let parsed = constrained_tool_result
+            .parse_response_oaicompat(
+                r#"{"tool_calls":[{"function":{"name":"profile","arguments":{"name":"Alice","score":42}}}]}"#,
+            )
+            .expect("unknown explicit tool_calls structured output should remain content");
+        let value: Value =
+            serde_json::from_str(&parsed).expect("valid constrained structured content envelope");
+        assert_eq!(
+            value["content"],
+            r#"{"tool_calls":[{"function":{"name":"profile","arguments":{"name":"Alice","score":42}}}]}"#
+        );
+        assert!(value.get("tool_calls").is_none());
+    }
+
+    #[test]
+    fn test_parse_tool_response_rejects_invalid_string_arguments() {
+        let err = parse_tool_response_message(
+            r#"{"tool_calls":[{"function":{"name":"lookup","arguments":"not json"}}]}"#,
+        )
+        .expect_err("invalid JSON arguments must be rejected");
+
+        assert!(err.to_string().contains("not valid JSON"));
+    }
+
+    #[test]
+    fn test_parse_openai_tool_calls_preserves_message_content_and_reasoning() {
+        let parsed = parse_tool_response_message(
+            r#"{"content":"I will look this up.","reasoning_content":"Need current data.","tool_calls":[{"id":"call_lookup","type":"function","function":{"name":"lookup","arguments":{"q":"rust"}}}]}"#,
+        )
+        .expect("OpenAI-compatible tool calls should parse")
+        .expect("OpenAI-compatible tool calls should normalize");
+
+        assert_eq!(parsed["content"], "I will look this up.");
+        assert_eq!(parsed["reasoning_content"], "Need current data.");
+        assert_eq!(parsed["tool_calls"][0]["id"], "call_lookup");
+        assert_eq!(parsed["tool_calls"][0]["function"]["name"], "lookup");
+        assert_eq!(
+            parsed_arguments(&parsed["tool_calls"][0]),
+            json!({"q": "rust"})
+        );
+    }
+
+    #[test]
+    fn test_parse_openai_tool_calls_maps_thinking_alias_to_reasoning_content() {
+        let parsed = parse_tool_response_message(
+            r#"{"thinking":"Need current data.","tool_calls":[{"function":{"name":"lookup","arguments":{"q":"rust"}}}]}"#,
+        )
+        .expect("OpenAI-compatible thinking alias should parse")
+        .expect("OpenAI-compatible thinking alias should normalize");
+
+        assert_eq!(parsed["reasoning_content"], "Need current data.");
+        assert_eq!(parsed["tool_calls"][0]["function"]["name"], "lookup");
+    }
+
+    #[test]
+    fn test_parse_openai_single_tool_call_requires_tool_shape_for_name_field() {
+        assert!(
+            parse_tool_response_message(r#"{"name":"Alice","score":42}"#)
+                .expect("structured content should not fail")
+                .is_none()
+        );
+
+        let parsed = parse_tool_response_message(r#"{"type":"function","name":"lookup"}"#)
+            .expect("explicit zero-arg function call should parse")
+            .expect("explicit zero-arg function call should normalize");
+
+        assert_eq!(parsed["tool_calls"][0]["function"]["name"], "lookup");
+        assert_eq!(parsed_arguments(&parsed["tool_calls"][0]), json!({}));
+    }
+
+    #[test]
+    fn test_parse_openai_tool_call_array_requires_tool_shaped_elements() {
+        assert!(
+            parse_tool_response_message(r#"[{"name":"Alice","score":42}]"#)
+                .expect("structured array should not fail")
+                .is_none()
+        );
+        assert!(
+            parse_tool_response_message(
+                r#"[{"type":"function","name":"lookup"},{"name":"Alice","score":42}]"#
+            )
+            .expect("mixed structured array should not fail")
+            .is_none()
+        );
+
+        let parsed = parse_tool_response_message(
+            r#"[{"type":"function","name":"lookup"},{"lookup":{"q":"rust"}},{"tool":{"name":"search","args":{"query":"llama.cpp"}}}]"#,
+        )
+        .expect("tool-shaped array should parse")
+        .expect("tool-shaped array should normalize");
+
+        let calls = parsed["tool_calls"].as_array().expect("tool calls array");
+        assert_eq!(calls.len(), 3);
+        assert_eq!(calls[0]["function"]["name"], "lookup");
+        assert_eq!(parsed_arguments(&calls[0]), json!({}));
+        assert_eq!(calls[1]["function"]["name"], "lookup");
+        assert_eq!(parsed_arguments(&calls[1]), json!({"q": "rust"}));
+        assert_eq!(calls[2]["function"]["name"], "search");
+        assert_eq!(parsed_arguments(&calls[2]), json!({"query": "llama.cpp"}));
+    }
+
+    #[test]
+    fn test_parse_native_xml_tool_call_payload() {
+        let parsed = parse_tool_response_message(
+            r#"<tool_call>{"name":"lookup","arguments":{"q":"rust"}}</tool_call>"#,
+        )
+        .expect("native tool call should parse")
+        .expect("native tool call should normalize");
+
+        assert_eq!(parsed["tool_calls"][0]["id"], "call_1");
+        assert_eq!(parsed["tool_calls"][0]["type"], "function");
+        assert_eq!(parsed["tool_calls"][0]["function"]["name"], "lookup");
+        assert_eq!(
+            parsed["tool_calls"][0]["function"]["arguments"],
+            "{\"q\":\"rust\"}"
+        );
+    }
+
+    #[test]
+    fn test_specialized_tool_parser_respects_allowed_tool_names() {
+        let allowed_tools = vec!["lookup".to_string()];
+
+        let parsed = parse_tool_response_message_with_allowed_tools(
+            r#"<tool_call>{"name":"lookup","arguments":{"q":"rust"}}</tool_call>"#,
+            Some(&allowed_tools),
+        )
+        .expect("known native tool call should parse")
+        .expect("known native tool call should normalize");
+        assert_eq!(parsed["tool_calls"][0]["function"]["name"], "lookup");
+
+        let parsed = parse_tool_response_message_with_allowed_tools(
+            r#"<tool_call>{"name":"profile","arguments":{"name":"Alice"}}</tool_call>"#,
+            Some(&allowed_tools),
+        )
+        .expect("unknown native tool call should be rejected as a tool call");
+        assert!(parsed.is_none());
+    }
+
+    #[test]
+    fn test_parse_generic_function_tag_tool_call_payload() {
+        let parsed = parse_tool_response_message(
+            r#"before<function=lookup>{"q":"rust","limit":2}</function>"#,
+        )
+        .expect("generic function-tag tool call should parse")
+        .expect("generic function-tag tool call should normalize");
+
+        assert_eq!(parsed["content"], "before");
+        assert_eq!(parsed["tool_calls"][0]["id"], "call_1");
+        assert_eq!(parsed["tool_calls"][0]["type"], "function");
+        assert_eq!(parsed["tool_calls"][0]["function"]["name"], "lookup");
+        assert_eq!(
+            parsed_arguments(&parsed["tool_calls"][0]),
+            json!({"limit": 2, "q": "rust"})
+        );
+    }
+
+    #[test]
+    fn test_parse_generic_function_tag_tagged_arguments_payload() {
+        let parsed = parse_tool_response_message(
+            r#"before<function=lookup><parameter name="q">rust</parameter><parameter name="limit">2</parameter></function>"#,
+        )
+        .expect("generic tagged-argument tool call should parse")
+        .expect("generic tagged-argument tool call should normalize");
+
+        assert_eq!(parsed["content"], "before");
+        assert_eq!(parsed["tool_calls"][0]["function"]["name"], "lookup");
+        assert_eq!(
+            parsed_arguments(&parsed["tool_calls"][0]),
+            json!({"limit": 2, "q": "rust"})
+        );
+    }
+
+    #[test]
+    fn test_parse_native_tool_calls_tag_array_payload() {
+        let parsed = parse_tool_response_message(
+            r#"[TOOL_CALLS] [{"name":"lookup","arguments":{"q":"rust"}},{"name":"lookup","arguments":{"q":"llama","limit":2}}] [/TOOL_CALLS]"#,
+        )
+        .expect("native tool calls array should parse")
+        .expect("native tool calls array should normalize");
+
+        let calls = parsed["tool_calls"].as_array().expect("tool calls array");
+        assert_eq!(calls.len(), 2);
+        assert_eq!(calls[0]["function"]["name"], "lookup");
+        assert_eq!(parsed_arguments(&calls[0]), json!({"q": "rust"}));
+        assert_eq!(
+            parsed_arguments(&calls[1]),
+            json!({"limit": 2, "q": "llama"})
+        );
+    }
+
+    #[test]
+    fn test_parse_json_native_function_name_key_payload() {
+        let parsed = parse_tool_response_message(r#"{"lookup":{"q":"rust","limit":2}}"#)
+            .expect("function-name-key tool call should parse")
+            .expect("function-name-key tool call should normalize");
+
+        assert_eq!(parsed["tool_calls"][0]["id"], "call_1");
+        assert_eq!(parsed["tool_calls"][0]["type"], "function");
+        assert_eq!(parsed["tool_calls"][0]["function"]["name"], "lookup");
+        assert_eq!(
+            parsed_arguments(&parsed["tool_calls"][0]),
+            json!({"limit": 2, "q": "rust"})
+        );
+    }
+
+    #[test]
+    fn test_parse_json_native_function_name_key_wrapped_arguments_and_id() {
+        let parsed = parse_tool_response_message(
+            r#"{"lookup":{"id":"call_lookup_1","arguments":{"q":"rust","limit":2}}}"#,
+        )
+        .expect("function-name-key wrapped args should parse")
+        .expect("function-name-key wrapped args should normalize");
+
+        assert_eq!(parsed["tool_calls"][0]["id"], "call_lookup_1");
+        assert_eq!(parsed["tool_calls"][0]["function"]["name"], "lookup");
+        assert_eq!(
+            parsed_arguments(&parsed["tool_calls"][0]),
+            json!({"limit": 2, "q": "rust"})
+        );
+    }
+
+    #[test]
+    fn test_parse_json_native_function_name_key_array_payload() {
+        let parsed = parse_tool_response_message(
+            r#"[{"lookup":{"q":"rust"}},{"lookup":{"q":"llama","limit":2}}]"#,
+        )
+        .expect("function-name-key array should parse")
+        .expect("function-name-key array should normalize");
+
+        let calls = parsed["tool_calls"].as_array().expect("tool calls array");
+        assert_eq!(calls.len(), 2);
+        assert_eq!(calls[0]["function"]["name"], "lookup");
+        assert_eq!(parsed_arguments(&calls[0]), json!({"q": "rust"}));
+        assert_eq!(
+            parsed_arguments(&calls[1]),
+            json!({"limit": 2, "q": "llama"})
+        );
+    }
+
+    #[test]
+    fn test_parse_json_native_function_name_key_array_wrapped_arguments() {
+        let parsed = parse_tool_response_message(
+            r#"[{"lookup":{"call_id":7,"args":{"q":"rust"}}},{"lookup":{"tool_call_id":"call_2","parameters":{"q":"llama","limit":2}}}]"#,
+        )
+        .expect("function-name-key wrapped array should parse")
+        .expect("function-name-key wrapped array should normalize");
+
+        let calls = parsed["tool_calls"].as_array().expect("tool calls array");
+        assert_eq!(calls[0]["id"], "7");
+        assert_eq!(parsed_arguments(&calls[0]), json!({"q": "rust"}));
+        assert_eq!(calls[1]["id"], "call_2");
+        assert_eq!(
+            parsed_arguments(&calls[1]),
+            json!({"limit": 2, "q": "llama"})
+        );
+    }
+
+    #[test]
+    fn test_parse_json_native_flat_alias_arguments_and_numeric_id() {
+        let parsed = parse_tool_response_message(r#"{"name":"lookup","args":{"q":"rust"},"id":7}"#)
+            .expect("flat JSON-native alias tool call should parse")
+            .expect("flat JSON-native alias tool call should normalize");
+
+        assert_eq!(parsed["tool_calls"][0]["id"], "7");
+        assert_eq!(parsed["tool_calls"][0]["type"], "function");
+        assert_eq!(parsed["tool_calls"][0]["function"]["name"], "lookup");
+        assert_eq!(
+            parsed_arguments(&parsed["tool_calls"][0]),
+            json!({"q": "rust"})
+        );
+    }
+
+    #[test]
+    fn test_parse_json_native_nested_alias_arguments_and_inner_id() {
+        let parsed = parse_tool_response_message(
+            r#"{"function":{"name":"lookup","parameters":{"q":"rust"},"call_id":"inner_1"}}"#,
+        )
+        .expect("nested JSON-native alias tool call should parse")
+        .expect("nested JSON-native alias tool call should normalize");
+
+        assert_eq!(parsed["tool_calls"][0]["id"], "inner_1");
+        assert_eq!(parsed["tool_calls"][0]["type"], "function");
+        assert_eq!(parsed["tool_calls"][0]["function"]["name"], "lookup");
+        assert_eq!(
+            parsed_arguments(&parsed["tool_calls"][0]),
+            json!({"q": "rust"})
+        );
+    }
+
+    #[test]
+    fn test_parse_json_native_wrapped_nested_alias_tool_call_array() {
+        let parsed = parse_tool_response_message(
+            r#"[{"tool":{"name":"lookup","args":{"q":"rust"},"id":"nested_1"}}]"#,
+        )
+        .expect("wrapped nested JSON-native tool call should parse")
+        .expect("wrapped nested JSON-native tool call should normalize");
+
+        assert_eq!(parsed["tool_calls"][0]["id"], "nested_1");
+        assert_eq!(parsed["tool_calls"][0]["type"], "function");
+        assert_eq!(parsed["tool_calls"][0]["function"]["name"], "lookup");
+        assert_eq!(
+            parsed_arguments(&parsed["tool_calls"][0]),
+            json!({"q": "rust"})
+        );
+    }
+
+    #[test]
+    fn test_parse_ministral_tool_calls_args_payload() {
+        let parsed = parse_tool_response_message(
+            r#"[THINK]plan[/THINK]before[TOOL_CALLS]lookup[ARGS]{"q":"rust"}[TOOL_CALLS]search[ARGS]{"query":"llama.cpp","limit":2}"#,
+        )
+        .expect("ministral tool calls should parse")
+        .expect("ministral tool calls should normalize");
+
+        let calls = parsed["tool_calls"].as_array().expect("tool calls array");
+        assert_eq!(parsed["content"], "[THINK]plan[/THINK]before");
+        assert_eq!(calls.len(), 2);
+        assert_eq!(calls[0]["function"]["name"], "lookup");
+        assert_eq!(parsed_arguments(&calls[0]), json!({"q": "rust"}));
+        assert_eq!(calls[1]["function"]["name"], "search");
+        assert_eq!(
+            parsed_arguments(&calls[1]),
+            json!({"limit": 2, "query": "llama.cpp"})
+        );
+    }
+
+    #[test]
+    fn test_tool_response_parsing_extracts_reasoning_from_content_envelope() {
+        let result = ChatTemplateResult {
+            prompt: "prompt".to_string(),
+            generation_prompt: String::new(),
+            force_pure_content: false,
+            is_continuation: false,
+            add_bos: true,
+            grammar: Some(JSON_GRAMMAR.to_string()),
+            grammar_lazy: false,
+            grammar_triggers: Vec::new(),
+            preserved_tokens: Vec::new(),
+            additional_stops: Vec::new(),
+            parse_tool_calls: true,
+            tool_names: Vec::new(),
+            reasoning_format: Some(crate::config::LlamaCppReasoningFormat::Auto),
+            reasoning_start_tag: Some("[THINK]".to_string()),
+            reasoning_end_tag: Some("[/THINK]".to_string()),
+        };
+
+        let parsed = result
+            .parse_response_oaicompat(
+                r#"[THINK]plan[/THINK]before[TOOL_CALLS]lookup[ARGS]{"q":"rust"}"#,
+            )
+            .expect("tool response should parse");
+        let value: Value = serde_json::from_str(&parsed).expect("valid tool envelope");
+
+        assert_eq!(value["reasoning_content"], "plan");
+        assert_eq!(value["content"], "before");
+        assert_eq!(value["tool_calls"][0]["function"]["name"], "lookup");
+    }
+
+    #[test]
+    fn test_parse_gpt_oss_tool_call_with_recipient_in_role_header() {
+        let parsed = parse_tool_response_message(
+            r#"<|start|>assistant to=functions.lookup<|channel|>commentary<|message|>{"q":"rust","limit":2}<|end|>"#,
+        )
+        .expect("gpt-oss role-recipient tool call should parse")
+        .expect("gpt-oss role-recipient tool call should normalize");
+
+        assert_eq!(parsed["tool_calls"][0]["id"], "call_1");
+        assert_eq!(parsed["tool_calls"][0]["type"], "function");
+        assert_eq!(parsed["tool_calls"][0]["function"]["name"], "lookup");
+        assert_eq!(
+            parsed_arguments(&parsed["tool_calls"][0]),
+            json!({"limit": 2, "q": "rust"})
+        );
+    }
+
+    #[test]
+    fn test_parse_gpt_oss_tool_call_with_recipient_in_channel_header() {
+        let parsed = parse_tool_response_message(
+            r#"<|start|>assistant<|channel|>analysis to=functions.search <|constrain|> json<|message|>{"query":"llama.cpp"}<|end|>"#,
+        )
+        .expect("gpt-oss channel-recipient tool call should parse")
+        .expect("gpt-oss channel-recipient tool call should normalize");
+
+        assert_eq!(parsed["tool_calls"][0]["function"]["name"], "search");
+        assert_eq!(
+            parsed["tool_calls"][0]["function"]["arguments"],
+            "{\"query\":\"llama.cpp\"}"
+        );
+    }
+
+    #[test]
+    fn test_parse_gpt_oss_tool_call_preserves_prior_commentary_content() {
+        let parsed = parse_tool_response_message(
+            r#"<|start|>assistant<|channel|>commentary<|message|>I will search.<|end|><|start|>assistant<|channel|>commentary to=functions.search <|constrain|> json<|message|>{"query":"llama.cpp"}<|end|>"#,
+        )
+        .expect("gpt-oss content before tool call should parse")
+        .expect("gpt-oss content before tool call should normalize");
+
+        assert_eq!(parsed["content"], "I will search.");
+        assert_eq!(parsed["tool_calls"][0]["function"]["name"], "search");
+        assert_eq!(
+            parsed_arguments(&parsed["tool_calls"][0]),
+            json!({"query": "llama.cpp"})
+        );
+    }
+
+    #[test]
+    fn test_parse_gpt_oss_tool_call_preserves_prior_final_content() {
+        let parsed = parse_tool_response_message(
+            r#"<|start|>assistant<|channel|>analysis<|message|>Need a lookup.<|end|><|start|>assistant<|channel|>final<|message|>I can answer after checking.<|end|><|start|>assistant to=functions.lookup<|channel|>commentary<|message|>{"q":"rust"}<|end|>"#,
+        )
+        .expect("gpt-oss final content before tool call should parse")
+        .expect("gpt-oss final content before tool call should normalize");
+
+        assert_eq!(parsed["content"], "I can answer after checking.");
+        assert_eq!(parsed["reasoning_content"], "Need a lookup.");
+        assert_eq!(parsed["tool_calls"][0]["function"]["name"], "lookup");
+        assert_eq!(
+            parsed_arguments(&parsed["tool_calls"][0]),
+            json!({"q": "rust"})
+        );
+    }
+
+    #[test]
+    fn test_parse_gpt_oss_tool_call_preserves_prior_analysis_reasoning() {
+        let parsed = parse_tool_response_message(
+            r#"<|start|>assistant<|channel|>analysis<|message|>Need a lookup.<|end|><|start|>assistant to=functions.lookup<|channel|>commentary<|message|>{"q":"rust"}<|end|>"#,
+        )
+        .expect("gpt-oss reasoning before tool call should parse")
+        .expect("gpt-oss reasoning before tool call should normalize");
+
+        assert_eq!(parsed["reasoning_content"], "Need a lookup.");
+        assert_eq!(parsed["tool_calls"][0]["function"]["name"], "lookup");
+        assert_eq!(
+            parsed_arguments(&parsed["tool_calls"][0]),
+            json!({"q": "rust"})
+        );
+    }
+
+    #[test]
+    fn test_parse_gpt_oss_tool_call_ignores_stray_commentary_prefix() {
+        let parsed = parse_tool_response_message(
+            r#"<|start|>assistant<|channel|>commentary to=assistant<|channel|>analysis<|message|>Need a lookup.<|end|><|start|>assistant to=functions.lookup<|channel|>commentary<|message|>{"q":"rust"}<|end|>"#,
+        )
+        .expect("gpt-oss stray commentary before reasoning should parse")
+        .expect("gpt-oss stray commentary before reasoning should normalize");
+
+        assert_eq!(parsed["reasoning_content"], "Need a lookup.");
+        assert_eq!(parsed["tool_calls"][0]["function"]["name"], "lookup");
+        assert_eq!(
+            parsed_arguments(&parsed["tool_calls"][0]),
+            json!({"q": "rust"})
+        );
+    }
+
+    #[test]
+    fn test_parse_gemma4_native_tool_call() {
+        let parsed = parse_tool_response_message(
+            "answer<|tool_call>call:lookup{q:<|\"|>rust<|\"|>,limit:2}<tool_call|>",
+        )
+        .expect("gemma4 tool call should parse")
+        .expect("gemma4 tool call should normalize");
+
+        assert_eq!(parsed["content"], "answer");
+        assert_eq!(parsed["tool_calls"][0]["function"]["name"], "lookup");
+        assert_eq!(
+            parsed_arguments(&parsed["tool_calls"][0]),
+            json!({"limit": 2, "q": "rust"})
+        );
+    }
+
+    #[test]
+    fn test_parse_gemma4_prefixed_native_tool_call() {
+        let parsed = parse_tool_response_message(
+            "<|turn>model\nanswer<|tool_call>call:lookup{q:<|\"|>rust<|\"|>}<tool_call|>",
+        )
+        .expect("prefixed gemma4 tool call should parse")
+        .expect("prefixed gemma4 tool call should normalize");
+
+        assert_eq!(parsed["content"], "answer");
+        assert_eq!(parsed["tool_calls"][0]["function"]["name"], "lookup");
+        assert_eq!(
+            parsed_arguments(&parsed["tool_calls"][0]),
+            json!({"q": "rust"})
+        );
+    }
+
+    #[test]
+    fn test_parse_functionary_v3_2_tool_call() {
+        let parsed = parse_tool_response_message(
+            r#">>>all
+I will call a function.
+>>>lookup
+{"q":"rust"}"#,
+        )
+        .expect("functionary tool call should parse")
+        .expect("functionary tool call should normalize");
+
+        assert_eq!(parsed["content"], "I will call a function.");
+        assert_eq!(parsed["tool_calls"][0]["function"]["name"], "lookup");
+        assert_eq!(
+            parsed["tool_calls"][0]["function"]["arguments"],
+            "{\"q\":\"rust\"}"
+        );
+    }
+
+    #[test]
+    fn test_parse_functionary_v3_2_content_only() {
+        let parsed = parse_tool_response_message(
+            r#">>>all
+No tools are needed."#,
+        )
+        .expect("functionary content should parse")
+        .expect("functionary content should normalize");
+
+        assert_eq!(parsed["content"], "No tools are needed.");
+        assert!(parsed.get("tool_calls").is_none());
+    }
+
+    #[test]
+    fn test_parse_functionary_v3_2_post_generation_content_only() {
+        let parsed = parse_tool_response_message(
+            r#"all
+No tools are needed."#,
+        )
+        .expect("post-generation functionary content should parse")
+        .expect("post-generation functionary content should normalize");
+
+        assert_eq!(parsed["content"], "No tools are needed.");
+        assert!(parsed.get("tool_calls").is_none());
+    }
+
+    #[test]
+    fn test_parse_functionary_v3_2_post_generation_tool_call() {
+        let parsed = parse_tool_response_message(
+            r#"lookup
+{"q":"rust"}"#,
+        )
+        .expect("post-generation functionary tool call should parse")
+        .expect("post-generation functionary tool call should normalize");
+
+        assert_eq!(parsed["tool_calls"][0]["function"]["name"], "lookup");
+        assert_eq!(
+            parsed["tool_calls"][0]["function"]["arguments"],
+            "{\"q\":\"rust\"}"
+        );
+    }
+
+    #[test]
+    fn test_parse_kimi_k2_tool_call_preserves_id() {
+        let parsed = parse_tool_response_message(
+            r#"<think>plan</think>answer<|tool_calls_section_begin|><|tool_call_begin|>functions.lookup:3<|tool_call_argument_begin|>{"q":"rust"}<|tool_call_end|><|tool_calls_section_end|>"#,
+        )
+        .expect("kimi tool call should parse")
+        .expect("kimi tool call should normalize");
+
+        assert_eq!(parsed["content"], "<think>plan</think>answer");
+        assert_eq!(parsed["tool_calls"][0]["id"], "functions.lookup:3");
+        assert_eq!(parsed["tool_calls"][0]["function"]["name"], "lookup");
+        assert_eq!(
+            parsed["tool_calls"][0]["function"]["arguments"],
+            "{\"q\":\"rust\"}"
+        );
+    }
+
+    #[test]
+    fn test_parse_kimi_k2_prefixed_tool_call_preserves_id() {
+        let parsed = parse_tool_response_message(
+            r#"<|im_assistant|>assistant<|im_middle|><think>plan</think>answer<|tool_calls_section_begin|><|tool_call_begin|>functions.lookup:3<|tool_call_argument_begin|>{"q":"rust"}<|tool_call_end|><|tool_calls_section_end|>"#,
+        )
+        .expect("prefixed kimi tool call should parse")
+        .expect("prefixed kimi tool call should normalize");
+
+        assert_eq!(parsed["content"], "<think>plan</think>answer");
+        assert_eq!(parsed["tool_calls"][0]["id"], "functions.lookup:3");
+        assert_eq!(parsed["tool_calls"][0]["function"]["name"], "lookup");
+    }
+
+    #[test]
+    fn test_parse_lfm2_python_style_tool_calls() {
+        let parsed = parse_tool_response_message(
+            r#"<think>plan</think>content<|tool_call_start|>[lookup(q='rust', limit=2, exact=True), search(query="llama,cpp", filters={"kind":"repo"})]<|tool_call_end|>"#,
+        )
+        .expect("lfm2 tool calls should parse")
+        .expect("lfm2 tool calls should normalize");
+
+        let calls = parsed["tool_calls"].as_array().expect("tool calls array");
+        assert_eq!(parsed["content"], "<think>plan</think>content");
+        assert_eq!(calls.len(), 2);
+        assert_eq!(calls[0]["function"]["name"], "lookup");
+        assert_eq!(
+            parsed_arguments(&calls[0]),
+            json!({"exact": true, "limit": 2, "q": "rust"})
+        );
+        assert_eq!(calls[1]["function"]["name"], "search");
+        assert_eq!(
+            parsed_arguments(&calls[1]),
+            json!({"filters": {"kind": "repo"}, "query": "llama,cpp"})
+        );
+    }
+
+    #[test]
+    fn test_parse_lfm2_nested_python_literals() {
+        let parsed = parse_tool_response_message(
+            r#"<|tool_call_start|>[lookup(filters={'kind': 'repo', 'flags': [True, False, None,],}, q='rust')]<|tool_call_end|>"#,
+        )
+        .expect("lfm2 nested Python literals should parse")
+        .expect("lfm2 nested Python literals should normalize");
+
+        assert_eq!(parsed["tool_calls"][0]["function"]["name"], "lookup");
+        assert_eq!(
+            parsed_arguments(&parsed["tool_calls"][0]),
+            json!({
+                "filters": {
+                    "flags": [true, false, null],
+                    "kind": "repo"
+                },
+                "q": "rust"
+            })
+        );
+    }
+
+    #[test]
+    fn test_parse_lfm2_prefixed_python_style_tool_calls() {
+        let parsed = parse_tool_response_message(
+            r#"<|im_start|>assistant
+<think>plan</think>content<|tool_call_start|>[lookup(q='rust')]<|tool_call_end|>"#,
+        )
+        .expect("prefixed lfm2 tool calls should parse")
+        .expect("prefixed lfm2 tool calls should normalize");
+
+        assert_eq!(parsed["content"], "<think>plan</think>content");
+        assert_eq!(parsed["tool_calls"][0]["function"]["name"], "lookup");
+        assert_eq!(
+            parsed_arguments(&parsed["tool_calls"][0]),
+            json!({"q": "rust"})
+        );
+    }
+
+    #[test]
+    fn test_parse_gigachat_v3_tool_call() {
+        let parsed = parse_tool_response_message(
+            "content<|message_sep|>\n\nfunction call<|role_sep|>\n{\"name\":\"lookup\",\"arguments\":{\"q\":\"rust\"}}<|message_sep|>\n\n",
+        )
+        .expect("gigachat tool call should parse")
+        .expect("gigachat tool call should normalize");
+
+        assert_eq!(parsed["content"], "content");
+        assert_eq!(parsed["tool_calls"][0]["function"]["name"], "lookup");
+        assert_eq!(
+            parsed["tool_calls"][0]["function"]["arguments"],
+            "{\"q\":\"rust\"}"
+        );
+    }
+
+    #[test]
+    fn test_parse_gigachat_v3_prefixed_content_only() {
+        let parsed =
+            parse_tool_response_message("assistant<|role_sep|>\nplain answer<|message_sep|>\n\n")
+                .expect("gigachat prefixed content should parse")
+                .expect("gigachat prefixed content should normalize");
+
+        assert_eq!(parsed["content"], "plain answer");
+        assert!(parsed.get("tool_calls").is_none());
+    }
+
+    #[test]
+    fn test_parse_gigachat_v3_prefixed_tool_call() {
+        let parsed = parse_tool_response_message(
+            "assistant<|role_sep|>\ncontent<|message_sep|>\n\nfunction call<|role_sep|>\n{\"name\":\"lookup\",\"arguments\":{\"q\":\"rust\"}}<|message_sep|>\n\n",
+        )
+        .expect("gigachat prefixed tool call should parse")
+        .expect("gigachat prefixed tool call should normalize");
+
+        assert_eq!(parsed["content"], "content");
+        assert_eq!(parsed["tool_calls"][0]["function"]["name"], "lookup");
+        assert_eq!(
+            parsed["tool_calls"][0]["function"]["arguments"],
+            "{\"q\":\"rust\"}"
+        );
+    }
+
+    #[test]
+    fn test_parse_deepseek_v3_2_dsml_tool_call() {
+        let parsed = parse_tool_response_message(
+            r#"<think>plan</think>content<｜DSML｜function_calls>
+<｜DSML｜invoke name="lookup">
+<｜DSML｜parameter name="q" string="true">rust</｜DSML｜parameter>
+<｜DSML｜parameter name="limit" string="false">2</｜DSML｜parameter>
+</｜DSML｜invoke>
+</｜DSML｜function_calls>"#,
+        )
+        .expect("deepseek dsml tool call should parse")
+        .expect("deepseek dsml tool call should normalize");
+
+        assert_eq!(parsed["content"], "<think>plan</think>content");
+        assert_eq!(parsed["tool_calls"][0]["function"]["name"], "lookup");
+        assert_eq!(
+            parsed_arguments(&parsed["tool_calls"][0]),
+            json!({"limit": 2, "q": "rust"})
+        );
+    }
+
+    #[test]
+    fn test_parse_deepseek_v3_2_prefixed_dsml_tool_call() {
+        let parsed = parse_tool_response_message(
+            r#"<｜Assistant｜><think>plan</think>content<｜DSML｜function_calls>
+<｜DSML｜invoke name="lookup">
+<｜DSML｜parameter name="q" string="true">rust</｜DSML｜parameter>
+</｜DSML｜invoke>
+</｜DSML｜function_calls>"#,
+        )
+        .expect("prefixed deepseek dsml tool call should parse")
+        .expect("prefixed deepseek dsml tool call should normalize");
+
+        assert_eq!(parsed["content"], "<think>plan</think>content");
+        assert_eq!(parsed["tool_calls"][0]["function"]["name"], "lookup");
+        assert_eq!(
+            parsed_arguments(&parsed["tool_calls"][0]),
+            json!({"q": "rust"})
+        );
+    }
+
+    #[test]
+    fn test_specialized_tool_responses_normalize_to_openai_compat_goldens() {
+        struct GoldenCase {
+            name: &'static str,
+            input: &'static str,
+            reasoning_start: Option<&'static str>,
+            reasoning_end: Option<&'static str>,
+            expected_content: Option<&'static str>,
+            expected_reasoning: Option<&'static str>,
+            expected_tool: &'static str,
+            expected_arguments: Value,
+        }
+
+        let cases = vec![
+            GoldenCase {
+                name: "gpt-oss native channels",
+                input: r#"<|start|>assistant<|channel|>analysis<|message|>Need lookup.<|end|><|start|>assistant<|channel|>commentary<|message|>I will search.<|end|><|start|>assistant to=functions.lookup<|channel|>commentary<|message|>{"q":"rust"}<|end|>"#,
+                reasoning_start: None,
+                reasoning_end: None,
+                expected_content: Some("I will search."),
+                expected_reasoning: Some("Need lookup."),
+                expected_tool: "lookup",
+                expected_arguments: json!({"q": "rust"}),
+            },
+            GoldenCase {
+                name: "ministral args tags",
+                input: r#"[THINK]plan[/THINK]content[TOOL_CALLS]lookup[ARGS]{"q":"rust"}"#,
+                reasoning_start: Some("[THINK]"),
+                reasoning_end: Some("[/THINK]"),
+                expected_content: Some("content"),
+                expected_reasoning: Some("plan"),
+                expected_tool: "lookup",
+                expected_arguments: json!({"q": "rust"}),
+            },
+            GoldenCase {
+                name: "gemma4 native tool",
+                input: "<|channel>thought\nplan<channel|>content<|tool_call>call:lookup{q:<|\"|>rust<|\"|>}<tool_call|>",
+                reasoning_start: Some("<|channel>thought"),
+                reasoning_end: Some("<channel|>"),
+                expected_content: Some("content"),
+                expected_reasoning: Some("plan"),
+                expected_tool: "lookup",
+                expected_arguments: json!({"q": "rust"}),
+            },
+            GoldenCase {
+                name: "functionary v3.2",
+                input: r#">>>all
+content
+>>>lookup
+{"q":"rust"}"#,
+                reasoning_start: None,
+                reasoning_end: None,
+                expected_content: Some("content"),
+                expected_reasoning: None,
+                expected_tool: "lookup",
+                expected_arguments: json!({"q": "rust"}),
+            },
+            GoldenCase {
+                name: "kimi k2",
+                input: r#"<think>plan</think>content<|tool_calls_section_begin|><|tool_call_begin|>functions.lookup:3<|tool_call_argument_begin|>{"q":"rust"}<|tool_call_end|><|tool_calls_section_end|>"#,
+                reasoning_start: Some("<think>"),
+                reasoning_end: Some("</think>"),
+                expected_content: Some("content"),
+                expected_reasoning: Some("plan"),
+                expected_tool: "lookup",
+                expected_arguments: json!({"q": "rust"}),
+            },
+            GoldenCase {
+                name: "lfm2 python style",
+                input: r#"<think>plan</think>content<|tool_call_start|>[lookup(q='rust')]<|tool_call_end|>"#,
+                reasoning_start: Some("<think>"),
+                reasoning_end: Some("</think>"),
+                expected_content: Some("content"),
+                expected_reasoning: Some("plan"),
+                expected_tool: "lookup",
+                expected_arguments: json!({"q": "rust"}),
+            },
+            GoldenCase {
+                name: "gigachat v3",
+                input: "content<|message_sep|>\n\nfunction call<|role_sep|>\n{\"name\":\"lookup\",\"arguments\":{\"q\":\"rust\"}}<|message_sep|>\n\n",
+                reasoning_start: None,
+                reasoning_end: None,
+                expected_content: Some("content"),
+                expected_reasoning: None,
+                expected_tool: "lookup",
+                expected_arguments: json!({"q": "rust"}),
+            },
+            GoldenCase {
+                name: "deepseek v3.2 dsml",
+                input: r#"<think>plan</think>content<｜DSML｜function_calls>
+<｜DSML｜invoke name="lookup">
+<｜DSML｜parameter name="q" string="true">rust</｜DSML｜parameter>
+</｜DSML｜invoke>
+</｜DSML｜function_calls>"#,
+                reasoning_start: Some("<think>"),
+                reasoning_end: Some("</think>"),
+                expected_content: Some("content"),
+                expected_reasoning: Some("plan"),
+                expected_tool: "lookup",
+                expected_arguments: json!({"q": "rust"}),
+            },
+            GoldenCase {
+                name: "generic function tag",
+                input: r#"<think>plan</think>content<function=lookup><parameter name="q">"rust"</parameter></function>"#,
+                reasoning_start: Some("<think>"),
+                reasoning_end: Some("</think>"),
+                expected_content: Some("content"),
+                expected_reasoning: Some("plan"),
+                expected_tool: "lookup",
+                expected_arguments: json!({"q": "rust"}),
+            },
+        ];
+
+        for case in cases {
+            let result = ChatTemplateResult {
+                prompt: "prompt".to_string(),
+                generation_prompt: String::new(),
+                force_pure_content: false,
+                is_continuation: false,
+                add_bos: true,
+                grammar: Some(JSON_GRAMMAR.to_string()),
+                grammar_lazy: false,
+                grammar_triggers: Vec::new(),
+                preserved_tokens: Vec::new(),
+                additional_stops: Vec::new(),
+                parse_tool_calls: true,
+                tool_names: Vec::new(),
+                reasoning_format: case
+                    .reasoning_start
+                    .map(|_| crate::config::LlamaCppReasoningFormat::Auto),
+                reasoning_start_tag: case.reasoning_start.map(str::to_string),
+                reasoning_end_tag: case.reasoning_end.map(str::to_string),
+            };
+
+            let parsed = result
+                .parse_response_oaicompat(case.input)
+                .unwrap_or_else(|err| panic!("{} should parse: {err}", case.name));
+            let message: Value = serde_json::from_str(&parsed)
+                .unwrap_or_else(|err| panic!("{} should emit valid JSON: {err}", case.name));
+
+            match case.expected_content {
+                Some(content) => assert_eq!(message["content"], content, "{}", case.name),
+                None => assert!(
+                    message.get("content").is_none(),
+                    "{} should not emit content",
+                    case.name
+                ),
+            }
+            match case.expected_reasoning {
+                Some(reasoning) => {
+                    assert_eq!(message["reasoning_content"], reasoning, "{}", case.name)
+                }
+                None => assert!(
+                    message.get("reasoning_content").is_none(),
+                    "{} should not emit reasoning",
+                    case.name
+                ),
+            }
+
+            let calls = message["tool_calls"]
+                .as_array()
+                .unwrap_or_else(|| panic!("{} should emit tool_calls", case.name));
+            assert_eq!(calls.len(), 1, "{}", case.name);
+            assert_eq!(
+                calls[0]["function"]["name"], case.expected_tool,
+                "{}",
+                case.name
+            );
+            assert_eq!(
+                parsed_arguments(&calls[0]),
+                case.expected_arguments,
+                "{}",
+                case.name
+            );
+        }
+    }
+
+    #[test]
+    fn test_gpt_oss_partial_streaming_diffs_reasoning_content_and_tool_call() {
+        let result = ChatTemplateResult {
+            prompt: "prompt".to_string(),
+            generation_prompt: String::new(),
+            force_pure_content: false,
+            is_continuation: false,
+            add_bos: true,
+            grammar: Some(JSON_GRAMMAR.to_string()),
+            grammar_lazy: false,
+            grammar_triggers: Vec::new(),
+            preserved_tokens: Vec::new(),
+            additional_stops: Vec::new(),
+            parse_tool_calls: true,
+            tool_names: Vec::new(),
+            reasoning_format: None,
+            reasoning_start_tag: None,
+            reasoning_end_tag: None,
+        };
+
+        let generated_parts = [
+            "<|start|>assistant<|channel|>analysis<|message|>Need",
+            "<|start|>assistant<|channel|>analysis<|message|>Need lookup",
+            "<|start|>assistant<|channel|>analysis<|message|>Need lookup<|end|><|start|>assistant<|channel|>commentary<|message|>I will search.",
+            r#"<|start|>assistant<|channel|>analysis<|message|>Need lookup<|end|><|start|>assistant<|channel|>commentary<|message|>I will search.<|end|><|start|>assistant to=functions.lookup<|channel|>commentary<|message|>{"q":"rust"}<|end|>"#,
+        ];
+
+        let mut stream_state = StreamMappingState::default();
+        let mut outputs = Vec::new();
+        for generated in generated_parts {
+            let message_json = result
+                .parse_partial_response_oaicompat(generated)
+                .expect("partial GPT-OSS response should parse")
+                .expect("partial GPT-OSS response should emit a parser message");
+            let delta_json = stream_delta_from_message_json(&message_json)
+                .expect("parser message should convert to stream delta");
+            outputs.extend(map_tool_stream_event(
+                Ok(StreamEvent::Delta(delta_json)),
+                &mut stream_state,
+            ));
+        }
+        outputs.extend(map_tool_stream_event(
+            Ok(StreamEvent::Done {
+                stop_reason: "tool_use".to_string(),
+            }),
+            &mut stream_state,
+        ));
+
+        assert!(matches!(
+            &outputs[0],
+            Ok(StreamChunk::ReasoningContent(text)) if text == "Need"
+        ));
+        assert!(matches!(
+            &outputs[1],
+            Ok(StreamChunk::ReasoningContent(text)) if text == " lookup"
+        ));
+        assert!(matches!(
+            &outputs[2],
+            Ok(StreamChunk::Text(text)) if text == "I will search."
+        ));
+        assert!(matches!(
+            &outputs[3],
+            Ok(StreamChunk::ToolUseStart { index, name, .. }) if *index == 0 && name == "lookup"
+        ));
+        assert!(matches!(
+            &outputs[4],
+            Ok(StreamChunk::ToolUseInputDelta { index, partial_json }) if *index == 0 && partial_json == "{\"q\":\"rust\"}"
+        ));
+        assert!(matches!(
+            &outputs[5],
+            Ok(StreamChunk::ToolUseComplete { index, tool_call }) if *index == 0
+                && tool_call.function.name == "lookup"
+                && tool_call.function.arguments == "{\"q\":\"rust\"}"
+        ));
+        assert!(matches!(
+            &outputs[6],
+            Ok(StreamChunk::Done { stop_reason }) if stop_reason == "tool_use"
+        ));
+        assert_eq!(
+            outputs.len(),
+            7,
+            "stream mapping must not duplicate cumulative reasoning/content/tool arguments"
+        );
+    }
+
+    #[test]
+    fn test_chat_template_result_parses_gpt_oss_final_and_reasoning_channels() {
+        let result = ChatTemplateResult {
+            prompt: "prompt".to_string(),
+            generation_prompt: String::new(),
+            force_pure_content: false,
+            is_continuation: false,
+            add_bos: true,
+            grammar: None,
+            grammar_lazy: false,
+            grammar_triggers: Vec::new(),
+            preserved_tokens: Vec::new(),
+            additional_stops: Vec::new(),
+            parse_tool_calls: true,
+            tool_names: Vec::new(),
+            reasoning_format: None,
+            reasoning_start_tag: None,
+            reasoning_end_tag: None,
+        };
+
+        let parsed = result
+            .parse_response_oaicompat(
+                "<|start|>assistant<|channel|>analysis<|message|>working<|end|><|start|>assistant<|channel|>final<|message|>done",
+            )
+            .expect("native channel content should parse");
+        let value: Value = serde_json::from_str(&parsed).expect("valid content envelope");
+        assert_eq!(value["content"], "done");
+        assert_eq!(value["reasoning_content"], "working");
+
+        let partial_reasoning = result
+            .parse_partial_response_oaicompat(
+                "<|start|>assistant<|channel|>analysis<|message|>working",
+            )
+            .expect("partial native channel reasoning should parse")
+            .expect("reasoning-only delta should be available");
+        let value: Value =
+            serde_json::from_str(&partial_reasoning).expect("valid partial content envelope");
+        assert_eq!(value["content"], "");
+        assert_eq!(value["reasoning_content"], "working");
+
+        let partial_final = result
+            .parse_partial_response_oaicompat(
+                "<|start|>assistant<|channel|>analysis<|message|>working<|end|><|start|>assistant<|channel|>final<|message|>do",
+            )
+            .expect("partial final native channel content should parse")
+            .expect("final delta should be available");
+        let value: Value =
+            serde_json::from_str(&partial_final).expect("valid partial content envelope");
+        assert_eq!(value["content"], "do");
+        assert_eq!(value["reasoning_content"], "working");
+
+        let stray_final = result
+            .parse_response_oaicompat(
+                "<|start|>assistant<|channel|>commentary to=assistant<|channel|>final<|message|>done",
+            )
+            .expect("stray commentary before final should parse");
+        let value: Value =
+            serde_json::from_str(&stray_final).expect("valid stray final content envelope");
+        assert_eq!(value["content"], "done");
+        assert!(value.get("reasoning_content").is_none());
+
+        let stray_reasoning = result
+            .parse_response_oaicompat(
+                "<|start|>assistant<|channel|>commentary<|channel|>analysis<|message|>working<|end|><|start|>assistant<|channel|>commentary to=assistant<|channel|>final<|message|>done",
+            )
+            .expect("stray commentary before analysis and final should parse");
+        let value: Value =
+            serde_json::from_str(&stray_reasoning).expect("valid stray reasoning envelope");
+        assert_eq!(value["content"], "done");
+        assert_eq!(value["reasoning_content"], "working");
+    }
+
+    #[test]
+    fn test_force_pure_content_parser_keeps_native_markers_as_content() {
+        let result = ChatTemplateResult {
+            prompt: "prompt".to_string(),
+            generation_prompt: "<|start|>assistant<|channel|>final<|message|>".to_string(),
+            force_pure_content: true,
+            is_continuation: false,
+            add_bos: true,
+            grammar: None,
+            grammar_lazy: false,
+            grammar_triggers: Vec::new(),
+            preserved_tokens: Vec::new(),
+            additional_stops: Vec::new(),
+            parse_tool_calls: false,
+            tool_names: Vec::new(),
+            reasoning_format: Some(crate::config::LlamaCppReasoningFormat::Auto),
+            reasoning_start_tag: Some("<think>".to_string()),
+            reasoning_end_tag: Some("</think>".to_string()),
+        };
+        let text = r#"<think>plan</think><|start|>assistant<|channel|>analysis<|message|>working<|end|><|start|>assistant<|channel|>final<|message|>done<tool_call>{"name":"lookup","arguments":{"q":"rust"}}</tool_call>"#;
+
+        let parsed = result
+            .parse_response_oaicompat(text)
+            .expect("pure content response should parse as plain content");
+        let value: Value = serde_json::from_str(&parsed).expect("valid content envelope");
+
+        assert_eq!(value["content"], text);
+        assert!(value.get("reasoning_content").is_none());
+        assert!(value.get("tool_calls").is_none());
+    }
+
+    #[test]
+    fn test_continuation_parser_strips_echoed_generation_prompt() {
+        let result = ChatTemplateResult {
+            prompt: "user:hi\nassistant:partial".to_string(),
+            generation_prompt: "assistant:partial".to_string(),
+            force_pure_content: false,
+            is_continuation: true,
+            add_bos: true,
+            grammar: None,
+            grammar_lazy: false,
+            grammar_triggers: Vec::new(),
+            preserved_tokens: Vec::new(),
+            additional_stops: Vec::new(),
+            parse_tool_calls: false,
+            tool_names: Vec::new(),
+            reasoning_format: None,
+            reasoning_start_tag: None,
+            reasoning_end_tag: None,
+        };
+
+        let parsed = result
+            .parse_response_oaicompat("assistant:partial completion")
+            .expect("continuation response should parse");
+        let value: Value = serde_json::from_str(&parsed).expect("valid message json");
+
+        assert_eq!(value["content"], " completion");
+    }
+
+    #[test]
+    fn test_partial_response_parsing_waits_for_complete_structured_json() {
+        let result = ChatTemplateResult {
+            prompt: "prompt".to_string(),
+            generation_prompt: String::new(),
+            force_pure_content: false,
+            is_continuation: false,
+            add_bos: true,
+            grammar: Some(JSON_GRAMMAR.to_string()),
+            grammar_lazy: false,
+            grammar_triggers: Vec::new(),
+            preserved_tokens: Vec::new(),
+            additional_stops: Vec::new(),
+            parse_tool_calls: false,
+            tool_names: Vec::new(),
+            reasoning_format: None,
+            reasoning_start_tag: None,
+            reasoning_end_tag: None,
+        };
+
+        assert!(
+            result
+                .parse_partial_response_oaicompat("{\"answer\":")
+                .expect("incomplete json should not fail")
+                .is_none()
+        );
+
+        let parsed = result
+            .parse_partial_response_oaicompat("{\"answer\":42}")
+            .expect("complete json should parse")
+            .expect("complete json should emit a parsed message");
+        let value: Value = serde_json::from_str(&parsed).expect("valid content envelope");
+        assert_eq!(value["content"], "{\"answer\":42}");
+    }
+
+    #[test]
+    fn test_structured_response_parsing_preserves_reasoning_before_json() {
+        let result = ChatTemplateResult {
+            prompt: "prompt".to_string(),
+            generation_prompt: String::new(),
+            force_pure_content: false,
+            is_continuation: false,
+            add_bos: true,
+            grammar: Some(JSON_GRAMMAR.to_string()),
+            grammar_lazy: false,
+            grammar_triggers: Vec::new(),
+            preserved_tokens: Vec::new(),
+            additional_stops: Vec::new(),
+            parse_tool_calls: false,
+            tool_names: Vec::new(),
+            reasoning_format: Some(crate::config::LlamaCppReasoningFormat::Auto),
+            reasoning_start_tag: Some("<think>".to_string()),
+            reasoning_end_tag: Some("</think>".to_string()),
+        };
+
+        let parsed = result
+            .parse_response_oaicompat("<think>plan</think>{\"answer\":42}")
+            .expect("structured response with reasoning should parse");
+        let value: Value = serde_json::from_str(&parsed).expect("valid content envelope");
+        assert_eq!(value["content"], "{\"answer\":42}");
+        assert_eq!(value["reasoning_content"], "plan");
+
+        let partial = result
+            .parse_partial_response_oaicompat("<think>plan</think>{\"answer\":42}")
+            .expect("partial structured response with reasoning should parse")
+            .expect("complete structured response should emit a parsed message");
+        let value: Value = serde_json::from_str(&partial).expect("valid partial content envelope");
+        assert_eq!(value["content"], "{\"answer\":42}");
+        assert_eq!(value["reasoning_content"], "plan");
+
+        let partial = result
+            .parse_partial_response_oaicompat("<think>plan")
+            .expect("open reasoning response should parse")
+            .expect("open reasoning should emit a partial message");
+        let value: Value = serde_json::from_str(&partial).expect("valid open reasoning envelope");
+        assert_eq!(value["content"], "");
+        assert_eq!(value["reasoning_content"], "plan");
+
+        let final_open = result
+            .parse_response_oaicompat("<think>plan")
+            .expect("final open reasoning response should parse");
+        let value: Value =
+            serde_json::from_str(&final_open).expect("valid final open reasoning envelope");
+        assert_eq!(value["content"], "");
+        assert_eq!(value["reasoning_content"], "plan");
+
+        let prefilled_result = ChatTemplateResult {
+            generation_prompt: "<|im_start|>assistant\n<think>\n".to_string(),
+            ..result.clone()
+        };
+
+        let partial = prefilled_result
+            .parse_partial_response_oaicompat("plan")
+            .expect("prefilled open reasoning response should parse")
+            .expect("prefilled open reasoning should emit a partial message");
+        let value: Value =
+            serde_json::from_str(&partial).expect("valid prefilled reasoning envelope");
+        assert_eq!(value["content"], "");
+        assert_eq!(value["reasoning_content"], "plan");
+
+        let partial = prefilled_result
+            .parse_partial_response_oaicompat("plan</think>{\"answer\":42}")
+            .expect("prefilled reasoning before JSON should parse")
+            .expect("prefilled reasoning plus JSON should emit a partial message");
+        let value: Value = serde_json::from_str(&partial).expect("valid prefilled JSON envelope");
+        assert_eq!(value["content"], "{\"answer\":42}");
+        assert_eq!(value["reasoning_content"], "plan");
+
+        let parsed = prefilled_result
+            .parse_response_oaicompat("plan</think>{\"answer\":42}")
+            .expect("final prefilled reasoning before JSON should parse");
+        let value: Value =
+            serde_json::from_str(&parsed).expect("valid final prefilled JSON envelope");
+        assert_eq!(value["content"], "{\"answer\":42}");
+        assert_eq!(value["reasoning_content"], "plan");
+
+        let parsed = prefilled_result
+            .parse_response_oaicompat("{\"answer\":42}")
+            .expect("prefilled parser should not treat JSON as reasoning");
+        let value: Value = serde_json::from_str(&parsed).expect("valid direct JSON envelope");
+        assert_eq!(value["content"], "{\"answer\":42}");
+        assert!(value.get("reasoning_content").is_none());
+    }
+
+    #[test]
+    fn test_partial_reasoning_stream_diffs_open_tagged_blocks() {
+        let result = ChatTemplateResult {
+            prompt: "prompt".to_string(),
+            generation_prompt: "<|im_start|>assistant\n<think>\n".to_string(),
+            force_pure_content: false,
+            is_continuation: false,
+            add_bos: true,
+            grammar: Some(JSON_GRAMMAR.to_string()),
+            grammar_lazy: false,
+            grammar_triggers: Vec::new(),
+            preserved_tokens: Vec::new(),
+            additional_stops: Vec::new(),
+            parse_tool_calls: false,
+            tool_names: Vec::new(),
+            reasoning_format: Some(crate::config::LlamaCppReasoningFormat::Auto),
+            reasoning_start_tag: Some("<think>".to_string()),
+            reasoning_end_tag: Some("</think>".to_string()),
+        };
+        let generated_parts = [
+            "<",
+            "<th",
+            "<think>h",
+            "<think>hi",
+            "<think>hi</",
+            "<think>hi</think>{\"answer\":42}",
+        ];
+        let mut stream_state = StreamMappingState::default();
+        let mut reasoning_chunks = Vec::new();
+
+        for generated in generated_parts {
+            let Some(message_json) = result
+                .parse_partial_response_oaicompat(generated)
+                .expect("partial reasoning response should parse")
+            else {
+                continue;
+            };
+            let delta_json = stream_delta_from_message_json(&message_json)
+                .expect("partial reasoning response should map to stream delta");
+            for output in
+                map_tool_stream_event(Ok(StreamEvent::Delta(delta_json)), &mut stream_state)
+            {
+                if let Ok(StreamChunk::ReasoningContent(content)) = output {
+                    reasoning_chunks.push(content);
+                }
+            }
+        }
+
+        assert_eq!(reasoning_chunks, vec!["h", "i"]);
+    }
+
+    #[test]
+    fn test_partial_response_parsing_streams_complete_native_tool_call() {
+        let result = ChatTemplateResult {
+            prompt: "prompt".to_string(),
+            generation_prompt: String::new(),
+            force_pure_content: false,
+            is_continuation: false,
+            add_bos: true,
+            grammar: Some(JSON_GRAMMAR.to_string()),
+            grammar_lazy: true,
+            grammar_triggers: Vec::new(),
+            preserved_tokens: Vec::new(),
+            additional_stops: Vec::new(),
+            parse_tool_calls: true,
+            tool_names: Vec::new(),
+            reasoning_format: None,
+            reasoning_start_tag: None,
+            reasoning_end_tag: None,
+        };
+
+        assert!(
+            result
+                .parse_partial_response_oaicompat("<tool_call>{\"name\":\"lookup\",\"arguments\":")
+                .expect("incomplete native tool json should not fail")
+                .is_none()
+        );
+
+        let parsed = result
+            .parse_partial_response_oaicompat(
+                r#"<tool_call>{"name":"lookup","arguments":{"q":"rust"}}</tool_call>"#,
+            )
+            .expect("complete native tool call should parse")
+            .expect("complete native tool call should emit a parsed message");
+        let delta = stream_delta_from_message_json(&parsed)
+            .expect("native tool call message should become stream delta");
+        let value: Value = serde_json::from_str(&delta).expect("valid delta");
+        assert_eq!(value["tool_calls"][0]["index"], 0);
+        assert_eq!(value["tool_calls"][0]["function"]["name"], "lookup");
+    }
+
+    #[test]
+    fn test_complete_chat_response_stop_detects_structured_content() {
+        let result = ChatTemplateResult {
+            prompt: "prompt".to_string(),
+            generation_prompt: String::new(),
+            force_pure_content: false,
+            is_continuation: false,
+            add_bos: true,
+            grammar: Some(JSON_GRAMMAR.to_string()),
+            grammar_lazy: false,
+            grammar_triggers: Vec::new(),
+            preserved_tokens: Vec::new(),
+            additional_stops: Vec::new(),
+            parse_tool_calls: false,
+            tool_names: Vec::new(),
+            reasoning_format: None,
+            reasoning_start_tag: None,
+            reasoning_end_tag: None,
+        };
+
+        assert!(
+            should_stop_after_complete_chat_response(&result, r#"{"value":50,"explanation":"ok"}"#)
+                .expect("complete structured JSON should be detected")
+        );
+        assert!(
+            should_stop_after_complete_chat_response(
+                &result,
+                r#"<think>plan</think>{"value":50,"explanation":"ok"}"#
+            )
+            .expect("complete structured JSON after reasoning should be detected")
+        );
+    }
+
+    #[test]
+    fn test_complete_chat_response_stop_detects_complete_tool_call() {
+        let result = ChatTemplateResult {
+            prompt: "prompt".to_string(),
+            generation_prompt: String::new(),
+            force_pure_content: false,
+            is_continuation: false,
+            add_bos: true,
+            grammar: Some(JSON_GRAMMAR.to_string()),
+            grammar_lazy: false,
+            grammar_triggers: Vec::new(),
+            preserved_tokens: Vec::new(),
+            additional_stops: Vec::new(),
+            parse_tool_calls: true,
+            tool_names: Vec::new(),
+            reasoning_format: None,
+            reasoning_start_tag: None,
+            reasoning_end_tag: None,
+        };
+
+        assert!(
+            !should_stop_after_complete_chat_response(
+                &result,
+                r#"<tool_call>{"name":"Addition","arguments":{"left":42,"right":"#
+            )
+            .expect("incomplete tool JSON should not fail")
+        );
+        assert!(
+            should_stop_after_complete_chat_response(
+                &result,
+                r#"<tool_call>{"name":"Addition","arguments":{"left":42,"right":8}}</tool_call>"#
+            )
+            .expect("complete tool call should be detected")
+        );
+    }
+
+    #[test]
+    fn test_complete_chat_response_stop_ignores_reasoning_only_native_channel() {
+        let result = ChatTemplateResult {
+            prompt: "prompt".to_string(),
+            generation_prompt: String::new(),
+            force_pure_content: false,
+            is_continuation: false,
+            add_bos: true,
+            grammar: Some(JSON_GRAMMAR.to_string()),
+            grammar_lazy: false,
+            grammar_triggers: Vec::new(),
+            preserved_tokens: Vec::new(),
+            additional_stops: Vec::new(),
+            parse_tool_calls: true,
+            tool_names: Vec::new(),
+            reasoning_format: None,
+            reasoning_start_tag: None,
+            reasoning_end_tag: None,
+        };
+
+        assert!(
+            !should_stop_after_complete_chat_response(
+                &result,
+                "<|start|>assistant<|channel|>analysis<|message|>thinking"
+            )
+            .expect("reasoning-only native channel output should not stop generation")
+        );
+    }
+
+    #[test]
+    fn test_complete_json_response_stop_detects_json_payload() {
+        assert!(should_stop_after_complete_json_response(
+            true,
+            r#"{"value":50}"#
+        ));
+        assert!(!should_stop_after_complete_json_response(
+            false,
+            r#"{"value":50}"#
+        ));
+        assert!(!should_stop_after_complete_json_response(
+            true,
+            r#"{"value":"#
+        ));
+        assert!(!should_stop_after_complete_json_response(
+            true,
+            "```json\n{\"value\":50}"
+        ));
+        assert!(should_stop_after_complete_json_response(
+            true,
+            "```json\n{\"value\":50}\n```"
+        ));
+    }
+
+    #[test]
+    fn test_chat_template_result_extracts_reasoning_content() {
+        let result = ChatTemplateResult {
+            prompt: "prompt".to_string(),
+            generation_prompt: String::new(),
+            force_pure_content: false,
+            is_continuation: false,
+            add_bos: true,
+            grammar: None,
+            grammar_lazy: false,
+            grammar_triggers: Vec::new(),
+            preserved_tokens: Vec::new(),
+            additional_stops: Vec::new(),
+            parse_tool_calls: false,
+            tool_names: Vec::new(),
+            reasoning_format: Some(crate::config::LlamaCppReasoningFormat::Auto),
+            reasoning_start_tag: Some("<think>".to_string()),
+            reasoning_end_tag: Some("</think>".to_string()),
+        };
+
+        let parsed = result
+            .parse_response_oaicompat("<think>plan</think>final answer")
+            .expect("reasoning response should parse");
+        let value: Value = serde_json::from_str(&parsed).expect("valid message json");
+        assert_eq!(value["reasoning_content"], "plan");
+        assert_eq!(value["content"], "final answer");
+    }
+
+    #[test]
+    fn test_gemma4_reasoning_cleanup_matches_channel_parser() {
+        let result = ChatTemplateResult {
+            prompt: "prompt".to_string(),
+            generation_prompt: String::new(),
+            force_pure_content: false,
+            is_continuation: false,
+            add_bos: true,
+            grammar: None,
+            grammar_lazy: false,
+            grammar_triggers: Vec::new(),
+            preserved_tokens: Vec::new(),
+            additional_stops: Vec::new(),
+            parse_tool_calls: false,
+            tool_names: Vec::new(),
+            reasoning_format: Some(crate::config::LlamaCppReasoningFormat::Auto),
+            reasoning_start_tag: Some("<|channel>thought".to_string()),
+            reasoning_end_tag: Some("<channel|>".to_string()),
+        };
+
+        let parsed = result
+            .parse_response_oaicompat(
+                "<|channel><|channel>thought\nplan<channel|>final answer<channel|>",
+            )
+            .expect("gemma4 reasoning response should parse");
+        let value: Value = serde_json::from_str(&parsed).expect("valid message json");
+        assert_eq!(value["reasoning_content"], "plan");
+        assert_eq!(value["content"], "final answer");
+    }
+
+    #[test]
+    fn test_gemma4_tool_call_reasoning_cleanup_matches_channel_parser() {
+        let result = ChatTemplateResult {
+            prompt: "prompt".to_string(),
+            generation_prompt: String::new(),
+            force_pure_content: false,
+            is_continuation: false,
+            add_bos: true,
+            grammar: None,
+            grammar_lazy: false,
+            grammar_triggers: Vec::new(),
+            preserved_tokens: Vec::new(),
+            additional_stops: Vec::new(),
+            parse_tool_calls: true,
+            tool_names: Vec::new(),
+            reasoning_format: Some(crate::config::LlamaCppReasoningFormat::Auto),
+            reasoning_start_tag: Some("<|channel>thought".to_string()),
+            reasoning_end_tag: Some("<channel|>".to_string()),
+        };
+
+        let parsed = result
+            .parse_response_oaicompat("<|channel><|channel>thought\nplan<channel|>answer<|tool_call>call:lookup{q:<|\"|>rust<|\"|>}<tool_call|>")
+            .expect("gemma4 tool response should parse");
+        let value: Value = serde_json::from_str(&parsed).expect("valid tool message json");
+        assert_eq!(value["reasoning_content"], "plan");
+        assert_eq!(value["content"], "answer");
+        assert_eq!(value["tool_calls"][0]["function"]["name"], "lookup");
+        assert_eq!(
+            parsed_arguments(&value["tool_calls"][0]),
+            json!({"q": "rust"})
+        );
+    }
+
+    #[test]
+    fn test_reasoning_only_chat_template_streams_final_message_delta() {
+        let result = ChatTemplateResult {
+            prompt: "prompt".to_string(),
+            generation_prompt: String::new(),
+            force_pure_content: false,
+            is_continuation: false,
+            add_bos: true,
+            grammar: None,
+            grammar_lazy: false,
+            grammar_triggers: Vec::new(),
+            preserved_tokens: Vec::new(),
+            additional_stops: Vec::new(),
+            parse_tool_calls: false,
+            tool_names: Vec::new(),
+            reasoning_format: Some(crate::config::LlamaCppReasoningFormat::Auto),
+            reasoning_start_tag: Some("<think>".to_string()),
+            reasoning_end_tag: Some("</think>".to_string()),
+        };
+
+        assert!(should_stream_final_message(&result));
+
+        let message_json = result
+            .parse_response_oaicompat("<think>plan</think>final answer")
+            .expect("reasoning response should parse");
+        let delta = stream_delta_from_message_json(&message_json)
+            .expect("reasoning response should become an OpenAI delta");
+        let parsed: OpenAICompatDelta = serde_json::from_str(&delta).expect("delta should parse");
+
+        assert_eq!(
+            parsed
+                .reasoning_content
+                .and_then(StringOrJson::into_non_empty_string)
+                .as_deref(),
+            Some("plan")
+        );
+        assert_eq!(
+            parsed
+                .content
+                .and_then(StringOrJson::into_non_empty_string)
+                .as_deref(),
+            Some("final answer")
+        );
+    }
+
+    #[test]
+    fn test_stream_delta_from_message_json_indexes_tool_calls() {
+        let delta = stream_delta_from_message_json(
+            r#"{
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": { "name": "lookup", "arguments": "{\"q\":\"rust\"}" }
+                    },
+                    {
+                        "id": "call_2",
+                        "type": "function",
+                        "function": { "name": "lookup", "arguments": "{\"q\":\"llama\"}" }
+                    }
+                ]
+            }"#,
+        )
+        .expect("delta conversion should succeed");
+
+        let parsed: OpenAICompatDelta =
+            serde_json::from_str(&delta).expect("delta should parse as OpenAI compat delta");
+        let calls = parsed.tool_calls.expect("tool calls should be present");
+        assert_eq!(calls[0].index, Some(0));
+        assert_eq!(calls[1].index, Some(1));
+    }
+
+    #[test]
+    fn test_tool_choice_none_disables_tool_template_and_grammar_inputs() {
+        let tools = [sample_lookup_tool()];
+        let default_config = LlamaCppConfig::default();
+        assert!(enabled_tools_for_config(&default_config, Some(&tools)).is_some());
+
+        let disabled_config = LlamaCppConfig {
+            tool_choice: LlamaCppToolChoice::None,
+            ..Default::default()
+        };
+        assert!(enabled_tools_for_config(&disabled_config, Some(&tools)).is_none());
+        assert!(enabled_tools_for_config(&disabled_config, Some(&[])).is_none());
+        assert!(enabled_tools_for_config(&disabled_config, None).is_none());
+    }
+
+    #[test]
+    fn test_stream_delta_from_message_json_keeps_content() {
+        let delta = stream_delta_from_message_json(r#"{"content":"done"}"#)
+            .expect("delta conversion should succeed");
+        let parsed: OpenAICompatDelta =
+            serde_json::from_str(&delta).expect("delta should parse as OpenAI compat delta");
+        assert_eq!(
+            parsed.content.and_then(StringOrJson::into_non_empty_string),
+            Some("done".to_string())
+        );
     }
 
     #[test]
@@ -3233,6 +9283,15 @@ mod tests {
 
         let payload = extract_json_payload("answer: {\"c\":3}").unwrap();
         assert_eq!(payload, "{\"c\":3}");
+
+        let native_array = extract_json_payload(
+            r#"[TOOL_CALLS] [{"name":"lookup","arguments":{"q":"rust"}}] [/TOOL_CALLS]"#,
+        )
+        .unwrap();
+        assert_eq!(
+            native_array,
+            r#"[{"name":"lookup","arguments":{"q":"rust"}}]"#
+        );
 
         assert!(is_valid_json("{\"ok\":true}"));
         assert!(!is_valid_json("{broken"));
@@ -3326,9 +9385,11 @@ mod tests {
     #[test]
     fn test_push_text_and_reasoning_chunks_emits_both() {
         let mut outputs = Vec::new();
+        let mut stream_state = StreamMappingState::default();
         push_text_and_reasoning_chunks(
             Some("answer".to_string()),
             Some("plan".to_string()),
+            &mut stream_state,
             &mut outputs,
         );
 
@@ -3411,23 +9472,656 @@ mod tests {
     }
 
     #[test]
-    fn test_select_template_schema_and_grammar_ignores_schema_when_tools_present() {
+    fn test_build_tool_response_schema_constrains_tool_names_and_arguments() {
+        let tool = sample_lookup_tool();
         let schema = StructuredOutputFormat {
             name: "MathAgentOutput".to_string(),
             description: None,
-            schema: Some(serde_json::json!({
+            schema: Some(json!({
                 "type": "object",
                 "properties": {
                     "value": {"type": "integer"}
-                },
-                "required": ["value"]
+                }
             })),
             strict: Some(true),
         };
 
-        let (json_schema, grammar) = select_template_schema_and_grammar(true, Some(&schema), true);
-        assert!(json_schema.is_none());
-        assert!(grammar.is_none());
+        let schema = build_tool_response_schema(
+            &[tool],
+            Some(&schema),
+            false,
+            LlamaCppToolChoice::Auto,
+            false,
+        )
+        .expect("tool schema should build");
+
+        assert_eq!(
+            schema["oneOf"][0]["properties"]["value"]["type"], "integer",
+            "structured final responses must remain allowed alongside tool calls"
+        );
+        let tool_call_schema = &schema["oneOf"][1]["properties"]["tool_calls"]["items"]["oneOf"][0];
+        assert_eq!(
+            tool_call_schema["properties"]["function"]["properties"]["name"]["enum"][0],
+            "lookup"
+        );
+        assert_eq!(
+            tool_call_schema["properties"]["function"]["properties"]["arguments"]["properties"]["q"]
+                ["type"],
+            "string"
+        );
+        assert_eq!(
+            tool_call_schema["properties"]["function"]["properties"]["arguments"]["additionalProperties"],
+            false
+        );
+        assert_eq!(
+            schema["oneOf"][1]["properties"]["tool_calls"]["maxItems"], 1,
+            "parallel_tool_calls=false must constrain generated tool calls to one"
+        );
+    }
+
+    #[test]
+    fn test_build_tool_response_schema_allows_parallel_when_enabled() {
+        let tool = sample_lookup_tool();
+        let schema =
+            build_tool_response_schema(&[tool], None, false, LlamaCppToolChoice::Auto, true)
+                .expect("tool schema should build");
+
+        assert!(
+            schema["oneOf"][1]["properties"]["tool_calls"]
+                .get("maxItems")
+                .is_none(),
+            "parallel_tool_calls=true must not cap tool call count"
+        );
+    }
+
+    #[test]
+    fn test_build_tool_response_schema_required_disallows_final_response() {
+        let tool = sample_lookup_tool();
+        let schema =
+            build_tool_response_schema(&[tool], None, false, LlamaCppToolChoice::Required, false)
+                .expect("tool schema should build");
+
+        assert!(
+            schema.get("oneOf").is_none(),
+            "required tool choice must not allow a final response branch"
+        );
+        assert_eq!(schema["required"][0], "tool_calls");
+        assert_eq!(
+            schema["properties"]["tool_calls"]["items"]["oneOf"][0]["properties"]["function"]["properties"]
+                ["name"]["enum"][0],
+            "lookup"
+        );
+    }
+
+    #[test]
+    fn test_named_tool_choice_selects_only_requested_tool() {
+        let lookup = sample_lookup_tool();
+        let search = sample_search_tool();
+        let (selected, effective_choice) = select_tools_for_tool_choice(
+            &[lookup.clone(), search.clone()],
+            LlamaCppToolChoice::Function {
+                name: "search".to_string(),
+            },
+        )
+        .expect("named tool choice should select provided function");
+
+        assert!(matches!(effective_choice, LlamaCppToolChoice::Required));
+        assert_eq!(selected.len(), 1);
+        assert_eq!(selected[0].function.name, "search");
+
+        let grammar = build_tool_response_grammar(
+            &[lookup, search],
+            None,
+            false,
+            LlamaCppToolChoice::Function {
+                name: "search".to_string(),
+            },
+            true,
+            ToolCallGrammarFormat::OpenAiEnvelope,
+        )
+        .expect("named tool choice grammar should compile");
+
+        assert!(grammar.contains("search"));
+        assert!(!grammar.contains("lookup"));
+        assert!(
+            !grammar.contains("content"),
+            "named tool choice should behave like required and remove final response branch"
+        );
+    }
+
+    #[test]
+    fn test_named_tool_choice_rejects_missing_function() {
+        let err = select_tools_for_tool_choice(
+            &[sample_lookup_tool()],
+            LlamaCppToolChoice::Function {
+                name: "search".to_string(),
+            },
+        )
+        .expect_err("missing named tool should fail");
+
+        assert!(
+            err.to_string().contains("no matching tool"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn test_build_tool_response_grammar_compiles() {
+        let tool = sample_lookup_tool();
+        let grammar = build_tool_response_grammar(
+            &[tool],
+            None,
+            false,
+            LlamaCppToolChoice::Auto,
+            false,
+            ToolCallGrammarFormat::OpenAiEnvelope,
+        )
+        .expect("tool response grammar should compile");
+
+        assert!(
+            grammar.contains("tool") && grammar.contains("lookup") && grammar.contains("content"),
+            "grammar must include the tool-call envelope and final content branch, got: {grammar}"
+        );
+    }
+
+    #[test]
+    fn test_reasoning_wrapped_tool_response_grammar_compiles() {
+        let tool = sample_lookup_tool();
+        let grammar = build_tool_response_grammar(
+            &[tool],
+            None,
+            false,
+            LlamaCppToolChoice::Auto,
+            false,
+            ToolCallGrammarFormat::OpenAiEnvelope,
+        )
+        .expect("tool response grammar should compile");
+        let wrapped = wrap_grammar_with_tagged_reasoning(&grammar, "<think>", "</think>");
+
+        assert!(
+            wrapped.contains("root ::= reasoning? root-content")
+                && wrapped.contains("reasoning ::=")
+                && !wrapped.contains("reasoning-ws ::=")
+                && wrapped.contains("root-content ::=")
+        );
+    }
+
+    #[test]
+    fn test_detect_native_tool_call_template_formats() {
+        assert_eq!(
+            detect_tool_call_grammar_format("{{ '<|tool_call>' }}{{ '<tool_call|>' }}"),
+            ToolCallGrammarFormat::Gemma4ToolCall
+        );
+        assert_eq!(
+            detect_tool_call_grammar_format(
+                "<|start|>assistant<|channel|>commentary to=functions.lookup<|message|>"
+            ),
+            ToolCallGrammarFormat::NativeChannelToolCall
+        );
+        assert_eq!(
+            detect_tool_call_grammar_format(
+                "<|tool_calls_section_begin|><|tool_call_begin|>functions.lookup:0<|tool_call_argument_begin|>"
+            ),
+            ToolCallGrammarFormat::KimiK2ToolCall
+        );
+        assert_eq!(
+            detect_tool_call_grammar_format(
+                "<|tool_call_start|>[lookup(q='rust')]<|tool_call_end|>"
+            ),
+            ToolCallGrammarFormat::Lfm2ToolCall
+        );
+        assert_eq!(
+            detect_tool_call_grammar_format("<|message_sep|>\n\nfunction call<|role_sep|>\n"),
+            ToolCallGrammarFormat::GigaChatV3ToolCall
+        );
+        assert_eq!(
+            detect_tool_call_grammar_format("<｜DSML｜function_calls>"),
+            ToolCallGrammarFormat::DeepSeekDsmlToolCall
+        );
+        assert_eq!(
+            detect_tool_call_grammar_format("{{ '<tool_call>' }}"),
+            ToolCallGrammarFormat::XmlToolCall
+        );
+        assert_eq!(
+            detect_tool_call_grammar_format("{{ '<function=' }}{{ '</function>' }}"),
+            ToolCallGrammarFormat::GenericFunctionTag
+        );
+        assert_eq!(
+            detect_tool_call_grammar_format(">>>all\n{{ content }}>>>${recipient}\n{{ args }}"),
+            ToolCallGrammarFormat::FunctionaryV32
+        );
+        assert_eq!(
+            detect_tool_call_grammar_format(">>>not_a_functionary_marker"),
+            ToolCallGrammarFormat::OpenAiEnvelope
+        );
+        assert_eq!(
+            detect_tool_call_grammar_format("{{ '[TOOL_CALLS]' }}"),
+            ToolCallGrammarFormat::ToolCallsArrayTag
+        );
+        assert_eq!(
+            detect_tool_call_grammar_format("{{ '[TOOL_CALLS]' }}{{ '[ARGS]' }}"),
+            ToolCallGrammarFormat::ToolCallsArgsTag
+        );
+        assert_eq!(
+            detect_tool_call_grammar_format("{{ tools | tojson }}"),
+            ToolCallGrammarFormat::OpenAiEnvelope
+        );
+    }
+
+    #[test]
+    fn test_native_xml_tool_response_grammar_omits_special_marker_tokens() {
+        let tool = sample_lookup_tool();
+        let grammar = build_tool_response_grammar(
+            &[tool],
+            None,
+            false,
+            LlamaCppToolChoice::Required,
+            false,
+            ToolCallGrammarFormat::XmlToolCall,
+        )
+        .expect("native XML tool grammar should compile");
+
+        assert!(!grammar.contains("\"<tool_call>\""));
+        assert!(!grammar.contains("\"</tool_call>\""));
+        assert!(grammar.contains("tool-payload"));
+        assert!(!grammar.contains("tool_calls"));
+    }
+
+    #[test]
+    fn test_generic_function_tag_tool_response_grammar_uses_tag_json_markers() {
+        let tool = sample_lookup_tool();
+        let grammar = build_tool_response_grammar(
+            &[tool],
+            None,
+            false,
+            LlamaCppToolChoice::Required,
+            false,
+            ToolCallGrammarFormat::GenericFunctionTag,
+        )
+        .expect("generic function-tag grammar should compile");
+
+        assert!(grammar.contains("\"<function=\""));
+        assert!(grammar.contains("\"</function>\""));
+        assert!(grammar.contains("\"<parameter name=\\\"\""));
+        assert!(grammar.contains("generic-function-string"));
+        assert!(grammar.contains("-value ::="));
+        assert!(grammar.contains("\"lookup\""));
+        assert!(!grammar.contains("tool_calls"));
+    }
+
+    #[test]
+    fn test_generic_function_tag_auto_grammar_starts_after_lazy_trigger() {
+        let tool = sample_lookup_tool();
+        let grammar = build_tool_response_grammar(
+            &[tool],
+            None,
+            false,
+            LlamaCppToolChoice::Auto,
+            false,
+            ToolCallGrammarFormat::GenericFunctionTag,
+        )
+        .expect("generic function-tag lazy grammar should compile");
+
+        assert!(grammar.starts_with("root ::= (generic-function-tool-0-suffix)"));
+        assert!(!grammar.contains("root ::= \"<function=\""));
+        assert!(grammar.contains("\"</function>\""));
+    }
+
+    #[test]
+    fn test_generic_function_tag_grammar_wraps_schema_final_response() {
+        let tool = sample_lookup_tool();
+        let schema = sample_structured_output_schema();
+        let grammar = build_tool_response_grammar(
+            &[tool],
+            Some(&schema),
+            false,
+            LlamaCppToolChoice::Auto,
+            false,
+            ToolCallGrammarFormat::GenericFunctionTag,
+        )
+        .expect("generic function-tag structured-output grammar should compile");
+
+        assert!(grammar.contains("root ::= final-root | tool-root"));
+        assert!(grammar.contains("final-root ::= \"```json\""));
+        assert!(grammar.contains("| final-response-format"));
+        assert!(grammar.contains("tool-root ::= (tool-generic-function-tool-0)"));
+    }
+
+    #[test]
+    fn test_native_tool_calls_tag_required_grammar_uses_array_marker() {
+        let tool = sample_lookup_tool();
+        let grammar = build_tool_response_grammar(
+            &[tool],
+            None,
+            false,
+            LlamaCppToolChoice::Required,
+            false,
+            ToolCallGrammarFormat::ToolCallsArrayTag,
+        )
+        .expect("native tag tool grammar should compile");
+
+        assert!(grammar.contains("\"[TOOL_CALLS]\""));
+        assert!(grammar.contains("\"[/TOOL_CALLS]\""));
+        assert!(grammar.contains("tool-payload"));
+    }
+
+    #[test]
+    fn test_ministral_tool_calls_args_grammar_uses_name_args_marker() {
+        let tool = sample_lookup_tool();
+        let grammar = build_tool_response_grammar(
+            &[tool],
+            None,
+            false,
+            LlamaCppToolChoice::Required,
+            false,
+            ToolCallGrammarFormat::ToolCallsArgsTag,
+        )
+        .expect("ministral tool grammar should compile");
+
+        assert!(grammar.contains("\"[TOOL_CALLS]\""));
+        assert!(grammar.contains("\"[ARGS]\""));
+        assert!(grammar.contains("\"lookup\""));
+        assert!(!grammar.contains("\"[/TOOL_CALLS]\""));
+        assert!(!grammar.contains("tool-payload)?"));
+    }
+
+    #[test]
+    fn test_ministral_tool_calls_args_grammar_wraps_schema_final_response() {
+        let tool = sample_lookup_tool();
+        let schema = sample_structured_output_schema();
+        let grammar = build_tool_response_grammar(
+            &[tool],
+            Some(&schema),
+            false,
+            LlamaCppToolChoice::Auto,
+            false,
+            ToolCallGrammarFormat::ToolCallsArgsTag,
+        )
+        .expect("ministral structured-output grammar should compile");
+
+        assert!(grammar.contains("root ::= final-root | tool-root"));
+        assert!(grammar.contains("final-root ::= \"```json\""));
+        assert!(grammar.contains("final-response-format"));
+        assert!(grammar.contains("tool-root ::= \"[TOOL_CALLS]\""));
+        assert!(!grammar.contains("\"<|start|>assistant\""));
+    }
+
+    #[test]
+    fn test_functionary_v3_2_tool_response_grammar_uses_recipient_format() {
+        let tool = sample_lookup_tool();
+        let grammar = build_tool_response_grammar(
+            &[tool],
+            None,
+            false,
+            LlamaCppToolChoice::Required,
+            false,
+            ToolCallGrammarFormat::FunctionaryV32,
+        )
+        .expect("functionary tool grammar should compile");
+
+        assert!(grammar.contains("\">>>\""));
+        assert!(grammar.contains("\"lookup\""));
+        assert!(grammar.contains("\"\\n\""));
+        assert!(!grammar.contains("\"[TOOL_CALLS]\""));
+    }
+
+    #[test]
+    fn test_functionary_v3_2_auto_grammar_starts_after_lazy_trigger() {
+        let tool = sample_lookup_tool();
+        let grammar = build_tool_response_grammar(
+            &[tool],
+            None,
+            false,
+            LlamaCppToolChoice::Auto,
+            true,
+            ToolCallGrammarFormat::FunctionaryV32,
+        )
+        .expect("functionary lazy tool grammar should compile");
+
+        assert!(grammar.starts_with("root ::= (functionary-tool-0)"));
+        assert!(grammar.contains("\">>>\""));
+        assert!(!grammar.contains("\">>>all\\n\""));
+    }
+
+    #[test]
+    fn test_gemma4_tool_response_grammar_uses_native_call_markers() {
+        let tool = sample_lookup_tool();
+        let grammar = build_tool_response_grammar(
+            &[tool],
+            None,
+            false,
+            LlamaCppToolChoice::Required,
+            false,
+            ToolCallGrammarFormat::Gemma4ToolCall,
+        )
+        .expect("gemma4 tool grammar should compile");
+
+        assert!(grammar.contains("\"<|tool_call>call:\""));
+        assert!(grammar.contains("\"<tool_call|>\""));
+        assert!(grammar.contains("\"lookup\""));
+        assert!(grammar.contains("gemma4-dict"));
+        assert!(grammar.contains("\"<|\\\"|>\""));
+        assert!(!grammar.contains("lookup-schema"));
+        assert!(!grammar.contains("tool_calls"));
+    }
+
+    #[test]
+    fn test_gemma4_tool_response_grammar_wraps_schema_final_response() {
+        let tool = sample_lookup_tool();
+        let schema = sample_structured_output_schema();
+        let grammar = build_tool_response_grammar(
+            &[tool],
+            Some(&schema),
+            false,
+            LlamaCppToolChoice::Auto,
+            false,
+            ToolCallGrammarFormat::Gemma4ToolCall,
+        )
+        .expect("gemma4 structured-output grammar should compile");
+
+        assert!(grammar.contains("root ::= final-root | tool-root"));
+        assert!(grammar.contains("final-root ::= final-gemma4-response-start"));
+        assert!(grammar.contains("final-gemma4-response-thought? \"```json\""));
+        assert!(grammar.contains("final-gemma4-response-thought ::="));
+        assert!(grammar.contains("final-response-format"));
+        assert!(grammar.contains("tool-root ::= (\"<|tool_call>call:\""));
+    }
+
+    #[test]
+    fn test_native_channel_tool_response_grammar_uses_gpt_oss_markers() {
+        let tool = sample_lookup_tool();
+        let grammar = build_tool_response_grammar(
+            &[tool],
+            None,
+            false,
+            LlamaCppToolChoice::Required,
+            false,
+            ToolCallGrammarFormat::NativeChannelToolCall,
+        )
+        .expect("native channel tool grammar should compile");
+
+        assert!(grammar.contains("\"<|start|>assistant\""));
+        assert!(grammar.contains("\" to=functions.\""));
+        assert!(grammar.contains("\"<|channel|>\""));
+        assert!(grammar.contains("\"<|message|>\""));
+        assert!(grammar.contains("\"lookup\""));
+        assert!(!grammar.contains("tool_calls"));
+    }
+
+    #[test]
+    fn test_native_channel_tool_response_grammar_wraps_schema_final_response() {
+        let tool = sample_lookup_tool();
+        let schema = sample_structured_output_schema();
+        let grammar = build_tool_response_grammar(
+            &[tool],
+            Some(&schema),
+            false,
+            LlamaCppToolChoice::Auto,
+            false,
+            ToolCallGrammarFormat::NativeChannelToolCall,
+        )
+        .expect("gpt-oss structured-output grammar should compile");
+
+        assert!(grammar.contains("root ::= final-root | tool-root"));
+        assert!(grammar.contains("final-root ::= \"<|start|>assistant\""));
+        assert!(grammar.contains("\"<|channel|>final\""));
+        assert!(grammar.contains("\"<|message|>\""));
+        assert!(grammar.contains("final-response-format"));
+        assert!(grammar.contains("tool-root ::= \"<|start|>assistant\""));
+        assert!(!grammar.contains("final-root ::= \"```json\""));
+    }
+
+    #[test]
+    fn test_native_channel_auto_grammar_starts_after_lazy_trigger() {
+        let tool = sample_lookup_tool();
+        let grammar = build_tool_response_grammar(
+            &[tool],
+            None,
+            false,
+            LlamaCppToolChoice::Auto,
+            false,
+            ToolCallGrammarFormat::NativeChannelToolCall,
+        )
+        .expect("native channel lazy grammar should compile");
+
+        assert!(grammar.contains("root ::= \"=functions.\""));
+        assert!(grammar.contains("| \".\""));
+        assert!(!grammar.contains("\"<|start|>assistant\""));
+        assert!(grammar.contains("\"lookup\""));
+    }
+
+    #[test]
+    fn test_kimi_k2_tool_response_grammar_uses_native_markers() {
+        let tool = sample_lookup_tool();
+        let grammar = build_tool_response_grammar(
+            &[tool],
+            None,
+            false,
+            LlamaCppToolChoice::Required,
+            false,
+            ToolCallGrammarFormat::KimiK2ToolCall,
+        )
+        .expect("kimi tool grammar should compile");
+
+        assert!(grammar.contains("\"<|tool_call_begin|>\""));
+        assert!(grammar.contains("\"functions.\""));
+        assert!(grammar.contains("\"<|tool_call_argument_begin|>\""));
+        assert!(grammar.contains("\"lookup\""));
+        assert!(!grammar.contains("\"tool_calls\""));
+    }
+
+    #[test]
+    fn test_lfm2_tool_response_grammar_uses_python_style_markers() {
+        let tool = sample_lookup_tool();
+        let grammar = build_tool_response_grammar(
+            &[tool],
+            None,
+            false,
+            LlamaCppToolChoice::Required,
+            false,
+            ToolCallGrammarFormat::Lfm2ToolCall,
+        )
+        .expect("lfm2 tool grammar should compile");
+
+        assert!(grammar.contains("\"<|tool_call_start|>\""));
+        assert!(grammar.contains("\"<|tool_call_end|>\""));
+        assert!(grammar.contains("\"lookup\""));
+        assert!(grammar.contains("lfm-args"));
+        assert!(grammar.contains("lfm-tool-0-args"));
+        assert!(grammar.contains("\"q\" lfm-ws \"=\" lfm-ws lfm-string"));
+        assert!(grammar.contains("\"limit\" lfm-ws \"=\" lfm-ws lfm-number"));
+        assert!(grammar.contains("lfm-object"));
+        assert!(grammar.contains("lfm-list"));
+        assert!(grammar.contains("\"True\""));
+        assert!(!grammar.contains("tool_calls"));
+    }
+
+    #[test]
+    fn test_gigachat_v3_tool_response_grammar_uses_native_marker() {
+        let tool = sample_lookup_tool();
+        let grammar = build_tool_response_grammar(
+            &[tool],
+            None,
+            false,
+            LlamaCppToolChoice::Required,
+            false,
+            ToolCallGrammarFormat::GigaChatV3ToolCall,
+        )
+        .expect("gigachat tool grammar should compile");
+
+        assert!(grammar.contains("\"<|message_sep|>\\n\\nfunction call<|role_sep|>\\n\""));
+        assert!(grammar.contains("\"\\\"name\\\"\""));
+        assert!(grammar.contains("\"\\\"arguments\\\"\""));
+        assert!(grammar.contains("\\\"lookup\\\""));
+        assert!(!grammar.contains("tool_calls"));
+    }
+
+    #[test]
+    fn test_deepseek_dsml_tool_response_grammar_uses_native_markers() {
+        let tool = sample_lookup_tool();
+        let grammar = build_tool_response_grammar(
+            &[tool],
+            None,
+            false,
+            LlamaCppToolChoice::Required,
+            true,
+            ToolCallGrammarFormat::DeepSeekDsmlToolCall,
+        )
+        .expect("deepseek dsml tool grammar should compile");
+
+        assert!(grammar.contains("\"<｜DSML｜function_calls>\""));
+        assert!(grammar.contains("\"<｜DSML｜invoke name=\\\"\""));
+        assert!(
+            grammar
+                .contains("\"<｜DSML｜parameter name=\\\"\" \"q\" \"\\\" string=\\\"true\\\">\"")
+        );
+        assert!(
+            grammar.contains(
+                "\"<｜DSML｜parameter name=\\\"\" \"limit\" \"\\\" string=\\\"false\\\">\""
+            )
+        );
+        assert!(grammar.contains("\"lookup\""));
+        assert!(grammar.contains("dsml-string"));
+        assert!(!grammar.contains("tool_calls"));
+    }
+
+    #[test]
+    fn test_deepseek_dsml_tool_response_grammar_wraps_schema_final_response() {
+        let tool = sample_lookup_tool();
+        let schema = sample_structured_output_schema();
+        let grammar = build_tool_response_grammar(
+            &[tool],
+            Some(&schema),
+            false,
+            LlamaCppToolChoice::Auto,
+            false,
+            ToolCallGrammarFormat::DeepSeekDsmlToolCall,
+        )
+        .expect("deepseek structured-output grammar should compile");
+
+        assert!(grammar.contains("root ::= final-root | tool-root"));
+        assert!(grammar.contains("final-root ::= \"```json\""));
+        assert!(grammar.contains("final-deepseek-response-ws"));
+        assert!(grammar.contains("final-response-format"));
+        assert!(grammar.contains("tool-root ::= \"<｜DSML｜function_calls>\""));
+    }
+
+    #[test]
+    fn test_native_auto_tool_response_grammar_is_lazy_payload_only() {
+        let tool = sample_lookup_tool();
+        let grammar = build_tool_response_grammar(
+            &[tool],
+            None,
+            false,
+            LlamaCppToolChoice::Auto,
+            false,
+            ToolCallGrammarFormat::XmlToolCall,
+        )
+        .expect("native lazy XML tool grammar should compile");
+
+        assert!(!grammar.contains("\"<tool_call>\""));
+        assert!(!grammar.contains("\"</tool_call>\""));
+        assert!(grammar.contains("tool-payload"));
     }
 
     #[test]
@@ -3447,8 +10141,8 @@ mod tests {
             strict: Some(true),
         };
 
-        let (json_schema, grammar) =
-            select_template_schema_and_grammar(false, Some(&schema), false);
+        let (json_schema, grammar) = select_template_schema_and_grammar(Some(&schema), false, None)
+            .expect("schema should compile");
         assert!(
             json_schema.is_none(),
             "schema must never be forwarded into the OAI-compat template slot"
@@ -3487,8 +10181,8 @@ mod tests {
             strict: Some(true),
         };
 
-        let (json_schema, grammar) =
-            select_template_schema_and_grammar(false, Some(&schema), false);
+        let (json_schema, grammar) = select_template_schema_and_grammar(Some(&schema), false, None)
+            .expect("schema should compile");
 
         assert!(
             json_schema.is_none(),
@@ -3503,10 +10197,56 @@ mod tests {
     }
 
     #[test]
-    fn test_select_template_schema_and_grammar_falls_back_to_json_grammar_on_unconvertible_schema()
-    {
-        // A schema that cannot be compiled to grammar must fall back to the generic JSON
-        // grammar (still enforces well-formed JSON), never re-introduce the schema slot.
+    fn test_select_template_schema_and_grammar_wraps_specialized_response_formats() {
+        let schema = StructuredOutputFormat {
+            name: "Answer".to_string(),
+            description: None,
+            schema: Some(json!({
+                "type": "object",
+                "properties": {
+                    "value": {"type": "integer"}
+                },
+                "required": ["value"]
+            })),
+            strict: Some(true),
+        };
+
+        let (_, gpt_oss) = select_template_schema_and_grammar(
+            Some(&schema),
+            false,
+            Some(ToolCallGrammarFormat::NativeChannelToolCall),
+        )
+        .expect("gpt-oss schema should compile");
+        let gpt_oss = gpt_oss.expect("schema grammar should be present");
+        assert!(gpt_oss.contains("\"<|start|>assistant\""));
+        assert!(gpt_oss.contains("\"<|channel|>final\""));
+        assert!(gpt_oss.contains("\"<|message|>\""));
+
+        let (_, fenced) = select_template_schema_and_grammar(
+            Some(&schema),
+            false,
+            Some(ToolCallGrammarFormat::Gemma4ToolCall),
+        )
+        .expect("gemma4 schema should compile");
+        let fenced = fenced.expect("schema grammar should be present");
+        assert!(fenced.contains("\"```json\""));
+        assert!(fenced.contains("response-format"));
+
+        let (_, deepseek) = select_template_schema_and_grammar(
+            Some(&schema),
+            false,
+            Some(ToolCallGrammarFormat::DeepSeekDsmlToolCall),
+        )
+        .expect("deepseek schema should compile");
+        let deepseek = deepseek.expect("schema grammar should be present");
+        assert!(deepseek.contains("\"```json\""));
+        assert!(deepseek.contains("deepseek-response-ws"));
+    }
+
+    #[test]
+    fn test_select_template_schema_and_grammar_rejects_unconvertible_schema() {
+        // Match llama.cpp server validation: an invalid schema should fail the
+        // request instead of silently degrading to generic JSON.
         let schema = StructuredOutputFormat {
             name: "Recursive".to_string(),
             description: None,
@@ -3516,14 +10256,12 @@ mod tests {
             strict: Some(true),
         };
 
-        let (json_schema, grammar) =
-            select_template_schema_and_grammar(false, Some(&schema), false);
-
-        assert!(json_schema.is_none(), "schema slot must stay empty");
-        assert_eq!(
-            grammar.as_deref(),
-            Some(JSON_GRAMMAR),
-            "must fall back to JSON_GRAMMAR when schema-to-grammar fails"
+        let err = select_template_schema_and_grammar(Some(&schema), false, None)
+            .expect_err("invalid schema must be rejected");
+        assert!(
+            err.to_string()
+                .contains("invalid llama.cpp structured output JSON schema"),
+            "unexpected error: {err}"
         );
     }
 
@@ -3657,9 +10395,11 @@ mod tests {
     #[test]
     fn test_struct_stream_helpers_cover_content_and_tool_updates() {
         let mut outputs = Vec::new();
+        let mut stream_state = StreamMappingState::default();
         push_struct_content_and_reasoning(
             Some("answer".to_string()),
             Some("plan".to_string()),
+            &mut stream_state,
             &mut outputs,
         );
         assert_eq!(outputs.len(), 2);
@@ -3680,6 +10420,7 @@ mod tests {
         push_struct_content_and_reasoning(
             Some(String::default()),
             Some(String::default()),
+            &mut stream_state,
             &mut empty_outputs,
         );
         assert!(empty_outputs.is_empty());
@@ -3738,15 +10479,15 @@ mod tests {
 
     #[test]
     fn test_map_struct_stream_event_handles_tokens_usage_and_errors() {
-        let mut tool_states = HashMap::new();
+        let mut stream_state = StreamMappingState::default();
         assert!(
-            map_struct_stream_event(Ok(StreamEvent::Token(String::default())), &mut tool_states,)
+            map_struct_stream_event(Ok(StreamEvent::Token(String::default())), &mut stream_state,)
                 .is_empty()
         );
 
         let token_outputs = map_struct_stream_event(
             Ok(StreamEvent::Token("alpha".to_string())),
-            &mut tool_states,
+            &mut stream_state,
         );
         assert_eq!(token_outputs.len(), 1);
         assert!(matches!(
@@ -3769,7 +10510,7 @@ mod tests {
         })
         .to_string();
         let delta_outputs =
-            map_struct_stream_event(Ok(StreamEvent::Delta(delta)), &mut tool_states);
+            map_struct_stream_event(Ok(StreamEvent::Delta(delta)), &mut stream_state);
         assert_eq!(delta_outputs.len(), 3);
         assert!(matches!(
             &delta_outputs[0],
@@ -3792,7 +10533,7 @@ mod tests {
 
         let usage_outputs = map_struct_stream_event(
             Ok(StreamEvent::Usage(LlamaCppProvider::build_usage(1, 2))),
-            &mut tool_states,
+            &mut stream_state,
         );
         assert_eq!(usage_outputs.len(), 1);
         assert_eq!(
@@ -3810,16 +10551,20 @@ mod tests {
                 Ok(StreamEvent::Done {
                     stop_reason: "end_turn".to_string(),
                 }),
-                &mut tool_states,
+                &mut stream_state,
             )
             .is_empty()
         );
 
-        let invalid =
-            map_struct_stream_event(Ok(StreamEvent::Delta("{bad".to_string())), &mut tool_states);
+        let invalid = map_struct_stream_event(
+            Ok(StreamEvent::Delta("{bad".to_string())),
+            &mut stream_state,
+        );
         assert!(matches!(invalid.as_slice(), [Err(LLMError::JsonError(_))]));
-        let generic =
-            map_struct_stream_event(Err(LLMError::Generic("boom".to_string())), &mut tool_states);
+        let generic = map_struct_stream_event(
+            Err(LLMError::Generic("boom".to_string())),
+            &mut stream_state,
+        );
         assert!(
             matches!(generic.as_slice(), [Err(LLMError::Generic(message))] if message == "boom")
         );
@@ -3827,7 +10572,7 @@ mod tests {
 
     #[test]
     fn test_tool_stream_mapping_covers_deltas_usage_done_and_completions() {
-        let mut tool_states = HashMap::new();
+        let mut stream_state = StreamMappingState::default();
         let delta = json!({
             "content": "answer",
             "reasoning_content": "plan",
@@ -3842,7 +10587,7 @@ mod tests {
             }]
         })
         .to_string();
-        let outputs = map_tool_stream_event(Ok(StreamEvent::Delta(delta)), &mut tool_states);
+        let outputs = map_tool_stream_event(Ok(StreamEvent::Delta(delta)), &mut stream_state);
         assert_eq!(outputs.len(), 4);
         assert!(matches!(&outputs[0], Ok(StreamChunk::Text(text)) if text == "answer"));
         assert!(matches!(
@@ -3862,7 +10607,7 @@ mod tests {
 
         let usage_outputs = map_tool_stream_event(
             Ok(StreamEvent::Usage(LlamaCppProvider::build_usage(1, 2))),
-            &mut tool_states,
+            &mut stream_state,
         );
         assert!(matches!(
             usage_outputs.as_slice(),
@@ -3873,7 +10618,7 @@ mod tests {
             Ok(StreamEvent::Done {
                 stop_reason: "tool_use".to_string(),
             }),
-            &mut tool_states,
+            &mut stream_state,
         );
         assert_eq!(done_outputs.len(), 2);
         assert!(matches!(
@@ -3888,20 +10633,96 @@ mod tests {
             &done_outputs[1],
             Ok(StreamChunk::Done { stop_reason }) if stop_reason == "tool_use"
         ));
-        assert!(tool_states.is_empty());
+        assert!(stream_state.tool_calls.is_empty());
 
         assert!(
             map_tool_stream_event(
                 Ok(StreamEvent::Token(String::default())),
-                &mut HashMap::new(),
+                &mut StreamMappingState::default(),
             )
             .is_empty()
         );
         let invalid = map_tool_stream_event(
             Ok(StreamEvent::Delta("{bad".to_string())),
-            &mut HashMap::new(),
+            &mut StreamMappingState::default(),
         );
         assert!(matches!(invalid.as_slice(), [Err(LLMError::JsonError(_))]));
+    }
+
+    #[test]
+    fn test_tool_stream_updates_diff_cumulative_parser_arguments() {
+        let mut tool_states = HashMap::new();
+        let mut outputs = Vec::new();
+
+        push_tool_chunk_updates(
+            vec![OpenAIToolCallDelta {
+                index: Some(0),
+                id: Some("call_1".to_string()),
+                call_type: Some("function".to_string()),
+                function: Some(OpenAIFunctionDelta {
+                    name: Some("lookup".to_string()),
+                    arguments: StringOrJson::String("{\"q\":\"".to_string()),
+                }),
+            }],
+            &mut tool_states,
+            &mut outputs,
+        );
+        push_tool_chunk_updates(
+            vec![OpenAIToolCallDelta {
+                index: Some(0),
+                id: None,
+                call_type: Some("function".to_string()),
+                function: Some(OpenAIFunctionDelta {
+                    name: None,
+                    arguments: StringOrJson::String("{\"q\":\"rust\"}".to_string()),
+                }),
+            }],
+            &mut tool_states,
+            &mut outputs,
+        );
+
+        let deltas = outputs
+            .iter()
+            .filter_map(|output| match output {
+                Ok(StreamChunk::ToolUseInputDelta { partial_json, .. }) => {
+                    Some(partial_json.as_str())
+                }
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+
+        assert_eq!(deltas, vec!["{\"q\":\"", "rust\"}"]);
+        assert_eq!(tool_states[&0].arguments, "{\"q\":\"rust\"}");
+    }
+
+    #[test]
+    fn test_tool_stream_updates_diff_cumulative_content_and_reasoning() {
+        let mut stream_state = StreamMappingState::default();
+        let first = map_tool_stream_event(
+            Ok(StreamEvent::Delta(
+                json!({
+                    "content": "hel",
+                    "reasoning_content": "pla"
+                })
+                .to_string(),
+            )),
+            &mut stream_state,
+        );
+        let second = map_tool_stream_event(
+            Ok(StreamEvent::Delta(
+                json!({
+                    "content": "hello",
+                    "reasoning_content": "plan"
+                })
+                .to_string(),
+            )),
+            &mut stream_state,
+        );
+
+        assert!(matches!(&first[0], Ok(StreamChunk::Text(text)) if text == "hel"));
+        assert!(matches!(&first[1], Ok(StreamChunk::ReasoningContent(text)) if text == "pla"));
+        assert!(matches!(&second[0], Ok(StreamChunk::Text(text)) if text == "lo"));
+        assert!(matches!(&second[1], Ok(StreamChunk::ReasoningContent(text)) if text == "n"));
     }
 
     #[test]
@@ -3921,7 +10742,8 @@ mod tests {
             Some("{\"answer\": true}".to_string())
         );
 
-        let (json_schema, grammar) = select_template_schema_and_grammar(false, None, true);
+        let (json_schema, grammar) =
+            select_template_schema_and_grammar(None, true, None).expect("generic JSON grammar");
         assert!(json_schema.is_none());
         assert_eq!(grammar.as_deref(), Some(JSON_GRAMMAR));
 
@@ -3948,6 +10770,102 @@ mod tests {
         )
         .expect("non-empty model path should resolve");
         assert_eq!(model_path, TEST_GGUF_MODEL_PATH);
+    }
+
+    #[test]
+    fn test_grammar_trigger_patterns_mirror_common_sampler_inputs() {
+        let (patterns, tokens) = grammar_trigger_patterns(&[
+            GrammarTrigger::Word("[TOOL_CALLS]".to_string()),
+            GrammarTrigger::Pattern("^\\s+to$".to_string()),
+            GrammarTrigger::PatternFull(">>>(?!all)".to_string()),
+            GrammarTrigger::Token(42),
+        ]);
+
+        assert_eq!(
+            patterns,
+            vec![
+                "\\[TOOL_CALLS\\]".to_string(),
+                "^\\s+to$".to_string(),
+                "^>>>(?!all)$".to_string(),
+            ]
+        );
+        assert_eq!(tokens, vec![LlamaToken(42)]);
+    }
+
+    #[test]
+    fn test_generation_prompt_prefill_only_uses_grammar_covered_suffix() {
+        let json_result = ChatTemplateResult {
+            prompt: "prompt".to_string(),
+            generation_prompt: "<|im_start|>assistant\n".to_string(),
+            force_pure_content: false,
+            is_continuation: false,
+            add_bos: true,
+            grammar: Some(JSON_GRAMMAR.to_string()),
+            grammar_lazy: false,
+            grammar_triggers: Vec::new(),
+            preserved_tokens: Vec::new(),
+            additional_stops: Vec::new(),
+            parse_tool_calls: false,
+            tool_names: Vec::new(),
+            reasoning_format: None,
+            reasoning_start_tag: None,
+            reasoning_end_tag: None,
+        };
+        assert!(
+            generation_prompt_grammar_prefill(&json_result).is_none(),
+            "raw JSON grammar must not consume rendered assistant markers"
+        );
+
+        let native_result = ChatTemplateResult {
+            generation_prompt: "<|start|>assistant<|channel|>final<|message|>".to_string(),
+            grammar: Some(
+                r#"root ::= "<|start|>assistant" "<|channel|>final" "<|message|>" "{}""#
+                    .to_string(),
+            ),
+            ..json_result
+        };
+        assert_eq!(
+            generation_prompt_grammar_prefill(&native_result),
+            Some("<|start|>assistant<|channel|>final<|message|>"),
+            "server-style grammars that include response markers should still be prefed",
+        );
+
+        let qwen_thinking_result = ChatTemplateResult {
+            generation_prompt: "<|im_start|>assistant\n<think>\n".to_string(),
+            grammar: Some(wrap_grammar_with_tagged_reasoning(
+                JSON_GRAMMAR,
+                "<think>",
+                "</think>",
+            )),
+            reasoning_format: Some(crate::config::LlamaCppReasoningFormat::Auto),
+            reasoning_start_tag: Some("<think>".to_string()),
+            reasoning_end_tag: Some("</think>".to_string()),
+            ..native_result
+        };
+        assert_eq!(
+            generation_prompt_grammar_prefill(&qwen_thinking_result),
+            Some("<think>\n"),
+            "only the rendered reasoning suffix should be prefed for Qwen-style prompts",
+        );
+    }
+
+    #[test]
+    fn test_regex_escape_covers_common_trigger_literals() {
+        assert_eq!(regex_escape("<|tool_call>"), "<\\|tool_call>");
+        assert_eq!(regex_escape("a+b*(c)"), "a\\+b\\*\\(c\\)");
+        assert_eq!(regex_escape("line\nnext"), "line\\nnext");
+    }
+
+    #[test]
+    fn test_split_top_level_ignores_nested_commas_and_strings() {
+        assert_eq!(
+            split_top_level("a=1, b={\"x\":[1,2]}, c='x,y'", ','),
+            vec!["a=1", "b={\"x\":[1,2]}", "c='x,y'"]
+        );
+        assert_eq!(
+            split_once_top_level("filters={\"a\":1}", '='),
+            Some(("filters", "{\"a\":1}"))
+        );
     }
 
     // ── common_prefix_len tests ──────────────────────────────────────────
@@ -4047,6 +10965,61 @@ mod tests {
         let shared: SharedSessionState = Arc::new(std::sync::Mutex::new(None));
         *shared.lock().unwrap() = None;
         assert!(shared.lock().unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn test_provider_scheduler_allows_active_slot_with_zero_queue() {
+        let scheduler = ProviderScheduler::new(1, 0);
+        let _permit = scheduler
+            .acquire()
+            .await
+            .expect("available slot should not count against queue capacity");
+    }
+
+    #[tokio::test]
+    async fn test_provider_scheduler_rejects_when_queue_full() {
+        let scheduler = ProviderScheduler::new(1, 0);
+        let _permit = scheduler
+            .acquire()
+            .await
+            .expect("first request should acquire slot");
+
+        let err = scheduler
+            .acquire()
+            .await
+            .expect_err("second request should be rejected with no queue capacity");
+
+        assert!(err.to_string().contains("queue is full"));
+    }
+
+    #[tokio::test]
+    async fn test_provider_scheduler_releases_queued_count_on_cancellation() {
+        let scheduler = ProviderScheduler::new(1, 1);
+        let _active = scheduler
+            .acquire()
+            .await
+            .expect("first request should acquire slot");
+
+        let mut queued_acquire = Box::pin(scheduler.acquire());
+        let timed_out = tokio::time::timeout(
+            std::time::Duration::from_millis(10),
+            queued_acquire.as_mut(),
+        )
+        .await;
+
+        assert!(timed_out.is_err());
+        assert_eq!(scheduler.queued.load(Ordering::Acquire), 1);
+
+        drop(queued_acquire);
+        assert_eq!(scheduler.queued.load(Ordering::Acquire), 0);
+
+        let mut second_queued = Box::pin(scheduler.acquire());
+        let timed_out =
+            tokio::time::timeout(std::time::Duration::from_millis(10), second_queued.as_mut())
+                .await;
+
+        assert!(timed_out.is_err());
+        assert_eq!(scheduler.queued.load(Ordering::Acquire), 1);
     }
 
     // ── from_model / model() / backend() tests ──────────────────────────────

--- a/crates/autoagents-llamacpp/src/server_chat.rs
+++ b/crates/autoagents-llamacpp/src/server_chat.rs
@@ -3,20 +3,20 @@ use autoagents_llm::chat::{ChatMessage, ChatRole, MessageType};
 use autoagents_llm::{FunctionCall, ToolCall};
 use serde_json::{Map, Value, json};
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub(crate) struct ServerChatToolCall {
     pub(crate) name: String,
     pub(crate) arguments: String,
     pub(crate) id: String,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub(crate) struct ServerChatContentPart {
     pub(crate) part_type: String,
     pub(crate) text: String,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub(crate) struct ServerChatMessage {
     pub(crate) role: String,
     pub(crate) content: String,
@@ -57,18 +57,6 @@ impl Default for ServerTemplateCaps {
 }
 
 impl ServerChatMessage {
-    fn empty(role: impl Into<String>) -> Self {
-        Self {
-            role: role.into(),
-            content: String::new(),
-            content_parts: Vec::new(),
-            tool_calls: Vec::new(),
-            reasoning_content: String::new(),
-            tool_name: String::new(),
-            tool_call_id: String::new(),
-        }
-    }
-
     #[allow(dead_code)]
     pub(crate) fn render_content(&self, delimiter: &str) -> String {
         if !self.content.is_empty() {
@@ -111,7 +99,7 @@ impl ServerChatMessage {
         } else if !self.content.is_empty() {
             object.insert("content".to_string(), Value::String(self.content.clone()));
         } else {
-            object.insert("content".to_string(), Value::String(String::new()));
+            object.insert("content".to_string(), Value::String(String::default()));
         }
 
         if !self.tool_calls.is_empty() {
@@ -170,7 +158,7 @@ impl ServerChatMessage {
             return self.content.clone();
         }
 
-        let mut text = String::new();
+        let mut text = String::default();
         let mut last_was_media_marker = false;
         for part in &self.content_parts {
             match part.part_type.as_str() {
@@ -202,9 +190,11 @@ pub(crate) fn messages_from_autoagents(
             .iter()
             .any(|message| matches!(message.role, ChatRole::System))
     {
-        let mut msg = ServerChatMessage::empty("system");
-        msg.content = system_prompt.clone();
-        values.push(msg);
+        values.push(ServerChatMessage {
+            role: "system".to_string(),
+            content: system_prompt.clone(),
+            ..Default::default()
+        });
     }
 
     for message in messages {
@@ -381,7 +371,7 @@ fn build_gemma4_model_turn(messages: &[Value], start: usize) -> (Value, usize) {
     let tool_calls = first
         .get("tool_calls")
         .cloned()
-        .unwrap_or_else(|| Value::Array(Vec::new()));
+        .unwrap_or_else(|| Value::Array(Vec::default()));
     let reasoning_content = first.get("reasoning_content").cloned();
     let tool_call_names = tool_calls
         .as_array()
@@ -518,14 +508,20 @@ fn base_message(message: &ChatMessage) -> ServerChatMessage {
         ChatRole::Assistant => "assistant",
         ChatRole::Tool => "tool",
     };
-    let mut msg = ServerChatMessage::empty(role);
-    if matches!(
+    let content = if matches!(
         message.message_type,
         MessageType::Text | MessageType::ToolUse(_)
     ) {
-        msg.content = message.content.clone();
+        message.content.clone()
+    } else {
+        String::default()
+    };
+
+    ServerChatMessage {
+        role: role.to_string(),
+        content,
+        ..Default::default()
     }
-    msg
 }
 
 fn append_text_and_media_marker(msg: &mut ServerChatMessage, text: &str, marker: &str) {
@@ -542,10 +538,12 @@ fn append_text_and_media_marker(msg: &mut ServerChatMessage, text: &str, marker:
 }
 
 fn tool_result_message(tool_call: &ToolCall) -> ServerChatMessage {
-    let mut msg = ServerChatMessage::empty("tool");
-    msg.content = tool_call.function.arguments.clone();
-    msg.tool_call_id = tool_call.id.clone();
-    msg
+    ServerChatMessage {
+        role: "tool".to_string(),
+        content: tool_call.function.arguments.clone(),
+        tool_call_id: tool_call.id.clone(),
+        ..Default::default()
+    }
 }
 
 fn server_tool_call_from_tool_call(
@@ -623,7 +621,7 @@ fn require_non_null_content(messages: &mut [Value]) {
                 .is_some_and(|calls| !calls.is_empty())
             && !object.contains_key("content")
         {
-            object.insert("content".to_string(), Value::String(String::new()));
+            object.insert("content".to_string(), Value::String(String::default()));
         }
     }
 }
@@ -697,7 +695,7 @@ mod tests {
         let message = ChatMessage {
             role: ChatRole::Assistant,
             message_type: MessageType::ToolUse(vec![tool_call()]),
-            content: String::new(),
+            content: String::default(),
         };
 
         let messages = messages_from_autoagents(&LlamaCppConfig::default(), &[message])
@@ -711,16 +709,12 @@ mod tests {
     fn omits_empty_tool_call_id_in_openai_compat_json() {
         let message = ServerChatMessage {
             role: "assistant".to_string(),
-            content: String::new(),
-            content_parts: Vec::new(),
             tool_calls: vec![ServerChatToolCall {
                 name: "lookup".to_string(),
                 arguments: "{}".to_string(),
-                id: String::new(),
+                ..Default::default()
             }],
-            reasoning_content: String::new(),
-            tool_name: String::new(),
-            tool_call_id: String::new(),
+            ..Default::default()
         };
 
         let value = message.to_json_oaicompat(false);
@@ -731,7 +725,10 @@ mod tests {
 
     #[test]
     fn empty_message_content_defaults_to_empty_string() {
-        let message = ServerChatMessage::empty("assistant");
+        let message = ServerChatMessage {
+            role: "assistant".to_string(),
+            ..Default::default()
+        };
 
         let value = message.to_json_oaicompat(false);
 
@@ -775,15 +772,11 @@ mod tests {
     fn text_only_parts_can_render_as_typed_content() {
         let message = ServerChatMessage {
             role: "user".to_string(),
-            content: String::new(),
             content_parts: vec![ServerChatContentPart {
                 part_type: "text".to_string(),
                 text: "caption".to_string(),
             }],
-            tool_calls: Vec::new(),
-            reasoning_content: String::new(),
-            tool_name: String::new(),
-            tool_call_id: String::new(),
+            ..Default::default()
         };
 
         let typed = render_messages_to_json(

--- a/crates/autoagents-llamacpp/src/server_chat.rs
+++ b/crates/autoagents-llamacpp/src/server_chat.rs
@@ -1,0 +1,1064 @@
+use crate::{config::LlamaCppConfig, error::LlamaCppProviderError};
+use autoagents_llm::chat::{ChatMessage, ChatRole, MessageType};
+use autoagents_llm::{FunctionCall, ToolCall};
+use serde_json::{Map, Value, json};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ServerChatToolCall {
+    pub(crate) name: String,
+    pub(crate) arguments: String,
+    pub(crate) id: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ServerChatContentPart {
+    pub(crate) part_type: String,
+    pub(crate) text: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ServerChatMessage {
+    pub(crate) role: String,
+    pub(crate) content: String,
+    pub(crate) content_parts: Vec<ServerChatContentPart>,
+    pub(crate) tool_calls: Vec<ServerChatToolCall>,
+    pub(crate) reasoning_content: String,
+    pub(crate) tool_name: String,
+    pub(crate) tool_call_id: String,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct ServerTemplateCaps {
+    pub(crate) supports_string_content: bool,
+    pub(crate) supports_typed_content: bool,
+    pub(crate) supports_system_role: bool,
+    pub(crate) supports_tool_calls: bool,
+    pub(crate) supports_object_arguments: bool,
+    pub(crate) gpt_oss_reasoning_compat: bool,
+    pub(crate) ministral_reasoning_blocks_compat: bool,
+    pub(crate) lfm2_reasoning_compat: bool,
+    pub(crate) gemma4_tool_response_compat: bool,
+}
+
+impl Default for ServerTemplateCaps {
+    fn default() -> Self {
+        Self {
+            supports_string_content: true,
+            supports_typed_content: true,
+            supports_system_role: true,
+            supports_tool_calls: false,
+            supports_object_arguments: false,
+            gpt_oss_reasoning_compat: false,
+            ministral_reasoning_blocks_compat: false,
+            lfm2_reasoning_compat: false,
+            gemma4_tool_response_compat: false,
+        }
+    }
+}
+
+impl ServerChatMessage {
+    fn empty(role: impl Into<String>) -> Self {
+        Self {
+            role: role.into(),
+            content: String::new(),
+            content_parts: Vec::new(),
+            tool_calls: Vec::new(),
+            reasoning_content: String::new(),
+            tool_name: String::new(),
+            tool_call_id: String::new(),
+        }
+    }
+
+    #[allow(dead_code)]
+    pub(crate) fn render_content(&self, delimiter: &str) -> String {
+        if !self.content.is_empty() {
+            return self.content.clone();
+        }
+
+        let blocks = self
+            .content_parts
+            .iter()
+            .filter(|part| part.part_type == "text")
+            .map(|part| part.text.clone())
+            .collect::<Vec<_>>();
+        blocks.join(delimiter)
+    }
+
+    fn to_json_oaicompat(&self, concat_typed_text: bool) -> Value {
+        let mut object = Map::new();
+        object.insert("role".to_string(), Value::String(self.role.clone()));
+
+        if concat_typed_text || self.contains_media_marker() {
+            object.insert(
+                "content".to_string(),
+                Value::String(self.render_content_for_template_concat()),
+            );
+        } else if !self.content_parts.is_empty() {
+            let mut content = Vec::new();
+            if !self.content.is_empty() {
+                content.push(json!({
+                    "type": "text",
+                    "text": self.content,
+                }));
+            }
+            content.extend(self.content_parts.iter().map(|part| {
+                json!({
+                    "type": part.part_type,
+                    "text": part.text,
+                })
+            }));
+            object.insert("content".to_string(), Value::Array(content));
+        } else if !self.content.is_empty() {
+            object.insert("content".to_string(), Value::String(self.content.clone()));
+        } else {
+            object.insert("content".to_string(), Value::String(String::new()));
+        }
+
+        if !self.tool_calls.is_empty() {
+            object.insert(
+                "tool_calls".to_string(),
+                Value::Array(
+                    self.tool_calls
+                        .iter()
+                        .map(|tool_call| {
+                            let mut call = Map::new();
+                            if !tool_call.id.is_empty() {
+                                call.insert("id".to_string(), Value::String(tool_call.id.clone()));
+                            }
+                            call.insert("type".to_string(), Value::String("function".to_string()));
+                            call.insert(
+                                "function".to_string(),
+                                json!({
+                                    "name": tool_call.name,
+                                    "arguments": tool_call.arguments,
+                                }),
+                            );
+                            Value::Object(call)
+                        })
+                        .collect(),
+                ),
+            );
+        }
+
+        if !self.reasoning_content.is_empty() {
+            object.insert(
+                "reasoning_content".to_string(),
+                Value::String(self.reasoning_content.clone()),
+            );
+        }
+        if !self.tool_name.is_empty() {
+            object.insert("name".to_string(), Value::String(self.tool_name.clone()));
+        }
+        if !self.tool_call_id.is_empty() {
+            object.insert(
+                "tool_call_id".to_string(),
+                Value::String(self.tool_call_id.clone()),
+            );
+        }
+
+        Value::Object(object)
+    }
+
+    fn contains_media_marker(&self) -> bool {
+        self.content_parts
+            .iter()
+            .any(|part| part.part_type == "media_marker")
+    }
+
+    fn render_content_for_template_concat(&self) -> String {
+        if !self.content.is_empty() {
+            return self.content.clone();
+        }
+
+        let mut text = String::new();
+        let mut last_was_media_marker = false;
+        for part in &self.content_parts {
+            match part.part_type.as_str() {
+                "text" => {
+                    if !last_was_media_marker && !text.is_empty() {
+                        text.push('\n');
+                    }
+                    text.push_str(&part.text);
+                    last_was_media_marker = false;
+                }
+                "media_marker" => {
+                    text.push_str(&part.text);
+                    last_was_media_marker = true;
+                }
+                _ => {}
+            }
+        }
+        text
+    }
+}
+
+pub(crate) fn messages_from_autoagents(
+    config: &LlamaCppConfig,
+    messages: &[ChatMessage],
+) -> Result<Vec<ServerChatMessage>, LlamaCppProviderError> {
+    let mut values = Vec::new();
+    if let Some(system_prompt) = config.system_prompt.as_ref()
+        && !messages
+            .iter()
+            .any(|message| matches!(message.role, ChatRole::System))
+    {
+        let mut msg = ServerChatMessage::empty("system");
+        msg.content = system_prompt.clone();
+        values.push(msg);
+    }
+
+    for message in messages {
+        append_message(&mut values, message)?;
+    }
+
+    Ok(values)
+}
+
+pub(crate) fn render_messages_to_json(
+    messages: &[ServerChatMessage],
+    caps: ServerTemplateCaps,
+) -> Vec<Value> {
+    let only_string_accepted = caps.supports_string_content && !caps.supports_typed_content;
+    let only_typed_accepted = !caps.supports_string_content && caps.supports_typed_content;
+
+    messages
+        .iter()
+        .map(|message| {
+            let mut value = if only_string_accepted {
+                message.to_json_oaicompat(true)
+            } else {
+                message.to_json_oaicompat(false)
+            };
+
+            if only_typed_accepted
+                && let Some(object) = value.as_object_mut()
+                && let Some(Value::String(content)) = object.get("content").cloned()
+            {
+                object.insert(
+                    "content".to_string(),
+                    Value::Array(vec![json!({
+                        "type": "text",
+                        "text": content,
+                    })]),
+                );
+            }
+
+            value
+        })
+        .collect()
+}
+
+pub(crate) fn apply_server_workarounds(
+    messages: &mut Vec<Value>,
+    caps: ServerTemplateCaps,
+) -> Result<(), LlamaCppProviderError> {
+    if caps.gpt_oss_reasoning_compat {
+        convert_reasoning_to_gpt_oss_thinking(messages);
+    }
+    if caps.lfm2_reasoning_compat {
+        copy_reasoning_to_thinking(messages);
+    }
+    if caps.ministral_reasoning_blocks_compat {
+        convert_reasoning_to_ministral_blocks(messages);
+    }
+    if caps.gemma4_tool_response_compat {
+        convert_tool_responses_gemma4(messages);
+    }
+    if !caps.supports_system_role {
+        merge_unsupported_system_messages(messages);
+    }
+    if caps.supports_tool_calls {
+        require_non_null_content(messages);
+    }
+    if caps.supports_object_arguments {
+        convert_function_arguments_to_objects(messages)?;
+    }
+    Ok(())
+}
+
+fn convert_reasoning_to_gpt_oss_thinking(messages: &mut [Value]) {
+    for message in messages {
+        let Some(object) = message.as_object_mut() else {
+            continue;
+        };
+        let Some(Value::String(reasoning_content)) = object.get("reasoning_content").cloned()
+        else {
+            continue;
+        };
+
+        object.insert("thinking".to_string(), Value::String(reasoning_content));
+        if object
+            .get("tool_calls")
+            .and_then(Value::as_array)
+            .is_some_and(|calls| !calls.is_empty())
+        {
+            object.remove("content");
+        }
+    }
+}
+
+fn copy_reasoning_to_thinking(messages: &mut [Value]) {
+    for message in messages {
+        let Some(object) = message.as_object_mut() else {
+            continue;
+        };
+        let Some(Value::String(reasoning_content)) = object.get("reasoning_content").cloned()
+        else {
+            continue;
+        };
+        object.insert("thinking".to_string(), Value::String(reasoning_content));
+    }
+}
+
+fn convert_reasoning_to_ministral_blocks(messages: &mut [Value]) {
+    for message in messages {
+        let Some(object) = message.as_object_mut() else {
+            continue;
+        };
+        let role = object.get("role").and_then(Value::as_str);
+        if !matches!(role, Some("system" | "assistant")) {
+            continue;
+        }
+
+        let mut content = Vec::new();
+        if let Some(Value::String(reasoning_content)) = object.get("reasoning_content") {
+            content.push(json!({
+                "type": "thinking",
+                "thinking": reasoning_content,
+            }));
+        }
+
+        match object.get("content") {
+            Some(Value::String(text)) => {
+                content.push(json!({
+                    "type": "text",
+                    "text": text,
+                }));
+            }
+            Some(Value::Array(blocks)) => content.extend(blocks.iter().cloned()),
+            Some(Value::Null) | None => {}
+            Some(value) => {
+                content.push(json!({
+                    "type": "text",
+                    "text": value.to_string(),
+                }));
+            }
+        }
+
+        object.insert("content".to_string(), Value::Array(content));
+        object.remove("reasoning_content");
+    }
+}
+
+fn convert_tool_responses_gemma4(messages: &mut Vec<Value>) {
+    let mut result = Vec::with_capacity(messages.len());
+    let mut index = 0;
+
+    while index < messages.len() {
+        let message = &messages[index];
+        if message.get("role").and_then(Value::as_str) != Some("assistant")
+            || message
+                .get("tool_calls")
+                .and_then(Value::as_array)
+                .is_none_or(|calls| calls.is_empty())
+        {
+            result.push(message.clone());
+            index += 1;
+            continue;
+        }
+
+        let (built, next_index) = build_gemma4_model_turn(messages, index);
+        result.push(built);
+        index = next_index;
+    }
+
+    *messages = result;
+}
+
+fn build_gemma4_model_turn(messages: &[Value], start: usize) -> (Value, usize) {
+    let mut index = start;
+    let first = &messages[index];
+    let tool_calls = first
+        .get("tool_calls")
+        .cloned()
+        .unwrap_or_else(|| Value::Array(Vec::new()));
+    let reasoning_content = first.get("reasoning_content").cloned();
+    let tool_call_names = tool_calls
+        .as_array()
+        .map(|calls| {
+            calls
+                .iter()
+                .map(|call| {
+                    call.get("function")
+                        .and_then(|function| function.get("name"))
+                        .and_then(Value::as_str)
+                        .unwrap_or_default()
+                        .to_string()
+                })
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    index += 1;
+
+    let mut tool_responses = Vec::new();
+    while index < messages.len()
+        && messages[index].get("role").and_then(Value::as_str) == Some("tool")
+    {
+        let tool_message = &messages[index];
+        let response = parse_gemma4_tool_response_content(tool_message.get("content"));
+        let response_index = tool_responses.len();
+        let name = tool_call_names
+            .get(response_index)
+            .filter(|name| !name.is_empty())
+            .cloned()
+            .or_else(|| {
+                tool_message
+                    .get("tool_call_id")
+                    .and_then(Value::as_str)
+                    .map(ToOwned::to_owned)
+            })
+            .unwrap_or_default();
+        tool_responses.push(json!({
+            "name": name,
+            "response": response,
+        }));
+        index += 1;
+    }
+
+    let mut content = None;
+    if index < messages.len()
+        && messages[index].get("role").and_then(Value::as_str) == Some("assistant")
+        && messages[index]
+            .get("tool_calls")
+            .and_then(Value::as_array)
+            .is_none_or(|calls| calls.is_empty())
+        && has_gemma4_content(&messages[index])
+    {
+        content = messages[index].get("content").cloned();
+        index += 1;
+    }
+
+    let mut object = Map::new();
+    object.insert("role".to_string(), Value::String("assistant".to_string()));
+    object.insert("tool_calls".to_string(), tool_calls);
+    if !tool_responses.is_empty() {
+        object.insert("tool_responses".to_string(), Value::Array(tool_responses));
+    }
+    if let Some(content) = content {
+        object.insert("content".to_string(), content);
+    }
+    if let Some(reasoning_content) = reasoning_content {
+        object.insert("reasoning_content".to_string(), reasoning_content);
+    }
+
+    (Value::Object(object), index)
+}
+
+fn parse_gemma4_tool_response_content(content: Option<&Value>) -> Value {
+    match content {
+        Some(Value::String(text)) => {
+            serde_json::from_str::<Value>(text).unwrap_or_else(|_| Value::String(text.clone()))
+        }
+        Some(value) => value.clone(),
+        None => Value::Null,
+    }
+}
+
+fn has_gemma4_content(message: &Value) -> bool {
+    match message.get("content") {
+        Some(Value::String(text)) => !text.is_empty(),
+        Some(Value::Array(items)) => !items.is_empty(),
+        Some(Value::Null) | None => false,
+        Some(_) => true,
+    }
+}
+
+fn append_message(
+    values: &mut Vec<ServerChatMessage>,
+    message: &ChatMessage,
+) -> Result<(), LlamaCppProviderError> {
+    match &message.message_type {
+        MessageType::ToolResult(tool_results) => {
+            values.extend(tool_results.iter().map(tool_result_message));
+        }
+        MessageType::ToolUse(tool_calls) => {
+            let mut msg = base_message(message);
+            msg.role = "assistant".to_string();
+            msg.tool_calls = tool_calls
+                .iter()
+                .map(server_tool_call_from_tool_call)
+                .collect::<Result<Vec<_>, _>>()?;
+            values.push(msg);
+        }
+        MessageType::Image(_) => {
+            let mut msg = base_message(message);
+            append_text_and_media_marker(&mut msg, &message.content, "<image>");
+            values.push(msg);
+        }
+        MessageType::ImageURL(url) => {
+            let mut msg = base_message(message);
+            append_text_and_media_marker(&mut msg, &message.content, url);
+            values.push(msg);
+        }
+        MessageType::Pdf(_) => {
+            let mut msg = base_message(message);
+            append_text_and_media_marker(&mut msg, &message.content, "<pdf>");
+            values.push(msg);
+        }
+        MessageType::Text => values.push(base_message(message)),
+    }
+
+    Ok(())
+}
+
+fn base_message(message: &ChatMessage) -> ServerChatMessage {
+    let role = match message.role {
+        ChatRole::System => "system",
+        ChatRole::User => "user",
+        ChatRole::Assistant => "assistant",
+        ChatRole::Tool => "tool",
+    };
+    let mut msg = ServerChatMessage::empty(role);
+    if matches!(
+        message.message_type,
+        MessageType::Text | MessageType::ToolUse(_)
+    ) {
+        msg.content = message.content.clone();
+    }
+    msg
+}
+
+fn append_text_and_media_marker(msg: &mut ServerChatMessage, text: &str, marker: &str) {
+    if !text.is_empty() {
+        msg.content_parts.push(ServerChatContentPart {
+            part_type: "text".to_string(),
+            text: text.to_string(),
+        });
+    }
+    msg.content_parts.push(ServerChatContentPart {
+        part_type: "media_marker".to_string(),
+        text: marker.to_string(),
+    });
+}
+
+fn tool_result_message(tool_call: &ToolCall) -> ServerChatMessage {
+    let mut msg = ServerChatMessage::empty("tool");
+    msg.content = tool_call.function.arguments.clone();
+    msg.tool_call_id = tool_call.id.clone();
+    msg
+}
+
+fn server_tool_call_from_tool_call(
+    tool_call: &ToolCall,
+) -> Result<ServerChatToolCall, LlamaCppProviderError> {
+    if tool_call.call_type != "function" {
+        return Err(LlamaCppProviderError::Template(format!(
+            "Unsupported tool call type: {}",
+            tool_call.call_type
+        )));
+    }
+    if tool_call.function.name.trim().is_empty() {
+        return Err(LlamaCppProviderError::Template(
+            "Missing tool call name".to_string(),
+        ));
+    }
+    Ok(ServerChatToolCall {
+        name: tool_call.function.name.clone(),
+        arguments: normalize_function_arguments(&tool_call.function)?,
+        id: tool_call.id.clone(),
+    })
+}
+
+fn normalize_function_arguments(function: &FunctionCall) -> Result<String, LlamaCppProviderError> {
+    let arguments = function.arguments.trim();
+    if arguments.is_empty() {
+        return Ok("{}".to_string());
+    }
+    if serde_json::from_str::<Value>(arguments).is_err() {
+        return Err(LlamaCppProviderError::Template(format!(
+            "Tool call arguments for `{}` are not valid JSON",
+            function.name
+        )));
+    }
+    Ok(arguments.to_string())
+}
+
+fn merge_unsupported_system_messages(messages: &mut Vec<Value>) {
+    if messages
+        .first()
+        .and_then(|message| message.get("role"))
+        .and_then(Value::as_str)
+        != Some("system")
+    {
+        return;
+    }
+
+    let system = messages.remove(0);
+    let Some(system_text) = stringify_content(system.get("content")) else {
+        return;
+    };
+    if system_text.is_empty() {
+        return;
+    }
+    if let Some(first) = messages.first_mut()
+        && first.get("role").and_then(Value::as_str) != Some("system")
+        && let Some(object) = first.as_object_mut()
+    {
+        let existing = stringify_content(object.get("content")).unwrap_or_default();
+        let content = if existing.is_empty() {
+            system_text
+        } else {
+            format!("{system_text}\n{existing}")
+        };
+        object.insert("content".to_string(), Value::String(content));
+    }
+}
+
+fn require_non_null_content(messages: &mut [Value]) {
+    for message in messages {
+        if let Some(object) = message.as_object_mut()
+            && object
+                .get("tool_calls")
+                .and_then(Value::as_array)
+                .is_some_and(|calls| !calls.is_empty())
+            && !object.contains_key("content")
+        {
+            object.insert("content".to_string(), Value::String(String::new()));
+        }
+    }
+}
+
+fn convert_function_arguments_to_objects(
+    messages: &mut [Value],
+) -> Result<(), LlamaCppProviderError> {
+    for message in messages {
+        let Some(calls) = message
+            .as_object_mut()
+            .and_then(|object| object.get_mut("tool_calls"))
+            .and_then(Value::as_array_mut)
+        else {
+            continue;
+        };
+
+        for call in calls {
+            let Some(arguments) = call
+                .get_mut("function")
+                .and_then(Value::as_object_mut)
+                .and_then(|function| function.get_mut("arguments"))
+            else {
+                continue;
+            };
+            if let Some(argument_text) = arguments.as_str() {
+                *arguments = serde_json::from_str::<Value>(argument_text).map_err(|err| {
+                    LlamaCppProviderError::Template(format!(
+                        "Failed to parse tool call arguments as JSON: {err}"
+                    ))
+                })?;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn stringify_content(value: Option<&Value>) -> Option<String> {
+    match value {
+        Some(Value::String(text)) => Some(text.clone()),
+        Some(Value::Array(parts)) => {
+            let text = parts
+                .iter()
+                .filter_map(|part| part.get("text").and_then(Value::as_str))
+                .collect::<Vec<_>>()
+                .join("\n\n");
+            Some(text)
+        }
+        Some(Value::Null) | None => None,
+        Some(value) => Some(value.to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use autoagents_llm::FunctionCall;
+
+    fn tool_call() -> ToolCall {
+        ToolCall {
+            id: "call_1".to_string(),
+            call_type: "function".to_string(),
+            function: FunctionCall {
+                name: "lookup".to_string(),
+                arguments: "{\"q\":\"rust\"}".to_string(),
+            },
+        }
+    }
+
+    #[test]
+    fn converts_tool_calls_to_server_messages() {
+        let message = ChatMessage {
+            role: ChatRole::Assistant,
+            message_type: MessageType::ToolUse(vec![tool_call()]),
+            content: String::new(),
+        };
+
+        let messages = messages_from_autoagents(&LlamaCppConfig::default(), &[message])
+            .expect("messages should convert");
+        assert_eq!(messages[0].role, "assistant");
+        assert_eq!(messages[0].tool_calls[0].name, "lookup");
+        assert_eq!(messages[0].tool_calls[0].arguments, "{\"q\":\"rust\"}");
+    }
+
+    #[test]
+    fn omits_empty_tool_call_id_in_openai_compat_json() {
+        let message = ServerChatMessage {
+            role: "assistant".to_string(),
+            content: String::new(),
+            content_parts: Vec::new(),
+            tool_calls: vec![ServerChatToolCall {
+                name: "lookup".to_string(),
+                arguments: "{}".to_string(),
+                id: String::new(),
+            }],
+            reasoning_content: String::new(),
+            tool_name: String::new(),
+            tool_call_id: String::new(),
+        };
+
+        let value = message.to_json_oaicompat(false);
+
+        assert_eq!(value["content"], "");
+        assert!(value["tool_calls"][0].get("id").is_none());
+    }
+
+    #[test]
+    fn empty_message_content_defaults_to_empty_string() {
+        let message = ServerChatMessage::empty("assistant");
+
+        let value = message.to_json_oaicompat(false);
+
+        assert_eq!(value["content"], "");
+    }
+
+    #[test]
+    fn renders_caps_driven_typed_or_string_content() {
+        let message = ChatMessage {
+            role: ChatRole::User,
+            message_type: MessageType::ImageURL("<image>".to_string()),
+            content: "caption".to_string(),
+        };
+        let messages = messages_from_autoagents(&LlamaCppConfig::default(), &[message])
+            .expect("messages should convert");
+
+        let typed = render_messages_to_json(
+            &messages,
+            ServerTemplateCaps {
+                supports_string_content: false,
+                supports_typed_content: true,
+                ..Default::default()
+            },
+        );
+        assert!(typed[0]["content"].is_array());
+        assert_eq!(typed[0]["content"][0]["type"], "text");
+        assert_eq!(typed[0]["content"][0]["text"], "caption<image>");
+
+        let string = render_messages_to_json(
+            &messages,
+            ServerTemplateCaps {
+                supports_string_content: true,
+                supports_typed_content: false,
+                ..Default::default()
+            },
+        );
+        assert_eq!(string[0]["content"], "caption<image>");
+    }
+
+    #[test]
+    fn text_only_parts_can_render_as_typed_content() {
+        let message = ServerChatMessage {
+            role: "user".to_string(),
+            content: String::new(),
+            content_parts: vec![ServerChatContentPart {
+                part_type: "text".to_string(),
+                text: "caption".to_string(),
+            }],
+            tool_calls: Vec::new(),
+            reasoning_content: String::new(),
+            tool_name: String::new(),
+            tool_call_id: String::new(),
+        };
+
+        let typed = render_messages_to_json(
+            &[message],
+            ServerTemplateCaps {
+                supports_string_content: false,
+                supports_typed_content: true,
+                ..Default::default()
+            },
+        );
+
+        assert!(typed[0]["content"].is_array());
+        assert_eq!(typed[0]["content"][0]["type"], "text");
+        assert_eq!(typed[0]["content"][0]["text"], "caption");
+    }
+
+    #[test]
+    fn applies_server_tool_workarounds() {
+        let mut messages = vec![json!({
+            "role": "assistant",
+            "tool_calls": [{
+                "id": "call_1",
+                "type": "function",
+                "function": {
+                    "name": "lookup",
+                    "arguments": "{\"q\":\"rust\"}"
+                }
+            }]
+        })];
+
+        apply_server_workarounds(
+            &mut messages,
+            ServerTemplateCaps {
+                supports_tool_calls: true,
+                supports_object_arguments: true,
+                ..Default::default()
+            },
+        )
+        .expect("server workarounds should apply");
+
+        assert_eq!(messages[0]["content"], "");
+        assert_eq!(
+            messages[0]["tool_calls"][0]["function"]["arguments"]["q"],
+            "rust"
+        );
+    }
+
+    #[test]
+    fn object_argument_workaround_rejects_invalid_json_arguments() {
+        let mut messages = vec![json!({
+            "role": "assistant",
+            "tool_calls": [{
+                "type": "function",
+                "function": {
+                    "name": "lookup",
+                    "arguments": "{bad"
+                }
+            }]
+        })];
+
+        let err = apply_server_workarounds(
+            &mut messages,
+            ServerTemplateCaps {
+                supports_object_arguments: true,
+                ..Default::default()
+            },
+        )
+        .expect_err("invalid object arguments should match server failure");
+
+        assert!(
+            err.to_string()
+                .contains("Failed to parse tool call arguments as JSON")
+        );
+    }
+
+    #[test]
+    fn tool_content_workaround_only_applies_to_tool_call_messages() {
+        let mut messages = vec![
+            json!({
+                "role": "assistant",
+                "content": null,
+            }),
+            json!({
+                "role": "assistant",
+                "content": null,
+                "tool_calls": [{
+                    "type": "function",
+                    "function": {
+                        "name": "lookup",
+                        "arguments": "{}"
+                    }
+                }]
+            }),
+            json!({
+                "role": "assistant",
+                "tool_calls": [{
+                    "type": "function",
+                    "function": {
+                        "name": "lookup",
+                        "arguments": "{}"
+                    }
+                }]
+            }),
+        ];
+
+        apply_server_workarounds(
+            &mut messages,
+            ServerTemplateCaps {
+                supports_tool_calls: true,
+                ..Default::default()
+            },
+        )
+        .expect("server workarounds should apply");
+
+        assert!(messages[0]["content"].is_null());
+        assert!(messages[1]["content"].is_null());
+        assert_eq!(messages[2]["content"], "");
+    }
+
+    #[test]
+    fn gpt_oss_reasoning_workaround_sets_thinking_and_removes_tool_content() {
+        let mut messages = vec![json!({
+            "role": "assistant",
+            "content": "",
+            "reasoning_content": "think",
+            "tool_calls": [{
+                "type": "function",
+                "function": {
+                    "name": "lookup",
+                    "arguments": "{}"
+                }
+            }]
+        })];
+
+        apply_server_workarounds(
+            &mut messages,
+            ServerTemplateCaps {
+                gpt_oss_reasoning_compat: true,
+                ..Default::default()
+            },
+        )
+        .expect("server workarounds should apply");
+
+        assert_eq!(messages[0]["thinking"], "think");
+        assert!(messages[0].get("content").is_none());
+        assert_eq!(messages[0]["reasoning_content"], "think");
+    }
+
+    #[test]
+    fn lfm2_reasoning_workaround_sets_thinking() {
+        let mut messages = vec![json!({
+            "role": "assistant",
+            "content": "answer",
+            "reasoning_content": "think",
+        })];
+
+        apply_server_workarounds(
+            &mut messages,
+            ServerTemplateCaps {
+                lfm2_reasoning_compat: true,
+                ..Default::default()
+            },
+        )
+        .expect("server workarounds should apply");
+
+        assert_eq!(messages[0]["thinking"], "think");
+        assert_eq!(messages[0]["reasoning_content"], "think");
+        assert_eq!(messages[0]["content"], "answer");
+    }
+
+    #[test]
+    fn ministral_reasoning_workaround_converts_content_blocks() {
+        let mut messages = vec![
+            json!({
+                "role": "assistant",
+                "content": "answer",
+                "reasoning_content": "think",
+            }),
+            json!({
+                "role": "user",
+                "content": "question",
+                "reasoning_content": "ignored",
+            }),
+        ];
+
+        apply_server_workarounds(
+            &mut messages,
+            ServerTemplateCaps {
+                ministral_reasoning_blocks_compat: true,
+                ..Default::default()
+            },
+        )
+        .expect("server workarounds should apply");
+
+        assert_eq!(messages[0]["content"][0]["type"], "thinking");
+        assert_eq!(messages[0]["content"][0]["thinking"], "think");
+        assert_eq!(messages[0]["content"][1]["type"], "text");
+        assert_eq!(messages[0]["content"][1]["text"], "answer");
+        assert!(messages[0].get("reasoning_content").is_none());
+        assert_eq!(messages[1]["content"], "question");
+        assert_eq!(messages[1]["reasoning_content"], "ignored");
+    }
+
+    #[test]
+    fn merges_only_leading_system_message_when_system_role_is_unsupported() {
+        let mut messages = vec![
+            json!({
+                "role": "system",
+                "content": "policy"
+            }),
+            json!({
+                "role": "user",
+                "content": "question"
+            }),
+            json!({
+                "role": "system",
+                "content": "later"
+            }),
+        ];
+
+        apply_server_workarounds(
+            &mut messages,
+            ServerTemplateCaps {
+                supports_system_role: false,
+                ..Default::default()
+            },
+        )
+        .expect("server workarounds should apply");
+
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages[0]["role"], "user");
+        assert_eq!(messages[0]["content"], "policy\nquestion");
+        assert_eq!(messages[1]["role"], "system");
+    }
+
+    #[test]
+    fn converts_old_gemma4_tool_responses_into_model_turn() {
+        let mut messages = vec![
+            json!({
+                "role": "assistant",
+                "reasoning_content": "think",
+                "tool_calls": [{
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {
+                        "name": "lookup",
+                        "arguments": "{\"q\":\"rust\"}"
+                    }
+                }]
+            }),
+            json!({
+                "role": "tool",
+                "tool_call_id": "call_1",
+                "content": "{\"result\":\"ok\"}"
+            }),
+            json!({
+                "role": "assistant",
+                "content": "done"
+            }),
+        ];
+
+        apply_server_workarounds(
+            &mut messages,
+            ServerTemplateCaps {
+                gemma4_tool_response_compat: true,
+                ..Default::default()
+            },
+        )
+        .expect("server workarounds should apply");
+
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0]["role"], "assistant");
+        assert_eq!(messages[0]["reasoning_content"], "think");
+        assert_eq!(messages[0]["content"], "done");
+        assert_eq!(messages[0]["tool_responses"][0]["name"], "lookup");
+        assert_eq!(messages[0]["tool_responses"][0]["response"]["result"], "ok");
+    }
+}

--- a/crates/autoagents-mistral-rs/Cargo.toml
+++ b/crates/autoagents-mistral-rs/Cargo.toml
@@ -21,7 +21,7 @@ ring = ["mistralrs/ring"]
 
 [dependencies]
 autoagents-llm = { workspace = true }
-mistralrs = "0.7.0"
+mistralrs = "0.8.1"
 async-trait = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/autoagents-mistral-rs/src/conversion.rs
+++ b/crates/autoagents-mistral-rs/src/conversion.rs
@@ -2,7 +2,7 @@
 
 use autoagents_llm::chat::{ChatMessage, ChatRole, MessageType};
 use autoagents_llm::{FunctionCall, ToolCall};
-use mistralrs::{TextMessageRole, TextMessages, ToolCallResponse, VisionMessages};
+use mistralrs::{MultimodalMessages, TextMessageRole, TextMessages, ToolCallResponse};
 use std::fmt;
 
 /// Response wrapper that implements ChatResponse trait
@@ -115,9 +115,8 @@ pub(crate) fn convert_messages(messages: &[ChatMessage]) -> TextMessages {
 /// Note: This function needs access to the model for proper image message handling
 pub(crate) fn convert_vision_messages(
     messages: &[ChatMessage],
-    model: &mistralrs::Model,
-) -> Result<VisionMessages, anyhow::Error> {
-    let mut vision_messages = VisionMessages::new();
+) -> Result<MultimodalMessages, anyhow::Error> {
+    let mut vision_messages = MultimodalMessages::new();
 
     for msg in messages {
         let role = convert_role(&msg.role);
@@ -135,7 +134,7 @@ pub(crate) fn convert_vision_messages(
 
                 // Add message with image
                 vision_messages =
-                    vision_messages.add_image_message(role, &msg.content, vec![image], model)?;
+                    vision_messages.add_image_message(role, &msg.content, vec![image]);
             }
             MessageType::ImageURL(_url) => {
                 // For now, just add as text message

--- a/crates/autoagents-mistral-rs/src/error.rs
+++ b/crates/autoagents-mistral-rs/src/error.rs
@@ -47,8 +47,8 @@ impl From<MistralRsError> for LLMError {
     }
 }
 
-/// Convert anyhow::Error to LLMError
-pub(crate) fn convert_anyhow_error(err: anyhow::Error) -> LLMError {
+/// Convert mistral.rs-compatible errors to LLMError
+pub(crate) fn convert_anyhow_error(err: impl std::fmt::Display) -> LLMError {
     LLMError::ProviderError(format!("Mistral.rs error: {}", err))
 }
 

--- a/crates/autoagents-mistral-rs/src/provider.rs
+++ b/crates/autoagents-mistral-rs/src/provider.rs
@@ -22,9 +22,9 @@ use autoagents_llm::{
 use futures::{StreamExt, stream::Stream};
 use mistralrs::{
     CalledFunction, ChatCompletionChunkResponse, ChatCompletionResponse, ChunkChoice, Constraint,
-    Function, GgufModelBuilder, IsqType, PagedAttentionMetaBuilder, RequestBuilder, Response,
-    TextMessageRole, TextModelBuilder, ToolCallResponse, ToolCallType,
-    ToolChoice as MistralToolChoice, ToolType, Usage as MistralUsage, VisionModelBuilder,
+    Function, GgufModelBuilder, IsqType, MultimodalModelBuilder, PagedAttentionMetaBuilder,
+    RequestBuilder, Response, TextMessageRole, TextModelBuilder, ToolCallResponse, ToolCallType,
+    ToolChoice as MistralToolChoice, ToolType, Usage as MistralUsage,
 };
 use std::sync::OnceLock;
 use std::{
@@ -138,9 +138,10 @@ impl MistralRsProvider {
 
         // Apply paged attention if enabled
         if config.paged_attention {
-            builder = builder
-                .with_paged_attn(|| PagedAttentionMetaBuilder::default().build())
+            let paged_attention = PagedAttentionMetaBuilder::default()
+                .build()
                 .map_err(convert_anyhow_error)?;
+            builder = builder.with_paged_attn(paged_attention);
         }
 
         // Apply logging if enabled
@@ -157,7 +158,7 @@ impl MistralRsProvider {
         repo_id: &str,
         config: &MistralRsConfig,
     ) -> Result<mistralrs::Model, LLMError> {
-        let mut builder = VisionModelBuilder::new(repo_id.to_string());
+        let mut builder = MultimodalModelBuilder::new(repo_id.to_string());
 
         // Apply ISQ if specified
         if let Some(isq) = config.isq_type {
@@ -195,9 +196,10 @@ impl MistralRsProvider {
 
         // Apply paged attention if enabled
         if config.paged_attention {
-            builder = builder
-                .with_paged_attn(|| PagedAttentionMetaBuilder::default().build())
+            let paged_attention = PagedAttentionMetaBuilder::default()
+                .build()
                 .map_err(convert_anyhow_error)?;
+            builder = builder.with_paged_attn(paged_attention);
         }
 
         // Apply logging if enabled
@@ -254,8 +256,8 @@ impl MistralRsProvider {
         let request_builder = if tools.is_some() || json_schema.is_some() {
             build_request_builder(&all_messages, tools, json_schema)?
         } else if is_vision_model || has_images {
-            let vision_messages = convert_vision_messages(&all_messages, &self.model)
-                .map_err(convert_anyhow_error)?;
+            let vision_messages =
+                convert_vision_messages(&all_messages).map_err(convert_anyhow_error)?;
             RequestBuilder::from(vision_messages)
         } else {
             let text_messages = convert_messages(&all_messages);
@@ -868,8 +870,8 @@ impl ChatProvider for MistralRsProvider {
                 .map_err(convert_anyhow_error)?
         } else if is_vision_model || has_images {
             // Use vision messages for vision models or when images are present
-            let vision_messages = convert_vision_messages(&all_messages, &self.model)
-                .map_err(convert_anyhow_error)?;
+            let vision_messages =
+                convert_vision_messages(&all_messages).map_err(convert_anyhow_error)?;
             self.model
                 .send_chat_request(vision_messages)
                 .await

--- a/examples/llamacpp_agent/src/main.rs
+++ b/examples/llamacpp_agent/src/main.rs
@@ -60,8 +60,7 @@ struct MathAgentOutput {
 impl From<ReActAgentOutput> for MathAgentOutput {
     fn from(output: ReActAgentOutput) -> Self {
         let resp = output.response;
-        if output.done
-            && !resp.trim().is_empty()
+        if !resp.trim().is_empty()
             && let Ok(value) = serde_json::from_str::<MathAgentOutput>(&resp)
         {
             return value;
@@ -72,6 +71,15 @@ impl From<ReActAgentOutput> for MathAgentOutput {
             generic: None,
         }
     }
+}
+
+fn is_empty_stream_placeholder(output: &MathAgentOutput) -> bool {
+    output.value == 0
+        && output.explanation.trim().is_empty()
+        && output
+            .generic
+            .as_deref()
+            .is_none_or(|generic| generic.trim().is_empty())
 }
 
 #[derive(Serialize, Deserialize, ToolInput, Debug)]
@@ -114,29 +122,19 @@ async fn main() -> Result<(), Error> {
     init_logging();
     let args = Args::parse();
 
-    let effective_max_tokens = if args.thinking {
-        args.max_tokens.max(1024)
-    } else {
-        args.max_tokens
-    };
-
     let mut builder = LlamaCppProvider::builder()
         .model_source(ModelSource::HuggingFace {
             repo_id: "unsloth/Qwen3.5-9B-GGUF".to_string(),
-            filename: Some("Qwen3.5-9B-Q4_0.gguf".to_string()),
+            filename: Some("Qwen3.5-9B-Q4_K_M.gguf".to_string()),
             mmproj_filename: None,
         })
-        .max_tokens(effective_max_tokens)
+        .max_tokens(args.max_tokens)
         .temperature(args.temperature);
 
     if args.thinking {
         builder = builder
             .reasoning_format(LlamaCppReasoningFormat::Auto)
-            .extra_body(serde_json::json!({
-                "chat_template_kwargs": {
-                    "enable_thinking": true
-                }
-            }));
+            .enable_thinking(true);
     }
 
     if let Some(template) = args.chat_template {
@@ -175,24 +173,30 @@ async fn main() -> Result<(), Error> {
         let mut events_done = false;
         let mut saw_reasoning_event = false;
         let mut saw_text_event = false;
+        let mut last_stream_output = None::<String>;
+        let mut reasoning_output = String::new();
+        let mut last_tool_result = None::<Value>;
 
         println!("Running run_stream() and reading reasoning from events");
-        if effective_max_tokens > args.max_tokens {
-            println!(
-                "thinking mode enabled: increasing max_tokens from {} to {}",
-                args.max_tokens, effective_max_tokens
-            );
-        }
         while !(stream_done && events_done) {
             select! {
                 item = stream.next(), if !stream_done => {
                     match item {
                         Some(Ok(output)) => {
-                            print!("{:?}", output);
+                            if is_empty_stream_placeholder(&output) {
+                                continue;
+                            }
+                            let rendered = format!("{output:?}");
+                            if last_stream_output.as_deref() == Some(rendered.as_str()) {
+                                continue;
+                            }
+                            println!("{rendered}");
+                            last_stream_output = Some(rendered);
                         }
                         Some(Err(err)) => {
                             println!("stream error: {err}");
                             stream_done = true;
+                            events_done = true;
                         }
                         None => {
                             stream_done = true;
@@ -202,18 +206,27 @@ async fn main() -> Result<(), Error> {
                 event = event_stream.next(), if !events_done => {
                     match event {
                         Some(Event::StreamChunk { chunk, .. }) => match chunk {
-                            StreamChunk::ReasoningContent(content) if !content.is_empty() => {
-                                saw_reasoning_event = true;
-                                println!("\nreasoning event: {content}");
+                            StreamChunk::ReasoningContent(content) => {
+                                if !content.is_empty() {
+                                    saw_reasoning_event = true;
+                                    reasoning_output.push_str(&content);
+                                    println!("\nreasoning event: {content}");
+                                }
                             }
-                            StreamChunk::Text(content) if !content.is_empty() => {
-                                saw_text_event = true;
-                                println!("\ntext event: {content}");
+                            StreamChunk::Text(content) => {
+                                if !content.is_empty() {
+                                    saw_text_event = true;
+                                    println!("\ntext event: {content}");
+                                }
                             }
                             _ => {}
                         },
                         Some(Event::StreamComplete { .. }) => {
                             events_done = true;
+                        }
+                        Some(Event::ToolCallCompleted { result, .. }) => {
+                            println!("\ntool result: {result}");
+                            last_tool_result = Some(result);
                         }
                         Some(_) => {}
                         None => {
@@ -225,9 +238,25 @@ async fn main() -> Result<(), Error> {
         }
 
         if !saw_reasoning_event {
+            if let Some(value) = last_tool_result.as_ref().and_then(|value| value.as_i64()) {
+                let output = MathAgentOutput {
+                    value,
+                    explanation: "Tool result returned without a reasoning event.".to_string(),
+                    generic: None,
+                };
+                println!("\nResult: {output:?}");
+            }
             println!("\nnote: no reasoning_content events were emitted by this model/provider.");
         }
         if saw_reasoning_event && !saw_text_event {
+            if let Some(value) = last_tool_result.as_ref().and_then(|value| value.as_i64()) {
+                let output = MathAgentOutput {
+                    value,
+                    explanation: reasoning_output.trim().to_string(),
+                    generic: None,
+                };
+                println!("\nResult: {output:?}");
+            }
             println!(
                 "\nnote: reasoning streamed, but no text chunks were emitted. \
 this usually means the model used all generation tokens in thinking mode."
@@ -251,9 +280,18 @@ this usually means the model used all generation tokens in thinking mode."
     println!("🌊 Agent Streaming Example");
     println!("🔄 Processing stream tokens...\n");
 
+    let mut last_stream_output = None::<String>;
     while let Some(result) = stream.next().await {
         if let Ok(output) = result {
-            print!("{:?}", output);
+            if is_empty_stream_placeholder(&output) {
+                continue;
+            }
+            let rendered = format!("{output:?}");
+            if last_stream_output.as_deref() == Some(rendered.as_str()) {
+                continue;
+            }
+            println!("{rendered}");
+            last_stream_output = Some(rendered);
         }
     }
 

--- a/examples/llamacpp_agent/src/main.rs
+++ b/examples/llamacpp_agent/src/main.rs
@@ -206,18 +206,14 @@ async fn main() -> Result<(), Error> {
                 event = event_stream.next(), if !events_done => {
                     match event {
                         Some(Event::StreamChunk { chunk, .. }) => match chunk {
-                            StreamChunk::ReasoningContent(content) => {
-                                if !content.is_empty() {
-                                    saw_reasoning_event = true;
-                                    reasoning_output.push_str(&content);
-                                    println!("\nreasoning event: {content}");
-                                }
+                            StreamChunk::ReasoningContent(content) if !content.is_empty() => {
+                                saw_reasoning_event = true;
+                                reasoning_output.push_str(&content);
+                                println!("\nreasoning event: {content}");
                             }
-                            StreamChunk::Text(content) => {
-                                if !content.is_empty() {
-                                    saw_text_event = true;
-                                    println!("\ntext event: {content}");
-                                }
+                            StreamChunk::Text(content) if !content.is_empty() => {
+                                saw_text_event = true;
+                                println!("\ntext event: {content}");
                             }
                             _ => {}
                         },


### PR DESCRIPTION
<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR upgrades the llama.cpp and mistral-rs integrations. The main changes are:

- Updated llama.cpp and mistral-rs dependency versions.
- Added llama.cpp chat template rendering support.
- Expanded llama.cpp builder and config options.
- Updated ReAct streaming output handling for reasoning-only results.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| crates/autoagents-llamacpp/src/chat_template.rs | Adds chat template rendering with explicit generation-prompt, continuation, tool, grammar, and pure-content handling. |
| crates/autoagents-llamacpp/src/builder.rs | Adds builder methods for the expanded llama.cpp configuration surface. |
| crates/autoagents-core/src/agent/prebuilt/executor/react.rs | Preserves reasoning-only final content in streamed ReAct agent output. |
| Cargo.lock | Updates locked llama.cpp, mistral-rs, candle, and related transitive dependencies. |

<sub>Reviews (6): Last reviewed commit: ["\[REFACTOR\]: Upgrade llamacpp and mistral..."](https://github.com/liquidos-ai/autoagents/commit/b2f75cd7810494f7a1edbbeaa7bcb52d2d26ab8f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42839380)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - AGENTS.md ([source](https://app.greptile.com/liquidos/github/liquidos-ai/autoagents/-/custom-context?memory=3016560d-8393-46c9-8b28-32dd4efbbe2e))
- Context used - CLAUDE.md ([source](https://app.greptile.com/liquidos/github/liquidos-ai/autoagents/-/custom-context?memory=b47666cb-3593-419b-8e94-f613c4c4a23c))
- Context used - docs/content/core-concepts/agents.md ([source](https://app.greptile.com/liquidos/github/liquidos-ai/autoagents/-/custom-context?memory=ee5ee7f3-1bae-40fc-ab9a-3cfb1dc16d60))
</details>

<!-- /greptile_comment -->