### PR TITLE
test: update invalid strict trybuild snapshot

### DIFF
--- a/crates/autoagents-derive/tests/ui/compile_fail/invalid_strict.stderr
+++ b/crates/autoagents-derive/tests/ui/compile_fail/invalid_strict.stderr
@@ -2,4 +2,4 @@ error: `#[strict]` on AgentOutput structs must be a boolean literal, e.g. `#[str
  --> tests/ui/compile_fail/invalid_strict.rs:7:1
   |
 7 | #[strict("not-a-bool")]
-  | ^
+  | ^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
## Summary

Updates the trybuild expected stderr snapshot for `invalid_strict.rs`.

The compile error message is unchanged, but the diagnostic span now highlights the full `#[strict("not-a-bool")]` attribute instead of only the first character.

## Testing

```bash
TRYBUILD=overwrite cargo test -p autoagents-derive --test ui
cargo test -p autoagents-derive --test ui
cargo test --all-features
```

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the trybuild snapshot for the `invalid_strict` compile-fail test to match a change in Rust compiler diagnostic span output. No functional code changes are included.

- The `invalid_strict.stderr` snapshot is updated so the caret span now underlines the full `#[strict("not-a-bool")]` attribute (23 characters) instead of only its first character, reflecting an improvement in compiler diagnostic precision.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the only change is a one-line update to a trybuild snapshot file to match the updated compiler diagnostic span.

The change touches a single snapshot file, updating the caret underline from one character to the full 23-character width of the `#[strict("not-a-bool")]` attribute. The error message and file location are unchanged. No production code, macros, or test logic are modified.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| crates/autoagents-derive/tests/ui/compile_fail/invalid_strict.stderr | Snapshot updated: caret underline extended from 1 character to 23 characters to cover the full `#[strict("not-a-bool")]` attribute span; error message and location are unchanged. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[invalid_strict.rs] --> B[Rust compiler emits error with span]
    B --> C[Before this PR: span highlights only first char]
    B --> D[After this PR: span highlights full attribute]
    C --> E["^ single caret"]
    D --> F["^^^^^^^^^^^^^^^^^^^^^^^ full underline"]
    F --> G[invalid_strict.stderr snapshot updated]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[invalid_strict.rs] --> B[Rust compiler emits error with span]
    B --> C[Before this PR: span highlights only first char]
    B --> D[After this PR: span highlights full attribute]
    C --> E["^ single caret"]
    D --> F["^^^^^^^^^^^^^^^^^^^^^^^ full underline"]
    F --> G[invalid_strict.stderr snapshot updated]
```

</a>

<sub>Reviews (1): Last reviewed commit: ["test: update invalid strict trybuild sna..."](https://github.com/liquidos-ai/autoagents/commit/b40972e37e38f9c1ef88cd47a2d339e47d2496cc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45475528)</sub>

<!-- /greptile_comment -->