### PR TITLE
[MAINT]: Update ractor to 0.16.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1217,9 +1217,9 @@ dependencies = [
 
 [[package]]
 name = "bon"
-version = "2.3.0"
+version = "3.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97493a391b4b18ee918675fb8663e53646fd09321c58b46afa04e8ce2499c869"
+checksum = "a602c73c7b0148ec6d12af6fd5cc7a46e2eacc8878271a999abac56eed12f561"
 dependencies = [
  "bon-macros",
  "rustversion",
@@ -1227,14 +1227,16 @@ dependencies = [
 
 [[package]]
 name = "bon-macros"
-version = "2.3.0"
+version = "3.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a2af3eac944c12cdf4423eab70d310da0a8e5851a18ffb192c0a5e3f7ae1663"
+checksum = "6dee98b0db6a962de883bf5d20362dee4d7ca0d12fe39a7c6c73c844e1cd7c1f"
 dependencies = [
- "darling 0.20.11",
+ "darling 0.23.0",
  "ident_case",
+ "prettyplease",
  "proc-macro2",
  "quote",
+ "rustversion",
  "syn 2.0.118",
 ]
 
@@ -4484,7 +4486,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -7413,7 +7415,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.3",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -7452,7 +7454,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.4",
  "tracing",
  "windows-sys 0.61.2",
 ]
@@ -7480,9 +7482,9 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "ractor"
-version = "0.15.13"
+version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f12c86deb2af198b10a04c4fb3fba73baf3bb300df765a29272f0e5583da7510"
+checksum = "83ee8d79e5f2a18e941aee4cae10d27c9442d9f48c7a84b1318fe3627bd6b151"
 dependencies = [
  "async-trait",
  "bon",
@@ -7490,6 +7492,7 @@ dependencies = [
  "futures",
  "js-sys",
  "once_cell",
+ "ractor_macros",
  "serde",
  "strum 0.28.0",
  "tokio",
@@ -7498,6 +7501,18 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-time",
+]
+
+[[package]]
+name = "ractor_macros"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "836403307068b47a7636f8c3fd344a92a202f809f7831c4e5a8b5588df1b07ae"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -10390,9 +10405,9 @@ dependencies = [
 
 [[package]]
 name = "tokio_with_wasm"
-version = "0.8.8"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34e40fbbbd95441133fe9483f522db15dbfd26dc636164ebd8f2dd28759a6aa6"
+checksum = "ef3ce6a8f5b5190dfe4851db6c969e8360a262759e16a0b75dfc43af19d97a86"
 dependencies = [
  "js-sys",
  "tokio",
@@ -10404,9 +10419,9 @@ dependencies = [
 
 [[package]]
 name = "tokio_with_wasm_proc"
-version = "0.8.8"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d01145a2c788d6aae4cd653afec1e8332534d7d783d01897cefcafe4428de992"
+checksum = "1d8aa1d26c1550eef93cfb2dafadc145b3220432dae8d156b5ba485880594ffe"
 dependencies = [
  "quote",
  "syn 2.0.118",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,7 +123,7 @@ httpmock = "0.8.3"
 testcontainers = "0.27.3"
 hound = "3.5.1"
 rodio = "0.22.2"
-ractor = { version = "0.15.7" }
+ractor = { version = "0.16.2" }
 toml = { version = "1.0.7" }
 hf-hub = { version = "0.5.0", default-features = false }
 encoding_rs = "0.8.35"


### PR DESCRIPTION
Closes #296

## Summary

- update the workspace's declared `ractor` dependency from 0.15.7 to 0.16.2
- refresh the lockfile from resolved ractor 0.15.13 to 0.16.2
- preserve the existing `serde` and `async-trait` feature selection

## Performance changes

Relative to the lockfile's resolved 0.15.13 baseline, ractor 0.16 adds:

- one actor-loop allocation per actor lifetime instead of one per message; upstream's 100,000-message no-span benchmark improved from 12.995 ms to 8.861 ms median (31.8%)
- no disabled tracing span storage/instrumentation; the no-active-span benchmark improved from 15.370 ms to 13.602 ms median (11.5%)
- borrowed registry lookups and registration paths that avoid unnecessary string allocations
- process-group shutdown cleanup proportional to the stopping actor's relationships; the upstream 20,000-group/500-actor probe improved from 190.432 ms to 0.979 ms median
- fewer allocations in derived cluster-message serialization (cluster-only; not enabled here)

The benchmark percentages describe their individual upstream configurations and should not be added together. The lower 0.15.7 manifest floor means the requirement bump also makes 0.15.8-0.15.13 improvements explicit, although the existing lockfile already resolved those releases.

## 0.16 highlights

The main enhancement is the opt-in `actor-macros` feature: `#[ractor::actor]` can generate actor implementations, local message enums, and focused `#[ractor::message]`, `#[ractor::supervision]`, and `#[ractor::rpc]` dispatch. This PR does not enable that feature, so existing actor definitions and behavior are unchanged. The releases also improve factory API ergonomics and cluster reliability, and require Rust 1.85.

## Validation

- `cargo fmt --all`
- `cargo clippy --all-features --all-targets -- -D warnings`
- `cargo test --workspace --features default --exclude autoagents-burn --exclude autoagents-mistral-rs --exclude wasm_agent`

The workspace test required CMake for its native llama.cpp dependency; after supplying CMake locally, all unit tests, integration tests, UI tests, and doctests passed.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Updates the workspace’s ractor dependency from 0.15.7 to 0.16.2.
- Refreshes the resolved ractor version from 0.15.13 to 0.16.2.
- Updates required transitive dependencies, including bon, ractor_macros, and tokio_with_wasm.
- Retains the existing serde and async-trait feature configuration in autoagents-core.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete changed-code-triggered failures identified.

The workspace’s existing ractor API usage remains compatible, its Rust edition already requires a sufficiently recent toolchain, and the advisory-affected packages present in the lockfile were not added or changed by this update.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| Cargo.toml | Raises the workspace ractor requirement to 0.16.2 without changing its existing consumer feature configuration. |
| Cargo.lock | Resolves ractor 0.16.2 and its updated transitive dependency graph; no concrete compatibility or security regression was identified. |

</details>

<sub>Reviews (1): Last reviewed commit: ["\[MAINT\]: Update ractor to 0.16.2"](https://github.com/liquidos-ai/autoagents/commit/6af6f231a8abcee2741a316b313146d717005738) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49153129)</sub>

<!-- /greptile_comment -->