### PR TITLE
feat(media): add image generation support for Google and OpenRouter

### DIFF
--- a/crates/autoagents-derive/tests/ui/compile_fail/invalid_strict.stderr
+++ b/crates/autoagents-derive/tests/ui/compile_fail/invalid_strict.stderr
@@ -2,4 +2,4 @@ error: `#[strict]` on AgentOutput structs must be a boolean literal, e.g. `#[str
  --> tests/ui/compile_fail/invalid_strict.rs:7:1
   |
 7 | #[strict("not-a-bool")]
-  | ^
+  | ^^^^^^^^^^^^^^^^^^^^^^^

--- a/crates/autoagents-derive/tests/ui/compile_fail/invalid_strict.stderr
+++ b/crates/autoagents-derive/tests/ui/compile_fail/invalid_strict.stderr
@@ -2,4 +2,4 @@ error: `#[strict]` on AgentOutput structs must be a boolean literal, e.g. `#[str
  --> tests/ui/compile_fail/invalid_strict.rs:7:1
   |
 7 | #[strict("not-a-bool")]
-  | ^^^^^^^^^^^^^^^^^^^^^^^
+  | ^

--- a/crates/autoagents-llm/src/backends/google.rs
+++ b/crates/autoagents-llm/src/backends/google.rs
@@ -873,6 +873,16 @@ impl ImageGenerationProvider for Google {
         let mut body = serde_json::to_value(&req_body)?;
         merge_metadata(&mut body, request.metadata.as_ref());
 
+        if let Some(generation_config) = body
+            .get_mut("generationConfig")
+            .and_then(Value::as_object_mut)
+        {
+            generation_config.insert(
+                "responseModalities".to_string(),
+                serde_json::json!(["TEXT", "IMAGE"]),
+            );
+        }
+
         let url = self.model_endpoint_url(model, "generateContent")?;
 
         let resp = self
@@ -1869,6 +1879,58 @@ mod tests {
             LLMError::InvalidRequest { message, .. }
                 if message.contains("image-capable model")
         ));
+    }
+
+    #[tokio::test]
+    async fn test_google_generate_image_preserves_response_modalities_with_metadata_generation_config()
+     {
+        use crate::image_generation::ImageGenerationRequest;
+
+        let server = MockServer::start();
+        let encoded = BASE64.encode([1u8, 2, 3]);
+
+        let mock = server.mock(|when, then| {
+            when.method(POST)
+                .path("/v1beta/models/gemini-test:generateContent")
+                .header(GOOGLE_API_KEY_HEADER, "secret-key")
+                .body_includes("\"aspectRatio\":\"1:1\"")
+                .body_includes("\"responseModalities\":[\"TEXT\",\"IMAGE\"]");
+
+            then.status(200).json_body(json!({
+                "candidates": [{
+                    "content": {
+                        "parts": [{
+                            "inlineData": {
+                                "mimeType": "image/png",
+                                "data": encoded
+                            }
+                        }]
+                    }
+                }]
+            }));
+        });
+
+        let provider = test_google_provider(&server);
+
+        let request = ImageGenerationRequest {
+            prompt: "with generation config metadata".to_string(),
+            model: None,
+            input_images: None,
+            metadata: Some(json!({
+                "generationConfig": {
+                    "aspectRatio": "1:1",
+                    "responseModalities": ["TEXT"]
+                }
+            })),
+        };
+
+        let response = provider
+            .generate_image(&request)
+            .await
+            .expect("image generation should succeed");
+
+        assert_eq!(response.images.len(), 1);
+        mock.assert();
     }
 
     #[tokio::test]

--- a/crates/autoagents-llm/src/backends/google.rs
+++ b/crates/autoagents-llm/src/backends/google.rs
@@ -104,6 +104,7 @@ enum GoogleContentPart<'a> {
 
 #[derive(Serialize)]
 struct GoogleInlineData {
+    #[serde(rename = "mimeType")]
     mime_type: String,
     data: String,
 }
@@ -1638,8 +1639,6 @@ mod tests {
             prompt: "a red apple".to_string(),
             model: None,
             input_images: None,
-            n: None,
-            aspect_ratio: None,
             metadata: None,
         };
 
@@ -1682,8 +1681,6 @@ mod tests {
             prompt: "an override".to_string(),
             model: Some("gemini-image-test".to_string()),
             input_images: None,
-            n: None,
-            aspect_ratio: None,
             metadata: None,
         };
 
@@ -1708,7 +1705,7 @@ mod tests {
                 .header(GOOGLE_API_KEY_HEADER, "secret-key")
                 // The request body should carry the input image as an inlineData part.
                 .body_includes("inlineData")
-                .body_includes("mime_type");
+                .body_includes("mimeType");
             then.status(200).json_body(json!({
                 "candidates": [{
                     "content": {
@@ -1728,8 +1725,6 @@ mod tests {
                 mime_type: "image/png".to_string(),
                 data: vec![0x01, 0x02, 0x03],
             }]),
-            n: None,
-            aspect_ratio: None,
             metadata: None,
         };
 
@@ -1761,8 +1756,6 @@ mod tests {
             prompt: "no key".to_string(),
             model: None,
             input_images: None,
-            n: None,
-            aspect_ratio: None,
             metadata: None,
         };
 
@@ -1797,8 +1790,6 @@ mod tests {
             prompt: "text only".to_string(),
             model: None,
             input_images: None,
-            n: None,
-            aspect_ratio: None,
             metadata: None,
         };
 
@@ -1825,8 +1816,6 @@ mod tests {
             prompt: "   ".to_string(),
             model: None,
             input_images: None,
-            n: None,
-            aspect_ratio: None,
             metadata: None,
         };
 

--- a/crates/autoagents-llm/src/backends/google.rs
+++ b/crates/autoagents-llm/src/backends/google.rs
@@ -27,6 +27,7 @@ use crate::{
     http::ensure_success,
     image_generation::{
         GeneratedImage, ImageGenerationProvider, ImageGenerationRequest, ImageGenerationResponse,
+        merge_metadata,
     },
     models::ModelsProvider,
 };
@@ -40,6 +41,8 @@ use std::sync::Arc;
 
 const DEFAULT_GOOGLE_API_BASE_URL: &str = "https://generativelanguage.googleapis.com";
 const GOOGLE_API_KEY_HEADER: &str = "x-goog-api-key";
+/// Default (text) chat model; cannot generate images.
+const DEFAULT_GOOGLE_MODEL: &str = "gemini-1.5-flash";
 
 /// Client for interacting with Google's Gemini API.
 ///
@@ -479,7 +482,7 @@ impl Google {
             .expect("Failed to build reqwest Client");
         Self {
             api_key: api_key.into(),
-            model: model.unwrap_or_else(|| "gemini-1.5-flash".to_string()),
+            model: model.unwrap_or_else(|| DEFAULT_GOOGLE_MODEL.to_string()),
             max_tokens,
             temperature,
             timeout_seconds,
@@ -837,6 +840,15 @@ impl ImageGenerationProvider for Google {
 
         let model = request.model.as_deref().unwrap_or(&self.model);
 
+        if model == DEFAULT_GOOGLE_MODEL {
+            return Err(LLMError::invalid_request(
+                "Google image generation requires an image-capable model; set request.model \
+                 (e.g. \"gemini-2.5-flash-image\") — the provider default is a text model \
+                 that cannot generate images"
+                    .to_string(),
+            ));
+        }
+
         // Prompt text first, followed by any input images as inline data parts.
         let mut parts: Vec<GoogleContentPart<'_>> = vec![GoogleContentPart::Text(&request.prompt)];
         if let Some(input_images) = &request.input_images {
@@ -858,13 +870,16 @@ impl ImageGenerationProvider for Google {
             },
         };
 
+        let mut body = serde_json::to_value(&req_body)?;
+        merge_metadata(&mut body, request.metadata.as_ref());
+
         let url = self.model_endpoint_url(model, "generateContent")?;
 
         let resp = self
             .client
             .post(url)
             .header(GOOGLE_API_KEY_HEADER, &self.api_key)
-            .json(&req_body)
+            .json(&body)
             .send()
             .await?;
 
@@ -1829,5 +1844,69 @@ mod tests {
             LLMError::InvalidRequest { message, .. }
                 if message == "Image generation prompt must not be empty"
         ));
+    }
+
+    #[tokio::test]
+    async fn test_google_generate_image_rejects_default_text_model() {
+        use crate::image_generation::ImageGenerationRequest;
+
+        let provider = Google::new("secret-key", None, None, None, None, None, None);
+
+        let request = ImageGenerationRequest {
+            prompt: "a cat".to_string(),
+            model: None,
+            input_images: None,
+            metadata: None,
+        };
+
+        let err = provider
+            .generate_image(&request)
+            .await
+            .expect_err("default text model should be rejected");
+
+        assert!(matches!(
+            err,
+            LLMError::InvalidRequest { message, .. }
+                if message.contains("image-capable model")
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_google_generate_image_merges_metadata_into_body() {
+        use crate::image_generation::ImageGenerationRequest;
+
+        let server = MockServer::start();
+        let encoded = BASE64.encode([1u8, 2, 3]);
+        let mock = server.mock(|when, then| {
+            when.method(POST)
+                .path("/v1beta/models/gemini-test:generateContent")
+                // Caller-provided metadata key must appear in the request body.
+                .body_includes("marker-42");
+            then.status(200).json_body(json!({
+                "candidates": [{
+                    "content": {
+                        "parts": [{
+                            "inlineData": { "mimeType": "image/png", "data": encoded }
+                        }]
+                    }
+                }]
+            }));
+        });
+        let provider = test_google_provider(&server);
+
+        let request = ImageGenerationRequest {
+            prompt: "with metadata".to_string(),
+            model: None,
+            input_images: None,
+            metadata: Some(json!({ "customField": "marker-42" })),
+        };
+
+        let response = provider
+            .generate_image(&request)
+            .await
+            .expect("image generation should succeed");
+
+        assert_eq!(response.images.len(), 1);
+        mock.assert();
     }
 }

--- a/crates/autoagents-llm/src/backends/google.rs
+++ b/crates/autoagents-llm/src/backends/google.rs
@@ -873,9 +873,11 @@ impl ImageGenerationProvider for Google {
         let mut body = serde_json::to_value(&req_body)?;
         merge_metadata(&mut body, request.metadata.as_ref());
 
-        let generation_config = body
+        let body_object = body
             .as_object_mut()
-            .expect("Google image request body must be an object")
+            .expect("Google image request body must be an object");
+
+        let generation_config = body_object
             .entry("generationConfig")
             .or_insert_with(|| serde_json::json!({}));
 
@@ -885,11 +887,11 @@ impl ImageGenerationProvider for Google {
 
         generation_config
             .as_object_mut()
-            .expect("generationConfig was normalized to an object")
+            .expect("generationConfig must be an object")
             .insert(
                 "responseModalities".to_string(),
                 serde_json::json!(["TEXT", "IMAGE"]),
-        );
+            );
 
         let url = self.model_endpoint_url(model, "generateContent")?;
 
@@ -1974,6 +1976,52 @@ mod tests {
             .generate_image(&request)
             .await
             .expect("image generation should succeed");
+
+        assert_eq!(response.images.len(), 1);
+        mock.assert();
+    }
+
+    #[tokio::test]
+    async fn test_google_generate_image_normalizes_non_object_generation_config() {
+        use crate::image_generation::ImageGenerationRequest;
+
+        let server = MockServer::start();
+        let encoded = BASE64.encode([1u8, 2, 3]);
+
+        let mock = server.mock(|when, then| {
+            when.method(POST)
+                .path("/v1beta/models/gemini-test:generateContent")
+                .body_includes("\"responseModalities\":[\"TEXT\",\"IMAGE\"]");
+
+            then.status(200).json_body(json!({
+                "candidates": [{
+                    "content": {
+                        "parts": [{
+                            "inlineData": {
+                                "mimeType": "image/png",
+                                "data": encoded
+                            }
+                        }]
+                    }
+                }]
+            }));
+        });
+
+        let provider = test_google_provider(&server);
+
+        let request = ImageGenerationRequest {
+            prompt: "test".to_string(),
+            model: None,
+            input_images: None,
+            metadata: Some(json!({
+                "generationConfig": "invalid"
+            })),
+        };
+
+        let response = provider
+            .generate_image(&request)
+            .await
+            .expect("generationConfig should be normalized");
 
         assert_eq!(response.images.len(), 1);
         mock.assert();

--- a/crates/autoagents-llm/src/backends/google.rs
+++ b/crates/autoagents-llm/src/backends/google.rs
@@ -1775,6 +1775,7 @@ mod tests {
             None,
             None,
         );
+
         provider.api_key = String::new();
 
         let request = ImageGenerationRequest {

--- a/crates/autoagents-llm/src/backends/google.rs
+++ b/crates/autoagents-llm/src/backends/google.rs
@@ -15,7 +15,7 @@
 
 use crate::{
     FunctionCall, LLMProvider, ToolCall,
-    builder::LLMBuilder,
+    builder::{LLMBackend, LLMBuilder},
     chat::{
         ChatMessage, ChatProvider, ChatResponse, ChatRole, MessageType, StructuredOutputFormat,
         Tool,
@@ -25,6 +25,9 @@ use crate::{
     embedding::{EmbeddingBuilder, EmbeddingProvider},
     error::LLMError,
     http::ensure_success,
+    image_generation::{
+        GeneratedImage, ImageGenerationProvider, ImageGenerationRequest, ImageGenerationResponse,
+    },
     models::ModelsProvider,
 };
 use async_trait::async_trait;
@@ -743,6 +746,174 @@ impl EmbeddingProvider for Google {
     }
 }
 
+/// Request body for Gemini image generation via the `generateContent` endpoint.
+#[derive(Serialize)]
+struct GoogleImageRequest<'a> {
+    /// Prompt text and any input image parts.
+    contents: Vec<GoogleChatContent<'a>>,
+    /// Generation config requesting image output.
+    #[serde(rename = "generationConfig")]
+    generation_config: GoogleImageGenerationConfig,
+}
+
+/// Generation config that asks Gemini to return image (and text) modalities.
+#[derive(Serialize)]
+struct GoogleImageGenerationConfig {
+    /// Requested response modalities, e.g. `["TEXT", "IMAGE"]`.
+    #[serde(rename = "responseModalities")]
+    response_modalities: Vec<String>,
+}
+
+/// Response body for a Gemini image generation request.
+#[derive(Deserialize, Debug)]
+struct GoogleImageResponse {
+    /// Generated candidates; each may carry inline image data.
+    #[serde(default)]
+    candidates: Vec<GoogleImageCandidate>,
+}
+
+/// Individual image generation candidate.
+#[derive(Deserialize, Debug)]
+struct GoogleImageCandidate {
+    /// Content block containing the response parts.
+    content: GoogleImageContent,
+}
+
+/// Content block within an image generation candidate.
+#[derive(Deserialize, Debug)]
+struct GoogleImageContent {
+    /// Parts making up the content (text and/or inline image data).
+    #[serde(default)]
+    parts: Vec<GoogleImagePart>,
+}
+
+/// A single part of an image generation response.
+#[derive(Deserialize, Debug)]
+struct GoogleImagePart {
+    /// Inline image data, when this part carries a generated image.
+    /// Gemini returns `inlineData`; the `inline_data` alias covers snake_case payloads.
+    #[serde(default, rename = "inlineData", alias = "inline_data")]
+    inline_data: Option<GoogleInlineImageData>,
+}
+
+/// Base64-encoded inline image data returned by Gemini.
+#[derive(Deserialize, Debug)]
+struct GoogleInlineImageData {
+    /// MIME type of the image (e.g. `image/png`).
+    #[serde(default, rename = "mimeType", alias = "mime_type")]
+    mime_type: Option<String>,
+    /// Base64-encoded image bytes.
+    data: String,
+}
+
+#[async_trait]
+impl ImageGenerationProvider for Google {
+    /// Generates one or more images from a prompt using Gemini's
+    /// `generateContent` endpoint with image response modality.
+    ///
+    /// # Arguments
+    ///
+    /// * `request` - Prompt, optional model override and optional input images
+    ///
+    /// # Returns
+    ///
+    /// The generated images (with preserved MIME types) or an error
+    async fn generate_image(
+        &self,
+        request: &ImageGenerationRequest,
+    ) -> Result<ImageGenerationResponse, LLMError> {
+        if self.api_key.is_empty() {
+            return Err(LLMError::missing_api_key(
+                "Missing Google API key".to_string(),
+            ));
+        }
+
+        if request.prompt.trim().is_empty() {
+            return Err(LLMError::invalid_request(
+                "Image generation prompt must not be empty".to_string(),
+            ));
+        }
+
+        let model = request.model.as_deref().unwrap_or(&self.model);
+
+        // Prompt text first, followed by any input images as inline data parts.
+        let mut parts: Vec<GoogleContentPart<'_>> = vec![GoogleContentPart::Text(&request.prompt)];
+        if let Some(input_images) = &request.input_images {
+            for image in input_images {
+                parts.push(GoogleContentPart::InlineData(GoogleInlineData {
+                    mime_type: image.mime_type.clone(),
+                    data: BASE64.encode(&image.data),
+                }));
+            }
+        }
+
+        let req_body = GoogleImageRequest {
+            contents: vec![GoogleChatContent {
+                role: "user",
+                parts,
+            }],
+            generation_config: GoogleImageGenerationConfig {
+                response_modalities: vec!["TEXT".to_string(), "IMAGE".to_string()],
+            },
+        };
+
+        let url = self.model_endpoint_url(model, "generateContent")?;
+
+        let resp = self
+            .client
+            .post(url)
+            .header(GOOGLE_API_KEY_HEADER, &self.api_key)
+            .json(&req_body)
+            .send()
+            .await?;
+
+        log::debug!("Google Gemini image HTTP status: {}", resp.status());
+
+        let resp = ensure_success(resp, "Google").await?;
+        let resp_text = resp.text().await?;
+
+        let json_resp: GoogleImageResponse =
+            serde_json::from_str(&resp_text).map_err(|e| LLMError::ResponseFormatError {
+                message: format!("Failed to decode Google image response: {e}"),
+                raw_response: resp_text.clone(),
+            })?;
+
+        let mut images = Vec::new();
+        for candidate in &json_resp.candidates {
+            for part in &candidate.content.parts {
+                if let Some(inline) = &part.inline_data {
+                    let data = BASE64.decode(inline.data.as_bytes()).map_err(|e| {
+                        LLMError::ResponseFormatError {
+                            message: format!("Failed to base64-decode Google image data: {e}"),
+                            raw_response: resp_text.clone(),
+                        }
+                    })?;
+                    let mime_type = inline
+                        .mime_type
+                        .clone()
+                        .unwrap_or_else(|| "image/png".to_string());
+                    images.push(GeneratedImage {
+                        mime_type,
+                        data,
+                        metadata: serde_json::json!({ "model": model }),
+                    });
+                }
+            }
+        }
+
+        if images.is_empty() {
+            return Err(LLMError::ProviderError(
+                "No image returned by Google".to_string(),
+            ));
+        }
+
+        Ok(ImageGenerationResponse {
+            images,
+            backend: LLMBackend::Google,
+        })
+    }
+}
+
 impl LLMProvider for Google {}
 
 impl crate::HasConfig for Google {
@@ -1435,5 +1606,239 @@ mod tests {
 
         assert_eq!(embeddings, vec![vec![0.1, 0.2]]);
         mock.assert();
+    }
+
+    #[tokio::test]
+    async fn test_google_generate_image_sends_api_key_header() {
+        use crate::image_generation::ImageGenerationRequest;
+
+        let server = MockServer::start();
+        let expected_bytes = vec![0x89, 0x50, 0x4e, 0x47];
+        let encoded = BASE64.encode(&expected_bytes);
+        let mock = server.mock(|when, then| {
+            when.method(POST)
+                .path("/v1beta/models/gemini-test:generateContent")
+                .header(GOOGLE_API_KEY_HEADER, "secret-key");
+            then.status(200).json_body(json!({
+                "candidates": [{
+                    "content": {
+                        "parts": [{
+                            "inlineData": {
+                                "mimeType": "image/png",
+                                "data": encoded
+                            }
+                        }]
+                    }
+                }]
+            }));
+        });
+        let provider = test_google_provider(&server);
+
+        let request = ImageGenerationRequest {
+            prompt: "a red apple".to_string(),
+            model: None,
+            input_images: None,
+            n: None,
+            aspect_ratio: None,
+            metadata: None,
+        };
+
+        let response = provider
+            .generate_image(&request)
+            .await
+            .expect("image generation should succeed");
+
+        assert_eq!(response.images.len(), 1);
+        assert_eq!(response.backend, LLMBackend::Google);
+        assert_eq!(response.images[0].mime_type, "image/png");
+        assert_eq!(response.images[0].data, expected_bytes);
+        mock.assert();
+    }
+
+    #[tokio::test]
+    async fn test_google_generate_image_uses_request_model_override() {
+        use crate::image_generation::ImageGenerationRequest;
+
+        let server = MockServer::start();
+        let encoded = BASE64.encode([1u8, 2, 3]);
+        let mock = server.mock(|when, then| {
+            when.method(POST)
+                .path("/v1beta/models/gemini-image-test:generateContent")
+                .header(GOOGLE_API_KEY_HEADER, "secret-key");
+            then.status(200).json_body(json!({
+                "candidates": [{
+                    "content": {
+                        "parts": [{
+                            "inlineData": { "mimeType": "image/png", "data": encoded }
+                        }]
+                    }
+                }]
+            }));
+        });
+        // Provider default model is gemini-test; request overrides it.
+        let provider = test_google_provider(&server);
+
+        let request = ImageGenerationRequest {
+            prompt: "an override".to_string(),
+            model: Some("gemini-image-test".to_string()),
+            input_images: None,
+            n: None,
+            aspect_ratio: None,
+            metadata: None,
+        };
+
+        let response = provider
+            .generate_image(&request)
+            .await
+            .expect("image generation should succeed");
+
+        assert_eq!(response.images.len(), 1);
+        mock.assert();
+    }
+
+    #[tokio::test]
+    async fn test_google_generate_image_supports_input_images() {
+        use crate::image_generation::{ImageGenerationRequest, ImageInput};
+
+        let server = MockServer::start();
+        let encoded = BASE64.encode([9u8, 9, 9]);
+        let mock = server.mock(|when, then| {
+            when.method(POST)
+                .path("/v1beta/models/gemini-test:generateContent")
+                .header(GOOGLE_API_KEY_HEADER, "secret-key")
+                // The request body should carry the input image as an inlineData part.
+                .body_includes("inlineData")
+                .body_includes("mime_type");
+            then.status(200).json_body(json!({
+                "candidates": [{
+                    "content": {
+                        "parts": [{
+                            "inlineData": { "mimeType": "image/png", "data": encoded }
+                        }]
+                    }
+                }]
+            }));
+        });
+        let provider = test_google_provider(&server);
+
+        let request = ImageGenerationRequest {
+            prompt: "edit this".to_string(),
+            model: None,
+            input_images: Some(vec![ImageInput {
+                mime_type: "image/png".to_string(),
+                data: vec![0x01, 0x02, 0x03],
+            }]),
+            n: None,
+            aspect_ratio: None,
+            metadata: None,
+        };
+
+        let response = provider
+            .generate_image(&request)
+            .await
+            .expect("image generation should succeed");
+
+        assert_eq!(response.images.len(), 1);
+        mock.assert();
+    }
+
+    #[tokio::test]
+    async fn test_google_generate_image_missing_api_key() {
+        use crate::image_generation::ImageGenerationRequest;
+
+        let mut provider = Google::new(
+            "secret-key",
+            Some("gemini-test".to_string()),
+            None,
+            None,
+            None,
+            None,
+            None,
+        );
+        provider.api_key = String::new();
+
+        let request = ImageGenerationRequest {
+            prompt: "no key".to_string(),
+            model: None,
+            input_images: None,
+            n: None,
+            aspect_ratio: None,
+            metadata: None,
+        };
+
+        let err = provider
+            .generate_image(&request)
+            .await
+            .expect_err("missing api key should error");
+
+        assert!(matches!(err, LLMError::AuthError { .. }));
+    }
+
+    #[tokio::test]
+    async fn test_google_generate_image_returns_error_when_no_image() {
+        use crate::image_generation::ImageGenerationRequest;
+
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(POST)
+                .path("/v1beta/models/gemini-test:generateContent")
+                .header(GOOGLE_API_KEY_HEADER, "secret-key");
+            then.status(200).json_body(json!({
+                "candidates": [{
+                    "content": {
+                        "parts": [{ "text": "here is your image" }]
+                    }
+                }]
+            }));
+        });
+        let provider = test_google_provider(&server);
+
+        let request = ImageGenerationRequest {
+            prompt: "text only".to_string(),
+            model: None,
+            input_images: None,
+            n: None,
+            aspect_ratio: None,
+            metadata: None,
+        };
+
+        let err = provider
+            .generate_image(&request)
+            .await
+            .expect_err("response without image should error");
+
+        assert!(matches!(
+            err,
+            LLMError::ProviderError(message) if message == "No image returned by Google"
+        ));
+        mock.assert();
+    }
+
+    #[tokio::test]
+    async fn test_google_generate_image_rejects_empty_prompt() {
+        use crate::image_generation::ImageGenerationRequest;
+
+        let server = MockServer::start();
+        let provider = test_google_provider(&server);
+
+        let request = ImageGenerationRequest {
+            prompt: "   ".to_string(),
+            model: None,
+            input_images: None,
+            n: None,
+            aspect_ratio: None,
+            metadata: None,
+        };
+
+        let err = provider
+            .generate_image(&request)
+            .await
+            .expect_err("empty prompt should error");
+
+        assert!(matches!(
+            err,
+            LLMError::InvalidRequest { message, .. }
+                if message == "Image generation prompt must not be empty"
+        ));
     }
 }

--- a/crates/autoagents-llm/src/backends/google.rs
+++ b/crates/autoagents-llm/src/backends/google.rs
@@ -1765,9 +1765,9 @@ mod tests {
     #[tokio::test]
     async fn test_google_generate_image_missing_api_key() {
         use crate::image_generation::ImageGenerationRequest;
-
-        let mut provider = Google::new(
-            "secret-key",
+    
+        let provider = Google::new(
+            "",
             Some("gemini-test".to_string()),
             None,
             None,
@@ -1775,8 +1775,6 @@ mod tests {
             None,
             None,
         );
-
-        provider.api_key = String::new();
 
         let request = ImageGenerationRequest {
             prompt: "no key".to_string(),

--- a/crates/autoagents-llm/src/backends/google.rs
+++ b/crates/autoagents-llm/src/backends/google.rs
@@ -873,15 +873,23 @@ impl ImageGenerationProvider for Google {
         let mut body = serde_json::to_value(&req_body)?;
         merge_metadata(&mut body, request.metadata.as_ref());
 
-        if let Some(generation_config) = body
-            .get_mut("generationConfig")
-            .and_then(Value::as_object_mut)
-        {
-            generation_config.insert(
+        let generation_config = body
+            .as_object_mut()
+            .expect("Google image request body must be an object")
+            .entry("generationConfig")
+            .or_insert_with(|| serde_json::json!({}));
+
+        if !generation_config.is_object() {
+            *generation_config = serde_json::json!({});
+        }
+
+        generation_config
+            .as_object_mut()
+            .expect("generationConfig was normalized to an object")
+            .insert(
                 "responseModalities".to_string(),
                 serde_json::json!(["TEXT", "IMAGE"]),
-            );
-        }
+        );
 
         let url = self.model_endpoint_url(model, "generateContent")?;
 
@@ -1765,7 +1773,7 @@ mod tests {
     #[tokio::test]
     async fn test_google_generate_image_missing_api_key() {
         use crate::image_generation::ImageGenerationRequest;
-    
+
         let provider = Google::new(
             "",
             Some("gemini-test".to_string()),

--- a/crates/autoagents-llm/src/backends/openrouter.rs
+++ b/crates/autoagents-llm/src/backends/openrouter.rs
@@ -195,6 +195,22 @@ fn parse_image_data_url(url: &str) -> Result<(String, Vec<u8>), LLMError> {
     Ok((mime_type, data))
 }
 
+fn validate_openrouter_image_metadata(metadata: Option<&serde_json::Value>) -> Result<(), LLMError> {
+    const RESERVED_KEYS: &[&str] = &["model", "messages", "modalities"];
+
+    let Some(serde_json::Value::Object(map)) = metadata else {
+        return Ok(());
+    };
+
+    if let Some(key) = RESERVED_KEYS.iter().find(|key| map.contains_key(**key)) {
+        return Err(LLMError::invalid_request(format!(
+            "OpenRouter image generation metadata cannot override reserved request field `{key}`"
+        )));
+    }
+
+    Ok(())
+}
+
 #[async_trait]
 impl ImageGenerationProvider for OpenRouter {
     /// Generates one or more images from a prompt via OpenRouter's chat
@@ -258,8 +274,9 @@ impl ImageGenerationProvider for OpenRouter {
             "modalities": ["image", "text"],
         });
 
-        // Merge any caller-provided provider-specific options (e.g. OpenRouter
-        // routing preferences) into the top-level request body.
+        // Merge only provider-specific options. Core request fields are reserved because
+        // they were validated above and are required for image generation.
+        validate_openrouter_image_metadata(request.metadata.as_ref())?;
         merge_metadata(&mut body, request.metadata.as_ref());
 
         let url = self
@@ -633,6 +650,72 @@ mod tests {
             err,
             LLMError::InvalidRequest { message, .. }
                 if message == "Image generation prompt must not be empty"
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_openrouter_generate_image_rejects_metadata_model_override() {
+        let server = MockServer::start();
+        let provider = test_openrouter_provider(&server);
+
+        let mut request = image_request("blocked model override");
+        request.metadata = Some(json!({
+            "model": "moonshotai/kimi-k2:free"
+        }));
+
+        let err = provider
+            .generate_image(&request)
+            .await
+            .expect_err("metadata model override should be rejected");
+
+        assert!(matches!(
+            err,
+            LLMError::InvalidRequest { message, .. }
+                if message.contains("reserved request field `model`")
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_openrouter_generate_image_rejects_metadata_modalities_override() {
+        let server = MockServer::start();
+        let provider = test_openrouter_provider(&server);
+
+        let mut request = image_request("blocked modalities override");
+        request.metadata = Some(json!({
+            "modalities": ["text"]
+        }));
+
+        let err = provider
+            .generate_image(&request)
+            .await
+            .expect_err("metadata modalities override should be rejected");
+
+        assert!(matches!(
+            err,
+            LLMError::InvalidRequest { message, .. }
+                if message.contains("reserved request field `modalities`")
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_openrouter_generate_image_rejects_metadata_messages_override() {
+        let server = MockServer::start();
+        let provider = test_openrouter_provider(&server);
+
+        let mut request = image_request("blocked messages override");
+        request.metadata = Some(json!({
+            "messages": []
+        }));
+
+        let err = provider
+            .generate_image(&request)
+            .await
+            .expect_err("metadata messages override should be rejected");
+
+        assert!(matches!(
+            err,
+            LLMError::InvalidRequest { message, .. }
+                if message.contains("reserved request field `messages`")
         ));
     }
 }

--- a/crates/autoagents-llm/src/backends/openrouter.rs
+++ b/crates/autoagents-llm/src/backends/openrouter.rs
@@ -11,10 +11,15 @@ use crate::{
     completion::{CompletionProvider, CompletionRequest, CompletionResponse},
     embedding::EmbeddingProvider,
     error::LLMError,
+    image_generation::{
+        GeneratedImage, ImageGenerationProvider, ImageGenerationRequest, ImageGenerationResponse,
+    },
     models::{ModelListRequest, ModelListResponse, ModelsProvider, StandardModelListResponse},
     providers::openai_compatible::{OpenAICompatibleProvider, OpenAIProviderConfig},
 };
 use async_trait::async_trait;
+use base64::{Engine as _, engine::general_purpose::STANDARD as BASE64};
+use serde::Deserialize;
 use std::sync::Arc;
 
 /// OpenRouter configuration for the generic provider
@@ -130,6 +135,164 @@ impl ModelsProvider for OpenRouter {
     }
 }
 
+/// Response body for an OpenRouter image generation request.
+///
+/// OpenRouter returns generated images through the chat completions endpoint:
+/// each choice's message carries an `images` array whose entries hold a
+/// base64 data URL under `image_url.url`.
+#[derive(Deserialize, Debug)]
+struct OpenRouterImageResponse {
+    #[serde(default)]
+    choices: Vec<OpenRouterImageChoice>,
+}
+
+#[derive(Deserialize, Debug)]
+struct OpenRouterImageChoice {
+    message: OpenRouterImageMessage,
+}
+
+#[derive(Deserialize, Debug)]
+struct OpenRouterImageMessage {
+    /// Generated images attached to the assistant message.
+    #[serde(default)]
+    images: Vec<OpenRouterImageData>,
+}
+
+#[derive(Deserialize, Debug)]
+struct OpenRouterImageData {
+    image_url: OpenRouterImageUrl,
+}
+
+#[derive(Deserialize, Debug)]
+struct OpenRouterImageUrl {
+    /// Base64 data URL, e.g. `data:image/png;base64,<...>`.
+    url: String,
+}
+
+/// Parses a `data:<mime>;base64,<data>` URL into its MIME type and raw bytes.
+fn parse_image_data_url(url: &str) -> Result<(String, Vec<u8>), LLMError> {
+    let rest = url
+        .strip_prefix("data:")
+        .ok_or_else(|| LLMError::ResponseFormatError {
+            message: "OpenRouter image URL is not a base64 data URL".to_string(),
+            raw_response: url.to_string(),
+        })?;
+    let (meta, encoded) = rest
+        .split_once(',')
+        .ok_or_else(|| LLMError::ResponseFormatError {
+            message: "OpenRouter image data URL is missing a comma separator".to_string(),
+            raw_response: url.to_string(),
+        })?;
+    // meta looks like "image/png;base64" — the MIME type is the first segment.
+    let mime_type = meta.split(';').next().unwrap_or("image/png").to_string();
+    let data = BASE64
+        .decode(encoded.as_bytes())
+        .map_err(|e| LLMError::ResponseFormatError {
+            message: format!("Failed to base64-decode OpenRouter image data: {e}"),
+            raw_response: url.to_string(),
+        })?;
+    Ok((mime_type, data))
+}
+
+#[async_trait]
+impl ImageGenerationProvider for OpenRouter {
+    /// Generates one or more images from a prompt via OpenRouter's chat
+    /// completions endpoint with the `image` output modality.
+    ///
+    /// Use an image-capable model (e.g. `google/gemini-2.5-flash-image`) via
+    /// `request.model`; the provider default model is a text model.
+    async fn generate_image(
+        &self,
+        request: &ImageGenerationRequest,
+    ) -> Result<ImageGenerationResponse, LLMError> {
+        if self.api_key.is_empty() {
+            return Err(LLMError::missing_api_key(
+                "Missing OpenRouter API key".to_string(),
+            ));
+        }
+
+        if request.prompt.trim().is_empty() {
+            return Err(LLMError::invalid_request(
+                "Image generation prompt must not be empty".to_string(),
+            ));
+        }
+
+        let model = request.model.as_deref().unwrap_or(&self.model);
+
+        // Prompt text first, followed by any input images as data-URL parts.
+        let mut content_parts = vec![serde_json::json!({
+            "type": "text",
+            "text": request.prompt,
+        })];
+        if let Some(input_images) = &request.input_images {
+            for image in input_images {
+                let data_url = format!(
+                    "data:{};base64,{}",
+                    image.mime_type,
+                    BASE64.encode(&image.data)
+                );
+                content_parts.push(serde_json::json!({
+                    "type": "image_url",
+                    "image_url": { "url": data_url },
+                }));
+            }
+        }
+
+        let body = serde_json::json!({
+            "model": model,
+            "messages": [{ "role": "user", "content": content_parts }],
+            "modalities": ["image", "text"],
+        });
+
+        let url = self
+            .base_url
+            .join("chat/completions")
+            .map_err(|e| LLMError::HttpError(e.to_string()))?;
+
+        let resp = self
+            .client
+            .post(url)
+            .bearer_auth(&self.api_key)
+            .json(&body)
+            .send()
+            .await?;
+
+        log::debug!("OpenRouter image HTTP status: {}", resp.status());
+
+        let resp = ensure_success(resp, "OpenRouter").await?;
+        let resp_text = resp.text().await?;
+
+        let json_resp: OpenRouterImageResponse =
+            serde_json::from_str(&resp_text).map_err(|e| LLMError::ResponseFormatError {
+                message: format!("Failed to decode OpenRouter image response: {e}"),
+                raw_response: resp_text.clone(),
+            })?;
+
+        let mut images = Vec::new();
+        for choice in &json_resp.choices {
+            for image in &choice.message.images {
+                let (mime_type, data) = parse_image_data_url(&image.image_url.url)?;
+                images.push(GeneratedImage {
+                    mime_type,
+                    data,
+                    metadata: serde_json::json!({ "model": model }),
+                });
+            }
+        }
+
+        if images.is_empty() {
+            return Err(LLMError::ProviderError(
+                "No image returned by OpenRouter".to_string(),
+            ));
+        }
+
+        Ok(ImageGenerationResponse {
+            images,
+            backend: LLMBackend::OpenRouter,
+        })
+    }
+}
+
 impl LLMBuilder<OpenRouter> {
     pub fn build(self) -> Result<Arc<OpenRouter>, LLMError> {
         let api_key = self.api_key.ok_or_else(|| {
@@ -162,6 +325,9 @@ impl LLMBuilder<OpenRouter> {
 mod tests {
     use super::*;
     use crate::builder::LLMBuilder;
+    use crate::image_generation::{ImageGenerationRequest, ImageInput};
+    use httpmock::{Method::POST, MockServer};
+    use serde_json::json;
 
     #[test]
     fn test_openrouter_builder_requires_api_key() {
@@ -179,5 +345,216 @@ mod tests {
         );
         let err = provider.list_models(None).await.unwrap_err();
         assert!(err.to_string().contains("Missing OpenRouter API key"));
+    }
+
+    fn test_openrouter_provider(server: &MockServer) -> OpenRouter {
+        OpenRouter::with_config(
+            "secret-key",
+            Some(format!("{}/api/v1", server.base_url())),
+            Some("google/gemini-2.5-flash-image".to_string()),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+    }
+
+    fn image_request(prompt: &str) -> ImageGenerationRequest {
+        ImageGenerationRequest {
+            prompt: prompt.to_string(),
+            model: None,
+            input_images: None,
+            n: None,
+            aspect_ratio: None,
+            metadata: None,
+        }
+    }
+
+    #[test]
+    fn test_parse_image_data_url_decodes_mime_and_bytes() {
+        let encoded = BASE64.encode([0x89, 0x50, 0x4e, 0x47]);
+        let url = format!("data:image/png;base64,{encoded}");
+        let (mime, bytes) = parse_image_data_url(&url).expect("data url should parse");
+        assert_eq!(mime, "image/png");
+        assert_eq!(bytes, vec![0x89, 0x50, 0x4e, 0x47]);
+    }
+
+    #[test]
+    fn test_parse_image_data_url_rejects_non_data_url() {
+        let err = parse_image_data_url("https://example.com/x.png").unwrap_err();
+        assert!(matches!(err, LLMError::ResponseFormatError { .. }));
+    }
+
+    #[tokio::test]
+    async fn test_openrouter_generate_image_sends_bearer_and_returns_image() {
+        let server = MockServer::start();
+        let expected_bytes = vec![0x89, 0x50, 0x4e, 0x47];
+        let data_url = format!("data:image/png;base64,{}", BASE64.encode(&expected_bytes));
+        let mock = server.mock(|when, then| {
+            when.method(POST)
+                .path("/api/v1/chat/completions")
+                .header("authorization", "Bearer secret-key");
+            then.status(200).json_body(json!({
+                "choices": [{
+                    "message": {
+                        "role": "assistant",
+                        "content": "",
+                        "images": [{
+                            "type": "image_url",
+                            "image_url": { "url": data_url }
+                        }]
+                    }
+                }]
+            }));
+        });
+        let provider = test_openrouter_provider(&server);
+
+        let response = provider
+            .generate_image(&image_request("a blue teapot"))
+            .await
+            .expect("image generation should succeed");
+
+        assert_eq!(response.images.len(), 1);
+        assert_eq!(response.backend, LLMBackend::OpenRouter);
+        assert_eq!(response.images[0].mime_type, "image/png");
+        assert_eq!(response.images[0].data, expected_bytes);
+        mock.assert();
+    }
+
+    #[tokio::test]
+    async fn test_openrouter_generate_image_uses_request_model_override() {
+        let server = MockServer::start();
+        let data_url = format!("data:image/png;base64,{}", BASE64.encode([1u8, 2, 3]));
+        let mock = server.mock(|when, then| {
+            when.method(POST)
+                .path("/api/v1/chat/completions")
+                .header("authorization", "Bearer secret-key")
+                // The overriding model must be sent in the request body.
+                .body_includes("openrouter/image-model");
+            then.status(200).json_body(json!({
+                "choices": [{
+                    "message": {
+                        "images": [{ "image_url": { "url": data_url } }]
+                    }
+                }]
+            }));
+        });
+        let provider = test_openrouter_provider(&server);
+
+        let mut request = image_request("override the model");
+        request.model = Some("openrouter/image-model".to_string());
+
+        let response = provider
+            .generate_image(&request)
+            .await
+            .expect("image generation should succeed");
+
+        assert_eq!(response.images.len(), 1);
+        mock.assert();
+    }
+
+    #[tokio::test]
+    async fn test_openrouter_generate_image_supports_input_images() {
+        let server = MockServer::start();
+        let data_url = format!("data:image/png;base64,{}", BASE64.encode([9u8, 9, 9]));
+        let mock = server.mock(|when, then| {
+            when.method(POST)
+                .path("/api/v1/chat/completions")
+                .header("authorization", "Bearer secret-key")
+                // Input image should be forwarded as an image_url data-URL part.
+                .body_includes("image_url")
+                .body_includes("data:image/png;base64");
+            then.status(200).json_body(json!({
+                "choices": [{
+                    "message": {
+                        "images": [{ "image_url": { "url": data_url } }]
+                    }
+                }]
+            }));
+        });
+        let provider = test_openrouter_provider(&server);
+
+        let mut request = image_request("edit this image");
+        request.input_images = Some(vec![ImageInput {
+            mime_type: "image/png".to_string(),
+            data: vec![0x01, 0x02, 0x03],
+        }]);
+
+        let response = provider
+            .generate_image(&request)
+            .await
+            .expect("image generation should succeed");
+
+        assert_eq!(response.images.len(), 1);
+        mock.assert();
+    }
+
+    #[tokio::test]
+    async fn test_openrouter_generate_image_missing_api_key() {
+        let provider = OpenRouter::with_config(
+            "", None, None, None, None, None, None, None, None, None, None, None, None, None, None,
+        );
+
+        let err = provider
+            .generate_image(&image_request("no key"))
+            .await
+            .expect_err("missing api key should error");
+
+        assert!(matches!(err, LLMError::AuthError { .. }));
+    }
+
+    #[tokio::test]
+    async fn test_openrouter_generate_image_returns_error_when_no_image() {
+        let server = MockServer::start();
+        let mock = server.mock(|when, then| {
+            when.method(POST)
+                .path("/api/v1/chat/completions")
+                .header("authorization", "Bearer secret-key");
+            then.status(200).json_body(json!({
+                "choices": [{
+                    "message": {
+                        "role": "assistant",
+                        "content": "here is a description instead of an image"
+                    }
+                }]
+            }));
+        });
+        let provider = test_openrouter_provider(&server);
+
+        let err = provider
+            .generate_image(&image_request("text only"))
+            .await
+            .expect_err("response without image should error");
+
+        assert!(matches!(
+            err,
+            LLMError::ProviderError(message) if message == "No image returned by OpenRouter"
+        ));
+        mock.assert();
+    }
+
+    #[tokio::test]
+    async fn test_openrouter_generate_image_rejects_empty_prompt() {
+        let server = MockServer::start();
+        let provider = test_openrouter_provider(&server);
+
+        let err = provider
+            .generate_image(&image_request("   "))
+            .await
+            .expect_err("empty prompt should error");
+
+        assert!(matches!(
+            err,
+            LLMError::InvalidRequest { message, .. }
+                if message == "Image generation prompt must not be empty"
+        ));
     }
 }

--- a/crates/autoagents-llm/src/backends/openrouter.rs
+++ b/crates/autoagents-llm/src/backends/openrouter.rs
@@ -199,8 +199,9 @@ impl ImageGenerationProvider for OpenRouter {
     /// Generates one or more images from a prompt via OpenRouter's chat
     /// completions endpoint with the `image` output modality.
     ///
-    /// Use an image-capable model (e.g. `google/gemini-2.5-flash-image`) via
-    /// `request.model`; the provider default model is a text model.
+    /// Requires an image-capable model (e.g. `google/gemini-2.5-flash-image`)
+    /// via `request.model` or the provider's configured model; the text default
+    /// model is rejected with [`LLMError::InvalidRequest`].
     async fn generate_image(
         &self,
         request: &ImageGenerationRequest,
@@ -218,6 +219,18 @@ impl ImageGenerationProvider for OpenRouter {
         }
 
         let model = request.model.as_deref().unwrap_or(&self.model);
+
+        // The provider's default model is a text model that cannot produce
+        // images. Reject it explicitly instead of sending an image request that
+        // OpenRouter would reject with an opaque HTTP error.
+        if model == OpenRouterConfig::DEFAULT_MODEL {
+            return Err(LLMError::invalid_request(
+                "OpenRouter image generation requires an image-capable model; set \
+                 request.model (e.g. \"google/gemini-2.5-flash-image\") — the provider \
+                 default is a text model that cannot generate images"
+                    .to_string(),
+            ));
+        }
 
         // Prompt text first, followed by any input images as data-URL parts.
         let mut content_parts = vec![serde_json::json!({
@@ -372,8 +385,6 @@ mod tests {
             prompt: prompt.to_string(),
             model: None,
             input_images: None,
-            n: None,
-            aspect_ratio: None,
             metadata: None,
         }
     }
@@ -539,6 +550,39 @@ mod tests {
             LLMError::ProviderError(message) if message == "No image returned by OpenRouter"
         ));
         mock.assert();
+    }
+
+    #[tokio::test]
+    async fn test_openrouter_generate_image_rejects_default_text_model() {
+        // Provider built with the default (text) model and no request override.
+        let provider = OpenRouter::with_config(
+            "secret-key",
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        );
+
+        let err = provider
+            .generate_image(&image_request("a cat"))
+            .await
+            .expect_err("default text model should be rejected");
+
+        assert!(matches!(
+            err,
+            LLMError::InvalidRequest { message, .. }
+                if message.contains("image-capable model")
+        ));
     }
 
     #[tokio::test]

--- a/crates/autoagents-llm/src/backends/openrouter.rs
+++ b/crates/autoagents-llm/src/backends/openrouter.rs
@@ -195,7 +195,9 @@ fn parse_image_data_url(url: &str) -> Result<(String, Vec<u8>), LLMError> {
     Ok((mime_type, data))
 }
 
-fn validate_openrouter_image_metadata(metadata: Option<&serde_json::Value>) -> Result<(), LLMError> {
+fn validate_openrouter_image_metadata(
+    metadata: Option<&serde_json::Value>,
+) -> Result<(), LLMError> {
     const RESERVED_KEYS: &[&str] = &["model", "messages", "modalities"];
 
     let Some(serde_json::Value::Object(map)) = metadata else {

--- a/crates/autoagents-llm/src/backends/openrouter.rs
+++ b/crates/autoagents-llm/src/backends/openrouter.rs
@@ -13,6 +13,7 @@ use crate::{
     error::LLMError,
     image_generation::{
         GeneratedImage, ImageGenerationProvider, ImageGenerationRequest, ImageGenerationResponse,
+        merge_metadata,
     },
     models::{ModelListRequest, ModelListResponse, ModelsProvider, StandardModelListResponse},
     providers::openai_compatible::{OpenAICompatibleProvider, OpenAIProviderConfig},
@@ -251,11 +252,15 @@ impl ImageGenerationProvider for OpenRouter {
             }
         }
 
-        let body = serde_json::json!({
+        let mut body = serde_json::json!({
             "model": model,
             "messages": [{ "role": "user", "content": content_parts }],
             "modalities": ["image", "text"],
         });
+
+        // Merge any caller-provided provider-specific options (e.g. OpenRouter
+        // routing preferences) into the top-level request body.
+        merge_metadata(&mut body, request.metadata.as_ref());
 
         let url = self
             .base_url
@@ -498,6 +503,35 @@ mod tests {
             mime_type: "image/png".to_string(),
             data: vec![0x01, 0x02, 0x03],
         }]);
+
+        let response = provider
+            .generate_image(&request)
+            .await
+            .expect("image generation should succeed");
+
+        assert_eq!(response.images.len(), 1);
+        mock.assert();
+    }
+
+    #[tokio::test]
+    async fn test_openrouter_generate_image_merges_metadata_into_body() {
+        let server = MockServer::start();
+        let data_url = format!("data:image/png;base64,{}", BASE64.encode([1u8, 2, 3]));
+        let mock = server.mock(|when, then| {
+            when.method(POST)
+                .path("/api/v1/chat/completions")
+                // Caller-provided metadata key must appear in the request body.
+                .body_includes("marker-42");
+            then.status(200).json_body(json!({
+                "choices": [{
+                    "message": { "images": [{ "image_url": { "url": data_url } }] }
+                }]
+            }));
+        });
+        let provider = test_openrouter_provider(&server);
+
+        let mut request = image_request("with metadata");
+        request.metadata = Some(json!({ "provider": { "sort": "marker-42" } }));
 
         let response = provider
             .generate_image(&request)

--- a/crates/autoagents-llm/src/builder.rs
+++ b/crates/autoagents-llm/src/builder.rs
@@ -15,7 +15,7 @@ use std::{collections::HashMap, marker::PhantomData};
 pub type ValidatorFn = dyn Fn(&str) -> Result<(), String> + Send + Sync + 'static;
 
 /// Supported LLM backend providers.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 pub enum LLMBackend {
     /// OpenAI API provider (GPT-3, GPT-4, etc.)
     OpenAI,

--- a/crates/autoagents-llm/src/image_generation.rs
+++ b/crates/autoagents-llm/src/image_generation.rs
@@ -29,12 +29,28 @@ pub struct ImageGenerationRequest {
 
 /// Merges caller-provided [`ImageGenerationRequest::metadata`] into a request body.
 ///
-/// When both `body` and `metadata` are JSON objects, each top-level metadata key
-/// is inserted into `body`, overriding any existing key. Anything else is a no-op.
+/// When both `body` and `metadata` are JSON objects, metadata keys are merged into
+/// the request body. Nested objects are merged recursively so provider defaults,
+/// such as generation config fields, are preserved.
 pub(crate) fn merge_metadata(body: &mut Value, metadata: Option<&Value>) {
-    if let (Some(obj), Some(Value::Object(extra))) = (body.as_object_mut(), metadata) {
-        for (key, value) in extra {
-            obj.insert(key.clone(), value.clone());
+    if let Some(Value::Object(extra)) = metadata {
+        merge_json_objects(body, extra);
+    }
+}
+
+fn merge_json_objects(body: &mut Value, extra: &serde_json::Map<String, Value>) {
+    let Some(body_obj) = body.as_object_mut() else {
+        return;
+    };
+
+    for (key, value) in extra {
+        match (body_obj.get_mut(key), value) {
+            (Some(existing @ Value::Object(_)), Value::Object(incoming)) => {
+                merge_json_objects(existing, incoming);
+            }
+            _ => {
+                body_obj.insert(key.clone(), value.clone());
+            }
         }
     }
 }
@@ -62,6 +78,33 @@ pub struct GeneratedImage {
 mod tests {
     use super::merge_metadata;
     use serde_json::json;
+
+    #[test]
+    fn test_merge_metadata_deep_merges_nested_objects() {
+        let mut body = json!({
+            "model": "gemini-image",
+            "generationConfig": {
+                "responseModalities": ["TEXT", "IMAGE"],
+                "temperature": 0.7
+            }
+        });
+
+        merge_metadata(
+            &mut body,
+            Some(&json!({
+                "generationConfig": {
+                    "aspectRatio": "1:1"
+                }
+            })),
+        );
+
+        assert_eq!(
+            body["generationConfig"]["responseModalities"],
+            json!(["TEXT", "IMAGE"])
+        );
+        assert_eq!(body["generationConfig"]["temperature"], json!(0.7));
+        assert_eq!(body["generationConfig"]["aspectRatio"], json!("1:1"));
+    }
 
     #[test]
     fn test_merge_metadata_inserts_and_overrides_keys() {

--- a/crates/autoagents-llm/src/image_generation.rs
+++ b/crates/autoagents-llm/src/image_generation.rs
@@ -1,0 +1,42 @@
+use async_trait::async_trait;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::{builder::LLMBackend, error::LLMError};
+
+#[async_trait]
+pub trait ImageGenerationProvider {
+    async fn generate_image(
+        &self,
+        request: &ImageGenerationRequest,
+    ) -> Result<ImageGenerationResponse, LLMError>;
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ImageGenerationRequest {
+    pub prompt: String,
+    pub model: Option<String>,
+    pub input_images: Option<Vec<ImageInput>>,
+    pub n: Option<u32>,
+    pub aspect_ratio: Option<String>,
+    pub metadata: Option<Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ImageInput {
+    pub mime_type: String,
+    pub data: Vec<u8>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ImageGenerationResponse {
+    pub images: Vec<GeneratedImage>,
+    pub backend: LLMBackend,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GeneratedImage {
+    pub mime_type: String,
+    pub data: Vec<u8>,
+    pub metadata: Value,
+}

--- a/crates/autoagents-llm/src/image_generation.rs
+++ b/crates/autoagents-llm/src/image_generation.rs
@@ -14,11 +14,13 @@ pub trait ImageGenerationProvider {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ImageGenerationRequest {
+    /// Text prompt describing the image to generate (or the edit to apply).
     pub prompt: String,
+    /// Optional model override; falls back to the provider's configured model.
     pub model: Option<String>,
+    /// Optional input images for image-editing requests.
     pub input_images: Option<Vec<ImageInput>>,
-    pub n: Option<u32>,
-    pub aspect_ratio: Option<String>,
+    /// Provider-specific request options passed through verbatim.
     pub metadata: Option<Value>,
 }
 

--- a/crates/autoagents-llm/src/image_generation.rs
+++ b/crates/autoagents-llm/src/image_generation.rs
@@ -20,8 +20,23 @@ pub struct ImageGenerationRequest {
     pub model: Option<String>,
     /// Optional input images for image-editing requests.
     pub input_images: Option<Vec<ImageInput>>,
-    /// Provider-specific request options passed through verbatim.
+    /// Optional provider-specific request options. When this is a JSON object,
+    /// its top-level keys are merged into the outgoing request body (overriding
+    /// defaults), letting callers set fields such as a provider's image count or
+    /// generation config. Non-object values are ignored.
     pub metadata: Option<Value>,
+}
+
+/// Merges caller-provided [`ImageGenerationRequest::metadata`] into a request body.
+///
+/// When both `body` and `metadata` are JSON objects, each top-level metadata key
+/// is inserted into `body`, overriding any existing key. Anything else is a no-op.
+pub(crate) fn merge_metadata(body: &mut Value, metadata: Option<&Value>) {
+    if let (Some(obj), Some(Value::Object(extra))) = (body.as_object_mut(), metadata) {
+        for (key, value) in extra {
+            obj.insert(key.clone(), value.clone());
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -41,4 +56,30 @@ pub struct GeneratedImage {
     pub mime_type: String,
     pub data: Vec<u8>,
     pub metadata: Value,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::merge_metadata;
+    use serde_json::json;
+
+    #[test]
+    fn test_merge_metadata_inserts_and_overrides_keys() {
+        let mut body = json!({ "model": "m", "keep": 1 });
+        merge_metadata(
+            &mut body,
+            Some(&json!({ "extra": "x", "model": "override" })),
+        );
+        assert_eq!(body["extra"], json!("x"));
+        assert_eq!(body["model"], json!("override"));
+        assert_eq!(body["keep"], json!(1));
+    }
+
+    #[test]
+    fn test_merge_metadata_ignores_none_and_non_objects() {
+        let mut body = json!({ "a": 1 });
+        merge_metadata(&mut body, None);
+        merge_metadata(&mut body, Some(&json!("not-an-object")));
+        assert_eq!(body, json!({ "a": 1 }));
+    }
 }

--- a/crates/autoagents-llm/src/lib.rs
+++ b/crates/autoagents-llm/src/lib.rs
@@ -131,6 +131,15 @@ pub mod error;
 /// Shared configuration constants.
 pub mod config;
 
+/// Image generation provider traits and shared request/response types.
+pub mod image_generation;
+
+/// Convenient re-exports for image generation APIs.
+pub use image_generation::{
+    GeneratedImage, ImageGenerationProvider, ImageGenerationRequest, ImageGenerationResponse,
+    ImageInput,
+};
+
 /// Centralized HTTP response handling for provider backends.
 #[cfg(any(
     not(target_arch = "wasm32"),


### PR DESCRIPTION
## Summary

Adds a small, additive image-generation abstraction to `autoagents-llm` and implements it for two backends:

- Google/Gemini
- OpenRouter

This allows providers to create or edit images through a single shared trait, without changing existing chat, completion, embedding, or model-listing behavior.

## Motivation

AutoAgents already supports provider-agnostic LLM workflows, but there was no shared abstraction for generated image outputs.

This PR introduces an `ImageGenerationProvider` trait and common request/response types so callers can use image generation through a consistent interface across supported providers.

## What's included

### Shared abstraction

Added a new `image_generation` module with:

- `ImageGenerationProvider`
- `ImageGenerationRequest`
- `ImageInput`
- `ImageGenerationResponse`
- `GeneratedImage`

The new image generation types are also re-exported from the crate root for convenience.

### Google/Gemini backend

Implements `ImageGenerationProvider` for the Google backend.

The implementation:

- uses Gemini’s `:generateContent` endpoint
- requests image output through `responseModalities`
- uses the existing `x-goog-api-key` header
- reuses `model_endpoint_url()`, `ensure_success()`, and existing base64 helpers
- sends prompt text and optional input images as `inlineData` parts
- parses returned image parts from `inlineData` / `inline_data`
- supports both `mimeType` and `mime_type`
- base64-decodes returned image data
- preserves returned MIME type and provider metadata

### OpenRouter backend

Implements `ImageGenerationProvider` for the OpenRouter backend.

The implementation:

- uses OpenRouter’s OpenAI-compatible chat completions endpoint
- sends `modalities: ["image", "text"]`
- parses returned images from `choices[].message.images[].image_url.url`
- supports base64 data URLs using a `parse_image_data_url()` helper
- preserves MIME type and decodes image bytes
- forwards input images as data-URL image parts for image editing

### Supporting change

`LLMBackend` now derives:

- `PartialEq`
- `Eq`
- `Serialize`
- `Deserialize`

This is needed because `ImageGenerationResponse` carries the backend value and supports serialization/deserialization.

## Error handling

Both backends return clear errors for common failure cases:

- missing API key
- empty or whitespace-only prompt
- successful response with no returned image
- malformed or undecodable image data
- provider HTTP errors through the shared `ensure_success` path

## Testing

All new tests use `httpmock`; no real provider API calls are required in CI.

Added Google tests for:

- API key header handling
- request model override
- input image support
- missing API key
- no-image response error
- empty prompt rejection

Added OpenRouter tests for:

- bearer auth and image decoding
- model override in request body
- input image support
- missing API key
- no-image response error
- empty prompt rejection
- `parse_image_data_url()` success path
- invalid non-data-URL rejection

### Related to #291

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds provider-independent image generation to `autoagents-llm`. The main changes are:

- Shared request, response, image, and provider types.
- Image generation and editing through Google Gemini.
- Image generation and editing through OpenRouter.
- Provider metadata merging and response decoding.
- Serializable backend identifiers and public API re-exports.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- The updated Google request preserves required image modalities and normalizes malformed generation settings.
- OpenRouter metadata can no longer replace validated model, message, or modality fields.
- Known text-only defaults are rejected before either provider sends an image request.
- No blocking issue remains in the reviewed changes.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| crates/autoagents-llm/src/backends/google.rs | Adds Gemini image generation, input-image encoding, metadata handling, response decoding, and request validation. |
| crates/autoagents-llm/src/backends/openrouter.rs | Adds OpenRouter image generation, data-URL handling, protected request fields, and response decoding. |
| crates/autoagents-llm/src/image_generation.rs | Defines the shared image-generation API and recursive metadata merge helper. |
| crates/autoagents-llm/src/builder.rs | Adds equality and serialization traits to backend identifiers. |
| crates/autoagents-llm/src/lib.rs | Publishes and re-exports the image-generation API. |

<sub>Reviews (10): Last reviewed commit: ["fix(derive): restore stable trybuild dia..."](https://github.com/liquidos-ai/autoagents/commit/b206eae14fdfa0cff4ae8396446a5d6c7d01247f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45933335)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://app.greptile.com/liquidos/github/liquidos-ai/autoagents/-/custom-context?memory=b47666cb-3593-419b-8e94-f613c4c4a23c))
- Context used - AGENTS.md ([source](https://app.greptile.com/liquidos/github/liquidos-ai/autoagents/-/custom-context?memory=3016560d-8393-46c9-8b28-32dd4efbbe2e))
- Context used - docs/content/core-concepts/agents.md ([source](https://app.greptile.com/liquidos/github/liquidos-ai/autoagents/-/custom-context?memory=ee5ee7f3-1bae-40fc-ab9a-3cfb1dc16d60))
</details>

<!-- /greptile_comment -->