### PR TITLE
[FEATURE]: Add runtime-loadable Agent Skills support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,6 +138,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ambient-authority"
+version = "0.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9d4ee0d472d1cd2e28c97dfa124b3d8d992e10eb0a035f33f5d12e3a177ba3b"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -431,6 +437,8 @@ dependencies = [
  "async-trait",
  "autoagents-llm",
  "autoagents-protocol",
+ "cap-fs-ext",
+ "cap-std",
  "core_affinity",
  "criterion",
  "deno_ast",
@@ -439,12 +447,15 @@ dependencies = [
  "futures-util",
  "getrandom 0.4.3",
  "log",
+ "notify",
  "ractor",
  "regex",
  "rquickjs",
  "schemars 0.8.22",
  "serde",
  "serde_json",
+ "serde_yaml_ng",
+ "sha2",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
@@ -1538,6 +1549,48 @@ dependencies = [
  "ug",
  "ug-cuda",
  "ug-metal",
+]
+
+[[package]]
+name = "cap-fs-ext"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d78e5a3368ae89b7cb68186411452b4b9fac8b41be9c19bf3f47c2d2c8e36e6b"
+dependencies = [
+ "cap-primitives",
+ "cap-std",
+ "io-lifetimes 3.0.1",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "cap-primitives"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdadbd7c002d3a484b35243669abdae85a0ebaded5a61117169dc3400f9a7ff0"
+dependencies = [
+ "ambient-authority",
+ "fs-set-times",
+ "io-extras",
+ "io-lifetimes 3.0.1",
+ "ipnet",
+ "maybe-owned",
+ "rustix 1.1.4",
+ "rustix-linux-procfs",
+ "windows-sys 0.61.2",
+ "winx",
+]
+
+[[package]]
+name = "cap-std"
+version = "4.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7281235d6e96d3544ca18bba9049be92f4190f8d923e3caef1b5f66cfa752608"
+dependencies = [
+ "cap-primitives",
+ "io-extras",
+ "io-lifetimes 3.0.1",
+ "rustix 1.1.4",
 ]
 
 [[package]]
@@ -3549,6 +3602,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs-set-times"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94e7099f6313ecacbe1256e8ff9d617b75d1bcb16a6fddef94866d225a01a14a"
+dependencies = [
+ "io-lifetimes 2.0.4",
+ "rustix 1.1.4",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "fs2"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3563,6 +3627,15 @@ name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "funty"
@@ -4763,6 +4836,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "153be1941a183ec9ccd095ddbe17a8b8d435ef6c76e9e02451b933c3999af2c8"
+dependencies = [
+ "bitflags 2.13.0",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c033f80b2c113cdf91ab7a33faa9cbc014726dcad99880c8609af2a370edf37d"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "inout"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4817,6 +4910,28 @@ dependencies = [
  "widestring",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "io-extras"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20fd6de4ccfcc187e38bc21cfa543cb5a302cb86a8b114eb7f0bf0dc9f8ac00f"
+dependencies = [
+ "io-lifetimes 3.0.1",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "io-lifetimes"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06432fb54d3be7964ecd3649233cddf80db2832f47fec34c01f65b3d9d774983"
+
+[[package]]
+name = "io-lifetimes"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f0fb0570afe1fed943c5c3d4102d5358592d8625fda6a0007fdbe65a92fba96"
 
 [[package]]
 name = "ipnet"
@@ -5004,6 +5119,26 @@ dependencies = [
  "cfg-if",
  "futures-util",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "kqueue"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "273c0752728918e0ac4976f2b275b6fefb9ecd400585dec929419f3844cd87b5"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07293a4e297ac234359b510362495713f75ea345d5307140414f20c69ffeb087"
+dependencies = [
+ "bitflags 2.13.0",
+ "libc",
 ]
 
 [[package]]
@@ -5400,6 +5535,12 @@ dependencies = [
  "autocfg",
  "rawpointer",
 ]
+
+[[package]]
+name = "maybe-owned"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4facc753ae494aeb6e3c22f839b158aebd4f9270f55cd3c79906c45476c47ab4"
 
 [[package]]
 name = "maybe-rayon"
@@ -6002,6 +6143,33 @@ name = "noop_proc_macro"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
+
+[[package]]
+name = "notify"
+version = "8.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
+dependencies = [
+ "bitflags 2.13.0",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio 1.2.1",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "notify-types"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
+dependencies = [
+ "bitflags 2.13.0",
+]
 
 [[package]]
 name = "ntapi"
@@ -8274,6 +8442,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustix-linux-procfs"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fc84bf7e9aa16c4f2c758f27412dc9841341e16aa682d9c7ac308fe3ee12056"
+dependencies = [
+ "once_cell",
+ "rustix 1.1.4",
+]
+
+[[package]]
 name = "rustls"
 version = "0.23.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8807,6 +8985,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml_ng"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4db627b98b36d4203a7b458cf3573730f2bb591b28871d916dfa9efabfd41f"
+dependencies = [
+ "indexmap 2.14.0",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "servo_arc"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8957,6 +9148,18 @@ name = "siphasher"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+
+[[package]]
+name = "skills-agent"
+version = "0.4.0"
+dependencies = [
+ "autoagents",
+ "autoagents-derive",
+ "env_logger",
+ "serde_json",
+ "tokio",
+ "tokio-stream",
+]
 
 [[package]]
 name = "slab"
@@ -12426,6 +12629,16 @@ name = "winsafe"
 version = "0.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
+
+[[package]]
+name = "winx"
+version = "0.36.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f3fd376f71958b862e7afb20cfe5a22830e1963462f3a17f49d82a6c1d1f42d"
+dependencies = [
+ "bitflags 2.13.0",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,10 +60,15 @@ tokio = { version = "1.50.0", features = ["full"] }
 async-trait = "0.1.89"
 reqwest = { version = "0.13.2", features = ["json", "query", "stream"] }
 serde = { version = "1.0.228", features = [
+    "alloc",
     "derive",
     "rc",
 ], default-features = false }
 serde_json = "1.0.149"
+serde_yaml_ng = "0.10.0"
+sha2 = "0.10.9"
+cap-std = "4.0.2"
+cap-fs-ext = "4.0.2"
 strum = { version = "0.28.0", features = ["derive", "strum_macros"] }
 schemars = "0.8.19"
 strum_macros = "0.28.0"
@@ -88,6 +93,7 @@ dirs = "6.0.0"
 regex = "1.12.3"
 glob = "0.3.3"
 walkdir = "2.5"
+notify = "8.2.0"
 ignore = "0.4.25"
 wasmtime = "44.0.1"
 tokenizers = { version = "0.23.1", default-features = false, features = [] }

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ model with structured tool calling, configurable memory, and pluggable LLM backe
 
 - **Agent execution**: ReAct and basic executors, streaming responses, and structured outputs
 - **Tooling**: Derive macros for tools and outputs, plus a sandboxed WASM runtime for tool execution
+- **Agent Skills**: Progressive, `SKILL.md`-based instructions with live add, update, and removal discovery
 - **Memory**: Sliding window memory with extensible backends
 - **LLM providers**: Cloud and local backends behind a unified interface
 - **LLM Guardrails**: Guardrail implementation for safeguarding LLM inference
@@ -316,6 +317,10 @@ Demonstrates configurable input and output guardrails with Block, Sanitize, and 
 ### [MCP Integration](examples/mcp/)
 
 Demonstrates how to integrate AutoAgents with the Model Context Protocol (MCP).
+
+### [Agent Skills](examples/skills_agent/)
+
+Demonstrates boot-time and live discovery of Agent Skills, activation, and scoped resource access.
 
 ### [Local Models](examples/mistral_rs)
 

--- a/bindings/python/autoagents/src/agent/builder.rs
+++ b/bindings/python/autoagents/src/agent/builder.rs
@@ -333,6 +333,7 @@ fn event_submission_id(event: &Event) -> Option<SubmissionId> {
         | Event::StreamChunk { sub_id, .. }
         | Event::StreamToolCall { sub_id, .. }
         | Event::StreamComplete { sub_id, .. } => Some(*sub_id),
+        Event::Skill { event } => event.submission_id,
         Event::PublishMessage { .. } | Event::NewTask { .. } | Event::SendMessage { .. } => None,
     }
 }

--- a/bindings/python/autoagents/src/events/mod.rs
+++ b/bindings/python/autoagents/src/events/mod.rs
@@ -110,6 +110,13 @@ fn event_to_payload(event: Event) -> PyResult<Value> {
             tool_name,
             json!({ "error": error }),
         )),
+        Event::Skill { event } => Ok(json!({
+            "kind": "skill",
+            "actor_id": event.actor_id.to_string(),
+            "sub_id": event.submission_id.map(|id| id.to_string()),
+            "skill_session_id": event.session_id.to_string(),
+            "event": event.event,
+        })),
         Event::TurnStarted {
             sub_id,
             actor_id,

--- a/crates/autoagents-core/Cargo.toml
+++ b/crates/autoagents-core/Cargo.toml
@@ -11,7 +11,8 @@ readme.workspace = true
 
 [features]
 default = []
-full = ["wasmtime", "codeact"]
+full = ["wasmtime", "codeact", "skill-watch"]
+skill-watch = ["dep:notify"]
 wasmtime = ["dep:wasmtime"]
 codeact = ["dep:rquickjs", "dep:deno_ast"]
 
@@ -21,6 +22,8 @@ autoagents-protocol = { workspace = true }
 async-trait = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+serde_yaml_ng = { workspace = true }
+sha2 = { workspace = true }
 uuid = { workspace = true, features = ["serde", "v4"] }
 thiserror = { workspace = true }
 futures = { workspace = true }
@@ -35,6 +38,9 @@ deno_ast = { workspace = true, optional = true, features = ["transpiling", "visi
 
 # Non-WASM dependencies (only when not targeting wasm32)
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+cap-std = { workspace = true }
+cap-fs-ext = { workspace = true }
+notify = { workspace = true, optional = true }
 tokio = { workspace = true }
 tokio-stream = { workspace = true, features = ["sync"] }
 ractor = { workspace = true, features = ["serde", "async-trait"] }

--- a/crates/autoagents-core/src/agent/actor.rs
+++ b/crates/autoagents-core/src/agent/actor.rs
@@ -98,7 +98,15 @@ where
         let tx = runtime.tx();
 
         let agent: Arc<BaseAgent<T, ActorAgent>> = Arc::new(
-            BaseAgent::<T, ActorAgent>::new(self.inner, llm, self.memory, tx, self.stream).await?,
+            BaseAgent::<T, ActorAgent>::new(
+                self.inner,
+                llm,
+                self.memory,
+                self.skills,
+                tx,
+                self.stream,
+            )
+            .await?,
         );
 
         // Create agent actor
@@ -141,7 +149,7 @@ impl<T: AgentDeriveT + AgentExecutor + AgentHooks> BaseAgent<T, ActorAgent> {
         let tx = self.tx().map_err(|_| RunnableAgentError::EmptyTx)?;
         let tx_event = Some(tx.clone());
 
-        let context = self.create_context();
+        let context = self.create_context(&task);
 
         //Run Hook
         let hook_outcome = self.inner.on_run_start(&task, &context).await;
@@ -193,7 +201,7 @@ impl<T: AgentDeriveT + AgentExecutor + AgentHooks> BaseAgent<T, ActorAgent> {
         <T as AgentDeriveT>::Output: From<<T as AgentExecutor>::Output>,
         <T as AgentExecutor>::Error: Into<RunnableAgentError>,
     {
-        let context = self.create_context();
+        let context = self.create_context(&task);
         self.run_stream_with_context(task, context).await
     }
 
@@ -262,7 +270,7 @@ impl<T: AgentDeriveT + AgentExecutor + AgentHooks> BaseAgent<T, ActorAgent> {
         let submission_id = task.submission_id;
         let tx = self.tx().map_err(|_| RunnableAgentError::EmptyTx)?;
         let tx_event = Some(tx.clone());
-        let context = self.create_context();
+        let context = self.create_context(&task);
 
         let hook_outcome = self.inner.on_run_start(&task, &context).await;
         match hook_outcome {
@@ -508,7 +516,7 @@ mod tests {
         let mock = MockAgentImpl::new("agent", "desc");
         let llm = Arc::new(MockLLMProvider);
         let (tx, _rx) = mpsc::channel(2);
-        let mut agent = BaseAgent::<_, ActorAgent>::new(mock, llm, None, tx, false)
+        let mut agent = BaseAgent::<_, ActorAgent>::new(mock, llm, None, None, tx, false)
             .await
             .unwrap();
         agent.tx = None;
@@ -521,7 +529,7 @@ mod tests {
         let llm = Arc::new(MockLLMProvider);
         let (tx, _rx) = mpsc::channel(8);
         Arc::new(
-            BaseAgent::<_, ActorAgent>::new(mock, llm, None, tx, stream)
+            BaseAgent::<_, ActorAgent>::new(mock, llm, None, None, tx, stream)
                 .await
                 .expect("agent should build"),
         )
@@ -605,7 +613,7 @@ mod tests {
         let llm = Arc::new(MockLLMProvider);
         let (tx, mut rx) = mpsc::channel(2);
         let agent = Arc::new(
-            BaseAgent::<_, ActorAgent>::new(AbortStreamingAgent, llm, None, tx, false)
+            BaseAgent::<_, ActorAgent>::new(AbortStreamingAgent, llm, None, None, tx, false)
                 .await
                 .expect("agent should build"),
         );
@@ -633,7 +641,7 @@ mod tests {
         let llm = Arc::new(MockLLMProvider);
         let (tx, mut rx) = mpsc::channel(2);
         let agent = Arc::new(
-            BaseAgent::<_, ActorAgent>::new(AbortStreamingAgent, llm, None, tx, true)
+            BaseAgent::<_, ActorAgent>::new(AbortStreamingAgent, llm, None, None, tx, true)
                 .await
                 .expect("agent should build"),
         );
@@ -718,7 +726,7 @@ mod tests {
         let llm = Arc::new(MockLLMProvider);
         let (tx, mut rx) = mpsc::channel(2);
         let agent = Arc::new(
-            BaseAgent::<_, ActorAgent>::new(FailingStreamSetupAgent, llm, None, tx, true)
+            BaseAgent::<_, ActorAgent>::new(FailingStreamSetupAgent, llm, None, None, tx, true)
                 .await
                 .expect("agent should build"),
         );
@@ -801,7 +809,7 @@ mod tests {
         let llm = Arc::new(MockLLMProvider);
         let (tx, mut rx) = mpsc::channel(2);
         let agent = Arc::new(
-            BaseAgent::<_, ActorAgent>::new(EmptyStreamAgent, llm, None, tx, true)
+            BaseAgent::<_, ActorAgent>::new(EmptyStreamAgent, llm, None, None, tx, true)
                 .await
                 .expect("agent should build"),
         );
@@ -887,7 +895,7 @@ mod tests {
         let llm = Arc::new(MockLLMProvider);
         let (tx, mut rx) = mpsc::channel(2);
         let agent = Arc::new(
-            BaseAgent::<_, ActorAgent>::new(StreamItemErrorAgent, llm, None, tx, true)
+            BaseAgent::<_, ActorAgent>::new(StreamItemErrorAgent, llm, None, None, tx, true)
                 .await
                 .expect("agent should build"),
         );
@@ -918,7 +926,7 @@ mod tests {
         let llm = Arc::new(MockLLMProvider);
         let (tx, mut rx) = mpsc::channel(2);
         let agent = Arc::new(
-            BaseAgent::<_, ActorAgent>::new(StreamItemErrorAgent, llm, None, tx, true)
+            BaseAgent::<_, ActorAgent>::new(StreamItemErrorAgent, llm, None, None, tx, true)
                 .await
                 .expect("agent should build"),
         );
@@ -950,6 +958,7 @@ mod tests {
             MockAgentImpl::new("agent", "desc"),
             llm,
             None,
+            None,
             tx,
             true,
         )
@@ -970,7 +979,7 @@ mod tests {
         let llm = Arc::new(MockLLMProvider);
         let (tx, mut rx) = mpsc::channel(2);
         let agent = Arc::new(
-            BaseAgent::<_, ActorAgent>::new(MultiItemStreamAgent, llm, None, tx, true)
+            BaseAgent::<_, ActorAgent>::new(MultiItemStreamAgent, llm, None, None, tx, true)
                 .await
                 .expect("agent should build"),
         );
@@ -1001,7 +1010,7 @@ mod tests {
         let llm = Arc::new(MockLLMProvider);
         let (tx, mut rx) = mpsc::channel(2);
         let agent = Arc::new(
-            BaseAgent::<_, ActorAgent>::new(DivergentStreamingAgent, llm, None, tx, true)
+            BaseAgent::<_, ActorAgent>::new(DivergentStreamingAgent, llm, None, None, tx, true)
                 .await
                 .expect("agent should build"),
         );
@@ -1036,6 +1045,7 @@ mod tests {
                 DivergentStreamingAgent,
                 llm.clone(),
                 None,
+                None,
                 tx_run,
                 false,
             )
@@ -1044,9 +1054,16 @@ mod tests {
         );
         let (tx_stream, mut rx_stream) = mpsc::channel(2);
         let stream_agent = Arc::new(
-            BaseAgent::<_, ActorAgent>::new(DivergentStreamingAgent, llm, None, tx_stream, true)
-                .await
-                .expect("stream agent should build"),
+            BaseAgent::<_, ActorAgent>::new(
+                DivergentStreamingAgent,
+                llm,
+                None,
+                None,
+                tx_stream,
+                true,
+            )
+            .await
+            .expect("stream agent should build"),
         );
 
         let task = Task::new("parity payload");

--- a/crates/autoagents-core/src/agent/base.rs
+++ b/crates/autoagents-core/src/agent/base.rs
@@ -1,13 +1,17 @@
 use crate::agent::config::AgentConfig;
 use crate::agent::executor::event_helper::EventHelper;
 use crate::agent::memory::MemoryProvider;
+use crate::agent::skill::{
+    SkillConfiguration, SkillLifecycle, SkillLifecycleDecision, SkillRefreshReport, SkillRuntime,
+    SkillRuntimeIdentity, SkillSession, SkillSnapshot,
+};
 use crate::agent::task::Task;
 use crate::agent::{AgentExecutor, Context, output::AgentOutputT};
 use crate::tool::{ToolT, to_llm_tool};
 use async_trait::async_trait;
 use autoagents_llm::LLMProvider;
 use autoagents_llm::chat::Tool;
-use autoagents_protocol::{ActorID, Event, SubmissionId};
+use autoagents_protocol::{ActorID, Event, SkillEvent, SubmissionId};
 
 use serde_json::Value;
 use std::marker::PhantomData;
@@ -63,6 +67,7 @@ pub struct BaseAgent<T: AgentDeriveT + AgentExecutor + AgentHooks + Send + Sync,
     pub id: ActorID,
     /// Optional memory provider
     pub(crate) memory: Option<Arc<Mutex<Box<dyn MemoryProvider>>>>,
+    pub(crate) skills: Option<SkillConfiguration>,
     /// Cached serialized tool definitions
     pub(crate) serialized_tools: Option<Arc<Vec<Tool>>>,
     /// Tx sender
@@ -84,10 +89,21 @@ impl<T: AgentDeriveT + AgentExecutor + AgentHooks, A: AgentType> BaseAgent<T, A>
         inner: T,
         llm: Arc<dyn LLMProvider>,
         memory: Option<Box<dyn MemoryProvider>>,
+        skills: Option<SkillConfiguration>,
         tx: Sender<Event>,
         stream: bool,
     ) -> Result<Self, RunnableAgentError> {
         let tool_defs = inner.tools();
+        if skills.is_some() && !inner.supports_agent_skills() {
+            return Err(RunnableAgentError::InitializationError(format!(
+                "executor '{}' does not support Agent Skills",
+                std::any::type_name::<T>()
+            )));
+        }
+        if skills.is_some() {
+            SkillRuntime::validate_agent_tools(&tool_defs)
+                .map_err(|error| RunnableAgentError::InitializationError(error.to_string()))?;
+        }
         let serialized_tools = if tool_defs.is_empty() {
             None
         } else {
@@ -101,6 +117,7 @@ impl<T: AgentDeriveT + AgentExecutor + AgentHooks, A: AgentType> BaseAgent<T, A>
             llm,
             tx: Some(tx),
             memory: memory.map(|m| Arc::new(Mutex::new(m))),
+            skills,
             serialized_tools,
             stream,
             marker: PhantomData,
@@ -108,6 +125,9 @@ impl<T: AgentDeriveT + AgentExecutor + AgentHooks, A: AgentType> BaseAgent<T, A>
 
         //Run Hook
         agent.inner().on_agent_create().await;
+        if let Some(runtime) = agent.skill_runtime(None) {
+            runtime.initialize().await;
+        }
 
         Ok(agent)
     }
@@ -139,19 +159,65 @@ impl<T: AgentDeriveT + AgentExecutor + AgentHooks, A: AgentType> BaseAgent<T, A>
         self.stream
     }
 
-    pub(crate) fn create_context(&self) -> Arc<Context> {
+    pub(crate) fn create_context(&self, task: &Task) -> Arc<Context> {
         let tools = self.tools();
         let cached_tools = self
             .serialized_tools()
-            .filter(|cached| tools_match_cached(&tools, cached));
+            .filter(|cached| Self::tools_match_cached(&tools, cached));
+        let runtime = self.skill_runtime(Some(task.submission_id));
         Arc::new(
             Context::new(self.llm(), self.tx.clone())
                 .with_memory(self.memory())
                 .with_serialized_tools(cached_tools)
                 .with_tools(tools)
                 .with_config(self.agent_config())
+                .with_skills(runtime)
                 .with_stream(self.stream()),
         )
+    }
+
+    pub fn skill_session(&self) -> Option<Arc<SkillSession>> {
+        self.skills.as_ref().map(SkillConfiguration::session)
+    }
+
+    pub fn skill_snapshot(&self) -> Option<Arc<SkillSnapshot>> {
+        self.skills
+            .as_ref()
+            .map(SkillConfiguration::registry)
+            .map(|registry| registry.snapshot())
+    }
+
+    pub async fn refresh_skills(&self) -> Option<SkillRefreshReport> {
+        let runtime = self.skill_runtime(None)?;
+        Some(runtime.refresh_now().await)
+    }
+
+    pub async fn reset_skill_session(&self) {
+        if let Some(runtime) = self.skill_runtime(None) {
+            runtime.reset_session().await;
+        }
+    }
+
+    fn skill_runtime(&self, submission_id: Option<SubmissionId>) -> Option<Arc<SkillRuntime>> {
+        let configuration = self.skills.clone()?;
+        let lifecycle: Arc<dyn SkillLifecycle> = Arc::new(AgentSkillLifecycle {
+            inner: self.inner(),
+        });
+        let identity = SkillRuntimeIdentity::new(self.id, submission_id, self.tx.clone());
+        Some(SkillRuntime::new(configuration, identity, lifecycle))
+    }
+
+    fn tools_match_cached(tools: &[Box<dyn ToolT>], cached: &[Tool]) -> bool {
+        if tools.len() != cached.len() {
+            return false;
+        }
+
+        tools.iter().zip(cached.iter()).all(|(tool, cached_tool)| {
+            cached_tool.tool_type == "function"
+                && cached_tool.function.name == tool.name()
+                && cached_tool.function.description == tool.description()
+                && cached_tool.function.parameters == tool.args_schema()
+        })
     }
 
     pub fn agent_config(&self) -> AgentConfig {
@@ -183,6 +249,7 @@ impl<T: AgentDeriveT + AgentExecutor + AgentHooks, A: AgentType> BaseAgent<T, A>
             llm: self.llm.clone(),
             id: self.id,
             memory: self.memory.clone(),
+            skills: self.skills.clone(),
             serialized_tools: self.serialized_tools.clone(),
             tx: self.tx.clone(),
             stream: self.stream,
@@ -229,17 +296,46 @@ impl<T: AgentDeriveT + AgentExecutor + AgentHooks, A: AgentType> BaseAgent<T, A>
     }
 }
 
-fn tools_match_cached(tools: &[Box<dyn ToolT>], cached: &[Tool]) -> bool {
-    if tools.len() != cached.len() {
-        return false;
+#[derive(Debug)]
+struct AgentSkillLifecycle<T: AgentDeriveT + AgentExecutor + AgentHooks> {
+    inner: Arc<T>,
+}
+
+#[async_trait]
+impl<T: AgentDeriveT + AgentExecutor + AgentHooks> SkillLifecycle for AgentSkillLifecycle<T> {
+    async fn on_catalog_changed(&self, event: &SkillEvent) {
+        self.inner.on_skill_catalog_changed(event).await;
     }
 
-    tools.iter().zip(cached.iter()).all(|(tool, cached_tool)| {
-        cached_tool.tool_type == "function"
-            && cached_tool.function.name == tool.name()
-            && cached_tool.function.description == tool.description()
-            && cached_tool.function.parameters == tool.args_schema()
-    })
+    async fn on_activation_requested(&self, event: &SkillEvent) -> SkillLifecycleDecision {
+        match self.inner.on_skill_activation(event).await {
+            crate::agent::HookOutcome::Continue => SkillLifecycleDecision::Continue,
+            crate::agent::HookOutcome::Abort => SkillLifecycleDecision::Abort,
+        }
+    }
+
+    async fn on_activated(&self, event: &SkillEvent) {
+        self.inner.on_skill_activated(event).await;
+    }
+
+    async fn on_deactivated(&self, event: &SkillEvent) {
+        self.inner.on_skill_deactivated(event).await;
+    }
+
+    async fn on_resource_access_requested(&self, event: &SkillEvent) -> SkillLifecycleDecision {
+        match self.inner.on_skill_resource_access(event).await {
+            crate::agent::HookOutcome::Continue => SkillLifecycleDecision::Continue,
+            crate::agent::HookOutcome::Abort => SkillLifecycleDecision::Abort,
+        }
+    }
+
+    async fn on_resource_accessed(&self, event: &SkillEvent) {
+        self.inner.on_skill_resource_result(event).await;
+    }
+
+    async fn on_operation_failed(&self, event: &SkillEvent) {
+        self.inner.on_skill_error(event).await;
+    }
 }
 
 #[cfg(test)]
@@ -281,9 +377,10 @@ mod tests {
         let llm = Arc::new(MockLLMProvider);
         let memory = Box::new(SlidingWindowMemory::new(5));
         let (tx, _): (Sender<Event>, Receiver<Event>) = channel(32);
-        let base_agent = BaseAgent::<_, DirectAgent>::new(mock_agent, llm, Some(memory), tx, true)
-            .await
-            .unwrap();
+        let base_agent =
+            BaseAgent::<_, DirectAgent>::new(mock_agent, llm, Some(memory), None, tx, true)
+                .await
+                .unwrap();
 
         assert_eq!(base_agent.name(), "test");
         assert_eq!(base_agent.description(), "test description");
@@ -296,11 +393,11 @@ mod tests {
         let mock_agent = MockAgentImpl::new("ctx_agent", "context agent");
         let llm = Arc::new(MockLLMProvider);
         let (tx, _): (Sender<Event>, Receiver<Event>) = channel(32);
-        let base_agent = BaseAgent::<_, DirectAgent>::new(mock_agent, llm, None, tx, false)
+        let base_agent = BaseAgent::<_, DirectAgent>::new(mock_agent, llm, None, None, tx, false)
             .await
             .unwrap();
 
-        let context = base_agent.create_context();
+        let context = base_agent.create_context(&Task::new("test"));
         let config = context.config();
         assert_eq!(config.name, "ctx_agent");
         assert_eq!(config.description, "context agent");

--- a/crates/autoagents-core/src/agent/builder.rs
+++ b/crates/autoagents-core/src/agent/builder.rs
@@ -3,6 +3,7 @@ use crate::actor::Topic;
 use crate::agent::base::AgentType;
 use crate::agent::hooks::AgentHooks;
 use crate::agent::memory::MemoryProvider;
+use crate::agent::skill::SkillConfiguration;
 use crate::agent::task::Task;
 use crate::agent::{AgentDeriveT, AgentExecutor};
 #[cfg(not(target_arch = "wasm32"))]
@@ -17,6 +18,7 @@ pub struct AgentBuilder<T: AgentDeriveT + AgentExecutor + AgentHooks, A: AgentTy
     pub(crate) stream: bool,
     pub(crate) llm: Option<Arc<dyn LLMProvider>>,
     pub(crate) memory: Option<Box<dyn MemoryProvider>>,
+    pub(crate) skills: Option<SkillConfiguration>,
     #[cfg(not(target_arch = "wasm32"))]
     pub(crate) runtime: Option<Arc<dyn Runtime>>,
     #[cfg(not(target_arch = "wasm32"))]
@@ -31,6 +33,7 @@ impl<T: AgentDeriveT + AgentExecutor + AgentHooks, A: AgentType> AgentBuilder<T,
             inner,
             llm: None,
             memory: None,
+            skills: None,
             #[cfg(not(target_arch = "wasm32"))]
             runtime: None,
             stream: false,
@@ -54,6 +57,12 @@ impl<T: AgentDeriveT + AgentExecutor + AgentHooks, A: AgentType> AgentBuilder<T,
     /// Set the memory provider
     pub fn memory(mut self, memory: Box<dyn MemoryProvider>) -> Self {
         self.memory = Some(memory);
+        self
+    }
+
+    /// Enable Agent Skills with an explicit catalog, conversation session, and policy.
+    pub fn skills(mut self, configuration: SkillConfiguration) -> Self {
+        self.skills = Some(configuration);
         self
     }
 

--- a/crates/autoagents-core/src/agent/context.rs
+++ b/crates/autoagents-core/src/agent/context.rs
@@ -2,6 +2,7 @@
 use crate::actor::{ActorMessage, Topic};
 use crate::agent::AgentConfig;
 use crate::agent::memory::MemoryProvider;
+use crate::agent::skill::SkillRuntime;
 use crate::agent::state::AgentState;
 use crate::tool::{ToolT, to_llm_tool};
 use autoagents_llm::LLMProvider;
@@ -27,6 +28,7 @@ pub struct Context {
     llm: Arc<dyn LLMProvider>,
     messages: Vec<ChatMessage>,
     memory: Option<Arc<Mutex<Box<dyn MemoryProvider>>>>,
+    skills: Option<Arc<SkillRuntime>>,
     tools: Vec<Box<dyn ToolT>>,
     serialized_tools: Option<Arc<Vec<Tool>>>,
     config: AgentConfig,
@@ -50,6 +52,7 @@ impl Context {
             llm,
             messages: vec![],
             memory: None,
+            skills: None,
             tools: vec![],
             serialized_tools: None,
             config: AgentConfig::default(),
@@ -98,6 +101,18 @@ impl Context {
         self
     }
 
+    pub(crate) fn with_skills(mut self, runtime: Option<Arc<SkillRuntime>>) -> Self {
+        let Some(runtime) = runtime else {
+            return self;
+        };
+        self.tools.extend(runtime.tools());
+        self.serialized_tools = Some(Arc::new(
+            self.tools.iter().map(to_llm_tool).collect::<Vec<_>>(),
+        ));
+        self.skills = Some(runtime);
+        self
+    }
+
     pub fn with_config(mut self, config: AgentConfig) -> Self {
         self.config = config;
         self
@@ -124,6 +139,17 @@ impl Context {
 
     pub fn memory(&self) -> Option<Arc<Mutex<Box<dyn MemoryProvider>>>> {
         self.memory.clone()
+    }
+
+    pub fn skills(&self) -> Option<Arc<SkillRuntime>> {
+        self.skills.clone()
+    }
+
+    pub async fn compose_system_prompt(&self, base_prompt: &str) -> String {
+        match &self.skills {
+            Some(skills) => skills.compose_system_prompt(base_prompt).await,
+            None => base_prompt.to_string(),
+        }
     }
 
     pub fn tools(&self) -> &[Box<dyn ToolT>] {

--- a/crates/autoagents-core/src/agent/direct.rs
+++ b/crates/autoagents-core/src/agent/direct.rs
@@ -6,6 +6,7 @@ use crate::agent::task::Task;
 use crate::agent::{AgentBuilder, AgentDeriveT, AgentExecutor, AgentHooks, BaseAgent, HookOutcome};
 use crate::error::Error;
 use autoagents_protocol::Event;
+use futures::{FutureExt, StreamExt};
 use serde_json::Value;
 use std::sync::Arc;
 
@@ -82,9 +83,37 @@ impl<T: AgentDeriveT + AgentExecutor + AgentHooks> AgentBuilder<T, DirectAgent> 
             "LLM provider is required".to_string(),
         ))?;
         let (tx, rx): (Sender<Event>, Receiver<Event>) = channel(DEFAULT_CHANNEL_BUFFER);
-        let agent: BaseAgent<T, DirectAgent> =
-            BaseAgent::<T, DirectAgent>::new(self.inner, llm, self.memory, tx, self.stream).await?;
-        let stream = receiver_into_stream(rx);
+        let mut stream = receiver_into_stream(rx);
+        let construction = BaseAgent::<T, DirectAgent>::new(
+            self.inner,
+            llm,
+            self.memory,
+            self.skills,
+            tx,
+            self.stream,
+        )
+        .fuse();
+        futures::pin_mut!(construction);
+
+        // Skill discovery runs during BaseAgent construction and emits lifecycle events. Drain
+        // the bounded channel concurrently so initialization can apply normal backpressure before
+        // the handle exposes its receiver. Captured events are replayed first, preserving the
+        // complete startup prefix and its ordering without making steady-state delivery unbounded.
+        let mut startup_events = Vec::new();
+        let agent: BaseAgent<T, DirectAgent> = loop {
+            futures::select_biased! {
+                result = construction => break result?,
+                event = stream.next().fuse() => match event {
+                    Some(event) => startup_events.push(event),
+                    None => {
+                        return Err(AgentBuildError::BuildFailure(
+                            "direct-agent event channel closed during construction".to_string(),
+                        ).into());
+                    }
+                }
+            }
+        };
+        let stream = Box::pin(futures::stream::iter(startup_events).chain(stream));
         Ok(DirectAgentHandle::new(agent, stream))
     }
 }
@@ -191,7 +220,7 @@ impl<T: AgentDeriveT + AgentExecutor + AgentHooks> BaseAgent<T, DirectAgent> {
     {
         let submission_id = task.submission_id;
         let tx_event = self.tx.clone();
-        let context = self.create_context();
+        let context = self.create_context(&task);
 
         //Run Hook
         let hook_outcome = self.inner.on_run_start(&task, &context).await;
@@ -237,7 +266,7 @@ impl<T: AgentDeriveT + AgentExecutor + AgentHooks> BaseAgent<T, DirectAgent> {
     {
         let submission_id = task.submission_id;
         let tx_event = self.tx.clone();
-        let context = self.create_context();
+        let context = self.create_context(&task);
 
         //Run Hook
         let hook_outcome = self.inner.on_run_start(&task, &context).await;

--- a/crates/autoagents-core/src/agent/executor/mod.rs
+++ b/crates/autoagents-core/src/agent/executor/mod.rs
@@ -47,6 +47,12 @@ pub trait AgentExecutor: Send + Sync + 'static {
 
     fn config(&self) -> ExecutorConfig;
 
+    /// Whether this executor can expose the Agent Skills activation tools and
+    /// continue with a subsequent turn containing the activated instructions.
+    fn supports_agent_skills(&self) -> bool {
+        false
+    }
+
     async fn execute(
         &self,
         task: &Task,

--- a/crates/autoagents-core/src/agent/executor/turn_engine.rs
+++ b/crates/autoagents-core/src/agent/executor/turn_engine.rs
@@ -586,10 +586,11 @@ impl TurnEngine {
             .system_prompt
             .as_deref()
             .unwrap_or_else(|| &context.config().description);
+        let system_prompt = context.compose_system_prompt(system_prompt).await;
         let mut messages = vec![ChatMessage {
             role: ChatRole::System,
             message_type: MessageType::Text,
-            content: system_prompt.to_string(),
+            content: system_prompt,
         }];
 
         let recalled = memory.recall_messages(task).await;

--- a/crates/autoagents-core/src/agent/hooks.rs
+++ b/crates/autoagents-core/src/agent/hooks.rs
@@ -3,6 +3,7 @@ use crate::agent::{AgentDeriveT, Context};
 use crate::tool::ToolCallResult;
 use async_trait::async_trait;
 use autoagents_llm::ToolCall;
+use autoagents_protocol::SkillEvent;
 use serde_json::Value;
 
 /// Outcome for hook execution: continue or abort the run.
@@ -46,6 +47,24 @@ pub trait AgentHooks: AgentDeriveT + Send + Sync {
     }
     /// Called if the execution of the tool failed
     async fn on_tool_error(&self, _tool_call: &ToolCall, _err: Value, _ctx: &Context) {}
+    /// Called after the available Agent Skills catalog changes.
+    async fn on_skill_catalog_changed(&self, _event: &SkillEvent) {}
+    /// Gate activation before skill instructions enter the prompt context.
+    async fn on_skill_activation(&self, _event: &SkillEvent) -> HookOutcome {
+        HookOutcome::Continue
+    }
+    /// Called after a skill becomes active for the current skill session.
+    async fn on_skill_activated(&self, _event: &SkillEvent) {}
+    /// Called after an active skill is removed from the current skill session.
+    async fn on_skill_deactivated(&self, _event: &SkillEvent) {}
+    /// Gate access before an activated skill resource is read.
+    async fn on_skill_resource_access(&self, _event: &SkillEvent) -> HookOutcome {
+        HookOutcome::Continue
+    }
+    /// Called after an activated skill resource is read successfully.
+    async fn on_skill_resource_result(&self, _event: &SkillEvent) {}
+    /// Called when discovery, activation, deactivation, or resource access fails.
+    async fn on_skill_error(&self, _event: &SkillEvent) {}
     /// Called when an Actor Agent post-shutdown, This has no effect on DirectAgent, It only works for ActorBased Agents
     async fn on_agent_shutdown(&self) {}
 }

--- a/crates/autoagents-core/src/agent/mod.rs
+++ b/crates/autoagents-core/src/agent/mod.rs
@@ -4,6 +4,7 @@ pub mod error;
 pub mod memory;
 mod output;
 mod protocol;
+pub mod skill;
 pub mod task;
 
 pub mod prebuilt;

--- a/crates/autoagents-core/src/agent/prebuilt/executor/basic.rs
+++ b/crates/autoagents-core/src/agent/prebuilt/executor/basic.rs
@@ -11,6 +11,7 @@ use crate::utils::stream_from_producer;
 use async_trait::async_trait;
 use autoagents_llm::ToolCall;
 use autoagents_llm::error::LLMError;
+use autoagents_protocol::SkillEvent;
 #[cfg(target_arch = "wasm32")]
 use futures::SinkExt;
 use serde::{Deserialize, Serialize};
@@ -175,6 +176,34 @@ where
 
     async fn on_tool_error(&self, tool_call: &ToolCall, err: Value, ctx: &Context) {
         self.inner.on_tool_error(tool_call, err, ctx).await
+    }
+
+    async fn on_skill_catalog_changed(&self, event: &SkillEvent) {
+        self.inner.on_skill_catalog_changed(event).await
+    }
+
+    async fn on_skill_activation(&self, event: &SkillEvent) -> HookOutcome {
+        self.inner.on_skill_activation(event).await
+    }
+
+    async fn on_skill_activated(&self, event: &SkillEvent) {
+        self.inner.on_skill_activated(event).await
+    }
+
+    async fn on_skill_deactivated(&self, event: &SkillEvent) {
+        self.inner.on_skill_deactivated(event).await
+    }
+
+    async fn on_skill_resource_access(&self, event: &SkillEvent) -> HookOutcome {
+        self.inner.on_skill_resource_access(event).await
+    }
+
+    async fn on_skill_resource_result(&self, event: &SkillEvent) {
+        self.inner.on_skill_resource_result(event).await
+    }
+
+    async fn on_skill_error(&self, event: &SkillEvent) {
+        self.inner.on_skill_error(event).await
     }
     async fn on_agent_shutdown(&self) {
         self.inner.on_agent_shutdown().await

--- a/crates/autoagents-core/src/agent/prebuilt/executor/codeact.rs
+++ b/crates/autoagents-core/src/agent/prebuilt/executor/codeact.rs
@@ -11,7 +11,7 @@ use async_trait::async_trait;
 use autoagents_llm::ToolCall;
 use autoagents_llm::chat::{ChatMessage, ChatRole, FunctionTool, MessageType, StreamChunk, Tool};
 use autoagents_llm::error::LLMError;
-use autoagents_protocol::{Event, SubmissionId};
+use autoagents_protocol::{Event, SkillEvent, SubmissionId};
 #[cfg(target_arch = "wasm32")]
 use futures::SinkExt;
 use futures::StreamExt;
@@ -282,6 +282,34 @@ where
         self.inner.on_tool_error(tool_call, err, ctx).await
     }
 
+    async fn on_skill_catalog_changed(&self, event: &SkillEvent) {
+        self.inner.on_skill_catalog_changed(event).await
+    }
+
+    async fn on_skill_activation(&self, event: &SkillEvent) -> HookOutcome {
+        self.inner.on_skill_activation(event).await
+    }
+
+    async fn on_skill_activated(&self, event: &SkillEvent) {
+        self.inner.on_skill_activated(event).await
+    }
+
+    async fn on_skill_deactivated(&self, event: &SkillEvent) {
+        self.inner.on_skill_deactivated(event).await
+    }
+
+    async fn on_skill_resource_access(&self, event: &SkillEvent) -> HookOutcome {
+        self.inner.on_skill_resource_access(event).await
+    }
+
+    async fn on_skill_resource_result(&self, event: &SkillEvent) {
+        self.inner.on_skill_resource_result(event).await
+    }
+
+    async fn on_skill_error(&self, event: &SkillEvent) {
+        self.inner.on_skill_error(event).await
+    }
+
     async fn on_agent_shutdown(&self) {
         self.inner.on_agent_shutdown().await
     }
@@ -300,6 +328,10 @@ where
         ExecutorConfig {
             max_turns: self.max_turns,
         }
+    }
+
+    fn supports_agent_skills(&self) -> bool {
+        true
     }
 
     async fn execute(
@@ -846,10 +878,11 @@ async fn build_messages(
         .system_prompt
         .as_deref()
         .unwrap_or_else(|| &context.config().description);
+    let system_prompt = context.compose_system_prompt(system_prompt).await;
     let mut messages = vec![ChatMessage {
         role: ChatRole::System,
         message_type: MessageType::Text,
-        content: build_codeact_system_prompt(system_prompt, tool_bindings),
+        content: build_codeact_system_prompt(&system_prompt, tool_bindings),
     }];
 
     let recalled = memory.recall_messages(task).await;

--- a/crates/autoagents-core/src/agent/prebuilt/executor/react.rs
+++ b/crates/autoagents-core/src/agent/prebuilt/executor/react.rs
@@ -27,7 +27,9 @@ pub use tokio::sync::mpsc::error::SendError;
 type SendError = futures::channel::mpsc::SendError;
 
 use crate::agent::hooks::{AgentHooks, HookOutcome};
+#[cfg(not(target_arch = "wasm32"))]
 use autoagents_protocol::Event;
+use autoagents_protocol::SkillEvent;
 
 /// Output of the ReAct-style agent
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -243,6 +245,34 @@ where
     async fn on_tool_error(&self, tool_call: &ToolCall, err: Value, ctx: &Context) {
         self.inner.on_tool_error(tool_call, err, ctx).await
     }
+
+    async fn on_skill_catalog_changed(&self, event: &SkillEvent) {
+        self.inner.on_skill_catalog_changed(event).await
+    }
+
+    async fn on_skill_activation(&self, event: &SkillEvent) -> HookOutcome {
+        self.inner.on_skill_activation(event).await
+    }
+
+    async fn on_skill_activated(&self, event: &SkillEvent) {
+        self.inner.on_skill_activated(event).await
+    }
+
+    async fn on_skill_deactivated(&self, event: &SkillEvent) {
+        self.inner.on_skill_deactivated(event).await
+    }
+
+    async fn on_skill_resource_access(&self, event: &SkillEvent) -> HookOutcome {
+        self.inner.on_skill_resource_access(event).await
+    }
+
+    async fn on_skill_resource_result(&self, event: &SkillEvent) {
+        self.inner.on_skill_resource_result(event).await
+    }
+
+    async fn on_skill_error(&self, event: &SkillEvent) {
+        self.inner.on_skill_error(event).await
+    }
     async fn on_agent_shutdown(&self) {
         self.inner.on_agent_shutdown().await
     }
@@ -259,6 +289,10 @@ impl<T: AgentDeriveT + AgentHooks> AgentExecutor for ReActAgent<T> {
         ExecutorConfig {
             max_turns: self.max_turns,
         }
+    }
+
+    fn supports_agent_skills(&self) -> bool {
+        true
     }
 
     async fn execute(

--- a/crates/autoagents-core/src/agent/skill/configuration.rs
+++ b/crates/autoagents-core/src/agent/skill/configuration.rs
@@ -1,0 +1,71 @@
+use crate::agent::skill::{SkillPolicy, SkillRegistry, SkillSession};
+use std::fmt;
+use std::sync::Arc;
+
+#[derive(Clone)]
+pub struct SkillConfiguration {
+    registry: Arc<SkillRegistry>,
+    session: Arc<SkillSession>,
+    policy: Arc<dyn SkillPolicy>,
+    max_resource_bytes: usize,
+}
+
+impl fmt::Debug for SkillConfiguration {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("SkillConfiguration")
+            .field("registry", &self.registry)
+            .field("session", &self.session)
+            .field("policy", &self.policy)
+            .field("max_resource_bytes", &self.max_resource_bytes)
+            .finish()
+    }
+}
+
+impl SkillConfiguration {
+    pub fn new(
+        registry: Arc<SkillRegistry>,
+        session: Arc<SkillSession>,
+        policy: Arc<dyn SkillPolicy>,
+    ) -> Self {
+        Self {
+            registry,
+            session,
+            policy,
+            max_resource_bytes: 1024 * 1024,
+        }
+    }
+
+    pub fn with_max_resource_bytes(mut self, max_resource_bytes: usize) -> Self {
+        self.max_resource_bytes = max_resource_bytes;
+        self
+    }
+
+    pub fn registry(&self) -> Arc<SkillRegistry> {
+        Arc::clone(&self.registry)
+    }
+
+    pub(crate) fn registry_ref(&self) -> &SkillRegistry {
+        &self.registry
+    }
+
+    pub fn session(&self) -> Arc<SkillSession> {
+        Arc::clone(&self.session)
+    }
+
+    pub(crate) fn session_ref(&self) -> &SkillSession {
+        &self.session
+    }
+
+    pub fn policy(&self) -> Arc<dyn SkillPolicy> {
+        Arc::clone(&self.policy)
+    }
+
+    pub(crate) fn policy_ref(&self) -> &dyn SkillPolicy {
+        self.policy.as_ref()
+    }
+
+    pub fn max_resource_bytes(&self) -> usize {
+        self.max_resource_bytes
+    }
+}

--- a/crates/autoagents-core/src/agent/skill/directory.rs
+++ b/crates/autoagents-core/src/agent/skill/directory.rs
@@ -1,0 +1,171 @@
+use crate::agent::skill::{SkillError, SkillSource, SkillSourceId, SkillSourceSnapshot};
+use async_trait::async_trait;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+#[cfg(not(target_arch = "wasm32"))]
+mod cache;
+#[cfg(not(target_arch = "wasm32"))]
+mod refresh;
+#[cfg(not(target_arch = "wasm32"))]
+mod scanner;
+
+#[cfg(not(target_arch = "wasm32"))]
+use cache::DirectorySkillCache;
+#[cfg(not(target_arch = "wasm32"))]
+use refresh::{DirectoryDiscovery, DirectoryRefreshState};
+#[cfg(not(target_arch = "wasm32"))]
+use scanner::DirectorySkillScanner;
+#[cfg(not(target_arch = "wasm32"))]
+use std::sync::{Arc, RwLock};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SkillRefreshStrategy {
+    Manual,
+    Poll {
+        interval: Duration,
+    },
+    Watch {
+        debounce: Duration,
+        fallback_interval: Duration,
+    },
+}
+
+#[derive(Clone, Debug)]
+pub struct SkillDiscoveryLimits {
+    pub max_skills: usize,
+    pub max_skill_file_bytes: usize,
+    pub max_total_skill_file_bytes: usize,
+    pub max_resources_per_skill: usize,
+    pub max_resource_file_bytes: usize,
+    pub max_total_resource_bytes: usize,
+    pub max_resource_depth: usize,
+}
+
+impl Default for SkillDiscoveryLimits {
+    fn default() -> Self {
+        Self {
+            max_skills: 256,
+            max_skill_file_bytes: 256 * 1024,
+            max_total_skill_file_bytes: 4 * 1024 * 1024,
+            max_resources_per_skill: 512,
+            max_resource_file_bytes: 1024 * 1024,
+            max_total_resource_bytes: 16 * 1024 * 1024,
+            max_resource_depth: 6,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct DirectorySkillSource {
+    id: SkillSourceId,
+    root: PathBuf,
+    refresh_strategy: SkillRefreshStrategy,
+    containment_root: Option<PathBuf>,
+    precedence: u16,
+    limits: SkillDiscoveryLimits,
+    #[cfg(not(target_arch = "wasm32"))]
+    cache: Arc<RwLock<DirectorySkillCache>>,
+    #[cfg(not(target_arch = "wasm32"))]
+    refresh: Arc<DirectoryRefreshState>,
+}
+
+impl DirectorySkillSource {
+    pub fn new(root: impl Into<PathBuf>, refresh_strategy: SkillRefreshStrategy) -> Self {
+        let root = root.into();
+        Self {
+            id: SkillSourceId::new(format!("directory:{}", root.display())),
+            root,
+            refresh_strategy,
+            containment_root: None,
+            precedence: 0,
+            limits: SkillDiscoveryLimits::default(),
+            #[cfg(not(target_arch = "wasm32"))]
+            cache: Arc::new(RwLock::new(DirectorySkillCache::default())),
+            #[cfg(not(target_arch = "wasm32"))]
+            refresh: Arc::new(DirectoryRefreshState::new()),
+        }
+    }
+
+    pub fn with_precedence(mut self, precedence: u16) -> Self {
+        self.precedence = precedence;
+        self
+    }
+
+    pub fn with_containment_root(mut self, containment_root: impl Into<PathBuf>) -> Self {
+        self.containment_root = Some(containment_root.into());
+        self
+    }
+
+    pub fn with_limits(mut self, limits: SkillDiscoveryLimits) -> Self {
+        self.limits = limits;
+        self
+    }
+
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    pub fn refresh_strategy(&self) -> SkillRefreshStrategy {
+        self.refresh_strategy
+    }
+}
+
+#[async_trait]
+impl SkillSource for DirectorySkillSource {
+    fn id(&self) -> &SkillSourceId {
+        &self.id
+    }
+
+    fn precedence(&self) -> u16 {
+        self.precedence
+    }
+
+    fn invalidate(&self) {
+        #[cfg(not(target_arch = "wasm32"))]
+        self.refresh.invalidate();
+    }
+
+    async fn discover(&self) -> Result<SkillSourceSnapshot, SkillError> {
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            let discovery = self.refresh.discovery(
+                &self.root,
+                self.containment_root.as_deref(),
+                &self.cache,
+                self.refresh_strategy,
+            )?;
+            if discovery == DirectoryDiscovery::Skip {
+                return Ok(self
+                    .cache
+                    .read()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner)
+                    .snapshot());
+            }
+            let scanner = DirectorySkillScanner::new(
+                self.root.clone(),
+                self.containment_root.clone(),
+                self.limits.clone(),
+                Arc::clone(&self.cache),
+                discovery == DirectoryDiscovery::VerifyContents,
+            );
+            let result = tokio::task::spawn_blocking(move || scanner.scan())
+                .await
+                .map_err(|error| SkillError::SourceWorker(error.to_string()))?;
+            if result.is_ok() {
+                self.refresh.record_discovery();
+            } else {
+                self.refresh.invalidate();
+            }
+            result
+        }
+
+        #[cfg(target_arch = "wasm32")]
+        {
+            Err(SkillError::source_unavailable(
+                self.id.as_str(),
+                "filesystem skill discovery is unavailable on wasm32",
+            ))
+        }
+    }
+}

--- a/crates/autoagents-core/src/agent/skill/directory/cache.rs
+++ b/crates/autoagents-core/src/agent/skill/directory/cache.rs
@@ -1,0 +1,206 @@
+use crate::agent::skill::{Skill, SkillSourceSnapshot};
+use sha2::{Digest, Sha256};
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::SystemTime;
+
+#[derive(Debug, Default)]
+pub(super) struct DirectorySkillCache {
+    skills: BTreeMap<PathBuf, CachedDirectorySkill>,
+    #[cfg(feature = "skill-watch")]
+    documents: DirectorySkillDocumentSnapshot,
+}
+
+impl DirectorySkillCache {
+    pub(super) fn snapshot(&self) -> SkillSourceSnapshot {
+        SkillSourceSnapshot::new(
+            self.skills
+                .values()
+                .map(|cached| Arc::clone(cached.skill()))
+                .collect(),
+            Vec::new(),
+        )
+    }
+
+    pub(super) fn cached_skill(&self, directory: &Path) -> Option<&CachedDirectorySkill> {
+        self.skills.get(directory)
+    }
+
+    pub(super) fn insert(&mut self, directory: PathBuf, skill: CachedDirectorySkill) {
+        self.skills.insert(directory, skill);
+    }
+
+    #[cfg(feature = "skill-watch")]
+    pub(super) fn capture_documents(&mut self, root: &Path) {
+        self.documents = DirectorySkillDocumentSnapshot::capture(root);
+    }
+
+    #[cfg(feature = "skill-watch")]
+    pub(super) fn documents_changed(&self, root: &Path) -> bool {
+        self.documents != DirectorySkillDocumentSnapshot::capture(root)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(super) struct CachedDirectorySkill {
+    fingerprint: SkillDirectoryFingerprint,
+    skill: Arc<Skill>,
+}
+
+impl CachedDirectorySkill {
+    pub(super) fn new(fingerprint: SkillDirectoryFingerprint, skill: Arc<Skill>) -> Self {
+        Self { fingerprint, skill }
+    }
+
+    pub(super) fn matches_metadata(&self, fingerprint: &SkillDirectoryFingerprint) -> bool {
+        self.fingerprint.matches_metadata(fingerprint)
+    }
+
+    pub(super) fn matches_content(&self, fingerprint: &SkillDirectoryFingerprint) -> bool {
+        self.fingerprint.matches_content(fingerprint)
+    }
+
+    pub(super) fn fingerprint(&self) -> &SkillDirectoryFingerprint {
+        &self.fingerprint
+    }
+
+    pub(super) fn skill(&self) -> &Arc<Skill> {
+        &self.skill
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(super) struct SkillDirectoryFingerprint {
+    document: SkillFileFingerprint,
+    resources: Vec<SkillFileFingerprint>,
+}
+
+impl SkillDirectoryFingerprint {
+    pub(super) fn new(
+        document: SkillFileFingerprint,
+        resources: Vec<SkillFileFingerprint>,
+    ) -> Self {
+        Self {
+            document,
+            resources,
+        }
+    }
+
+    fn matches_metadata(&self, other: &Self) -> bool {
+        self.document.matches_metadata(&other.document)
+            && self.resources.len() == other.resources.len()
+            && self
+                .resources
+                .iter()
+                .zip(&other.resources)
+                .all(|(left, right)| left.matches_metadata(right))
+    }
+
+    fn matches_content(&self, other: &Self) -> bool {
+        self.document.matches_content(&other.document)
+            && self.resources.len() == other.resources.len()
+            && self
+                .resources
+                .iter()
+                .zip(&other.resources)
+                .all(|(left, right)| left.matches_content(right))
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(super) struct SkillFileFingerprint {
+    path: PathBuf,
+    length: u64,
+    modified: Option<SystemTime>,
+    created: Option<SystemTime>,
+    content_hash: Option<[u8; 32]>,
+}
+
+impl SkillFileFingerprint {
+    pub(super) fn from_metadata(path: PathBuf, metadata: &fs::Metadata) -> Self {
+        Self::from_values(
+            path,
+            metadata.len(),
+            metadata.modified().ok(),
+            metadata.created().ok(),
+        )
+    }
+
+    pub(super) fn from_values(
+        path: PathBuf,
+        length: u64,
+        modified: Option<SystemTime>,
+        created: Option<SystemTime>,
+    ) -> Self {
+        Self {
+            path,
+            length,
+            modified,
+            created,
+            content_hash: None,
+        }
+    }
+
+    pub(super) fn with_content(mut self, content: &str) -> Self {
+        self.content_hash = Some(Sha256::digest(content.as_bytes()).into());
+        self
+    }
+
+    pub(super) fn with_digest(mut self, digest: [u8; 32]) -> Self {
+        self.content_hash = Some(digest);
+        self
+    }
+
+    pub(super) fn path(&self) -> &Path {
+        &self.path
+    }
+
+    fn matches_metadata(&self, other: &Self) -> bool {
+        self.path == other.path
+            && self.length == other.length
+            && self.modified == other.modified
+            && self.created == other.created
+    }
+
+    fn matches_content(&self, other: &Self) -> bool {
+        self.path == other.path
+            && self.length == other.length
+            && self.content_hash.is_some()
+            && self.content_hash == other.content_hash
+    }
+}
+
+#[cfg(feature = "skill-watch")]
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+struct DirectorySkillDocumentSnapshot {
+    documents: BTreeMap<PathBuf, SkillFileFingerprint>,
+}
+
+#[cfg(feature = "skill-watch")]
+impl DirectorySkillDocumentSnapshot {
+    fn capture(root: &Path) -> Self {
+        let Ok(entries) = fs::read_dir(root) else {
+            return Self::default();
+        };
+        let mut documents = BTreeMap::new();
+        for entry in entries.filter_map(Result::ok) {
+            let Ok(file_type) = entry.file_type() else {
+                continue;
+            };
+            if !file_type.is_dir() || file_type.is_symlink() {
+                continue;
+            }
+            let path = entry.path().join("SKILL.md");
+            let Ok(metadata) = fs::symlink_metadata(&path) else {
+                continue;
+            };
+            documents.insert(
+                entry.path(),
+                SkillFileFingerprint::from_metadata(PathBuf::from("SKILL.md"), &metadata),
+            );
+        }
+        Self { documents }
+    }
+}

--- a/crates/autoagents-core/src/agent/skill/directory/refresh.rs
+++ b/crates/autoagents-core/src/agent/skill/directory/refresh.rs
@@ -1,0 +1,379 @@
+use super::SkillRefreshStrategy;
+use super::cache::DirectorySkillCache;
+use crate::agent::skill::SkillError;
+use std::path::Path;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Mutex, RwLock};
+use std::time::{Duration, Instant};
+
+#[cfg(feature = "skill-watch")]
+use notify::{Config, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
+#[cfg(feature = "skill-watch")]
+use std::sync::Arc;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum DirectoryDiscovery {
+    Skip,
+    Metadata,
+    VerifyContents,
+}
+
+pub(super) struct DirectoryRefreshState {
+    forced: AtomicBool,
+    last_discovery: Mutex<Option<Instant>>,
+    #[cfg(feature = "skill-watch")]
+    dirty: Arc<AtomicBool>,
+    #[cfg(feature = "skill-watch")]
+    last_change: Arc<Mutex<Option<Instant>>>,
+    #[cfg(feature = "skill-watch")]
+    watcher: Mutex<Option<RecommendedWatcher>>,
+}
+
+impl std::fmt::Debug for DirectoryRefreshState {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut debug = formatter.debug_struct("DirectoryRefreshState");
+        debug.field("forced", &self.forced.load(Ordering::Acquire));
+        #[cfg(feature = "skill-watch")]
+        debug
+            .field("dirty", &self.dirty.load(Ordering::Acquire))
+            .field(
+                "watcher",
+                &self
+                    .watcher
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner)
+                    .as_ref()
+                    .map(|_| "active"),
+            );
+        debug.finish_non_exhaustive()
+    }
+}
+
+impl DirectoryRefreshState {
+    pub(super) fn new() -> Self {
+        Self {
+            forced: AtomicBool::new(true),
+            last_discovery: Mutex::new(None),
+            #[cfg(feature = "skill-watch")]
+            dirty: Arc::new(AtomicBool::new(true)),
+            #[cfg(feature = "skill-watch")]
+            last_change: Arc::new(Mutex::new(None)),
+            #[cfg(feature = "skill-watch")]
+            watcher: Mutex::new(None),
+        }
+    }
+
+    pub(super) fn invalidate(&self) {
+        self.forced.store(true, Ordering::Release);
+        #[cfg(feature = "skill-watch")]
+        self.dirty.store(true, Ordering::Release);
+    }
+
+    pub(super) fn discovery(
+        &self,
+        root: &Path,
+        containment_root: Option<&Path>,
+        cache: &RwLock<DirectorySkillCache>,
+        strategy: SkillRefreshStrategy,
+    ) -> Result<DirectoryDiscovery, SkillError> {
+        #[cfg(not(feature = "skill-watch"))]
+        let _ = (root, containment_root, cache);
+
+        match strategy {
+            SkillRefreshStrategy::Manual => Ok(if self.take_forced() {
+                DirectoryDiscovery::VerifyContents
+            } else {
+                DirectoryDiscovery::Skip
+            }),
+            SkillRefreshStrategy::Poll { interval } => Ok(if self.take_forced() {
+                DirectoryDiscovery::VerifyContents
+            } else if self.fallback_elapsed(interval) {
+                DirectoryDiscovery::Metadata
+            } else {
+                DirectoryDiscovery::Skip
+            }),
+            SkillRefreshStrategy::Watch {
+                debounce,
+                fallback_interval,
+            } => {
+                #[cfg(feature = "skill-watch")]
+                {
+                    self.ensure_watcher(root, containment_root)?;
+                    if self.take_forced() {
+                        self.dirty.store(false, Ordering::Release);
+                        return Ok(DirectoryDiscovery::VerifyContents);
+                    }
+                    Ok(self.watched_discovery(root, cache, debounce, fallback_interval))
+                }
+                #[cfg(not(feature = "skill-watch"))]
+                {
+                    let _ = (debounce, fallback_interval);
+                    Err(SkillError::WatchUnavailable)
+                }
+            }
+        }
+    }
+
+    pub(super) fn record_discovery(&self) {
+        *self
+            .last_discovery
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(Instant::now());
+    }
+
+    fn take_forced(&self) -> bool {
+        self.forced.swap(false, Ordering::AcqRel)
+    }
+
+    fn fallback_elapsed(&self, interval: Duration) -> bool {
+        self.last_discovery
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .is_none_or(|last_discovery| last_discovery.elapsed() >= interval)
+    }
+
+    #[cfg(feature = "skill-watch")]
+    fn watched_discovery(
+        &self,
+        root: &Path,
+        cache: &RwLock<DirectorySkillCache>,
+        debounce: Duration,
+        fallback_interval: Duration,
+    ) -> DirectoryDiscovery {
+        let documents_changed = cache
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .documents_changed(root);
+        let watcher_settled = self
+            .last_change
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .is_none_or(|change| change.elapsed() >= debounce);
+        let observed_dirty = self.dirty.swap(false, Ordering::AcqRel);
+        if observed_dirty && (documents_changed || watcher_settled) {
+            return DirectoryDiscovery::VerifyContents;
+        }
+        if observed_dirty {
+            self.dirty.store(true, Ordering::Release);
+        }
+        if documents_changed {
+            return DirectoryDiscovery::VerifyContents;
+        }
+        if self.fallback_elapsed(fallback_interval) {
+            DirectoryDiscovery::Metadata
+        } else {
+            DirectoryDiscovery::Skip
+        }
+    }
+
+    #[cfg(feature = "skill-watch")]
+    fn ensure_watcher(
+        &self,
+        root: &Path,
+        containment_root: Option<&Path>,
+    ) -> Result<(), SkillError> {
+        let mut watcher = self
+            .watcher
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if watcher.is_some() {
+            return Ok(());
+        }
+        if let Some(containment_root) = containment_root {
+            let canonical_root = match std::fs::canonicalize(root) {
+                Ok(canonical_root) => canonical_root,
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+                Err(error) => {
+                    return Err(SkillError::source_unavailable(
+                        root.display().to_string(),
+                        format!("cannot resolve watched skill root: {error}"),
+                    ));
+                }
+            };
+            let canonical_containment =
+                std::fs::canonicalize(containment_root).map_err(|error| {
+                    SkillError::source_unavailable(
+                        containment_root.display().to_string(),
+                        format!("cannot resolve watched skill containment root: {error}"),
+                    )
+                })?;
+            if !canonical_root.starts_with(&canonical_containment) {
+                return Err(SkillError::source_unavailable(
+                    root.display().to_string(),
+                    format!(
+                        "resolved watched source '{}' escapes containment root '{}'",
+                        canonical_root.display(),
+                        canonical_containment.display()
+                    ),
+                ));
+            }
+        }
+        let dirty = Arc::clone(&self.dirty);
+        let last_change = Arc::clone(&self.last_change);
+        let created = RecommendedWatcher::new(
+            move |result: notify::Result<notify::Event>| match result {
+                Ok(event) if !matches!(event.kind, EventKind::Access(_)) => {
+                    dirty.store(true, Ordering::Release);
+                    *last_change
+                        .lock()
+                        .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(Instant::now());
+                }
+                Err(_) => {
+                    dirty.store(true, Ordering::Release);
+                    *last_change
+                        .lock()
+                        .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(Instant::now());
+                }
+                Ok(_) => {}
+            },
+            Config::default(),
+        )
+        .and_then(|mut created| {
+            created.watch(root, RecursiveMode::Recursive)?;
+            Ok(created)
+        });
+        if let Ok(created) = created {
+            *watcher = Some(created);
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn debug_output_reports_refresh_state() {
+        let state = DirectoryRefreshState::new();
+        let debug = format!("{state:?}");
+
+        assert!(debug.contains("DirectoryRefreshState"));
+        assert!(debug.contains("forced"));
+        #[cfg(feature = "skill-watch")]
+        {
+            assert!(debug.contains("dirty"));
+            assert!(debug.contains("watcher"));
+        }
+    }
+
+    #[test]
+    fn poll_skips_until_its_fallback_interval_elapses() {
+        let state = DirectoryRefreshState::new();
+        let cache = RwLock::new(DirectorySkillCache::default());
+        let root = Path::new("unused");
+        let strategy = SkillRefreshStrategy::Poll {
+            interval: Duration::from_secs(60),
+        };
+
+        assert_eq!(
+            state
+                .discovery(root, None, &cache, strategy)
+                .expect("forced discovery"),
+            DirectoryDiscovery::VerifyContents
+        );
+        state.record_discovery();
+        assert_eq!(
+            state
+                .discovery(root, None, &cache, strategy)
+                .expect("poll discovery"),
+            DirectoryDiscovery::Skip
+        );
+    }
+
+    #[cfg(feature = "skill-watch")]
+    #[test]
+    fn watched_discovery_covers_dirty_document_and_fallback_transitions() {
+        let temporary = tempfile::tempdir().expect("temporary directory");
+        let root = temporary.path().join("skills");
+        fs::create_dir_all(&root).expect("skills root");
+        let cache = RwLock::new(DirectorySkillCache::default());
+        cache
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .capture_documents(&root);
+        let state = DirectoryRefreshState::new();
+
+        assert_eq!(
+            state.watched_discovery(&root, &cache, Duration::ZERO, Duration::from_secs(60),),
+            DirectoryDiscovery::VerifyContents
+        );
+
+        state.record_discovery();
+        assert_eq!(
+            state.watched_discovery(&root, &cache, Duration::ZERO, Duration::from_secs(60),),
+            DirectoryDiscovery::Skip
+        );
+
+        state.dirty.store(true, Ordering::Release);
+        *state
+            .last_change
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(Instant::now());
+        assert_eq!(
+            state.watched_discovery(
+                &root,
+                &cache,
+                Duration::from_secs(60),
+                Duration::from_secs(60),
+            ),
+            DirectoryDiscovery::Skip
+        );
+        assert!(state.dirty.load(Ordering::Acquire));
+
+        state.dirty.store(false, Ordering::Release);
+        let skill_directory = root.join("new-skill");
+        fs::create_dir_all(&skill_directory).expect("skill directory");
+        fs::write(skill_directory.join("SKILL.md"), "new document").expect("skill document");
+        assert_eq!(
+            state.watched_discovery(&root, &cache, Duration::ZERO, Duration::from_secs(60),),
+            DirectoryDiscovery::VerifyContents
+        );
+
+        cache
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .capture_documents(&root);
+        state.dirty.store(false, Ordering::Release);
+        *state
+            .last_discovery
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = None;
+        assert_eq!(
+            state.watched_discovery(&root, &cache, Duration::ZERO, Duration::ZERO,),
+            DirectoryDiscovery::Metadata
+        );
+    }
+
+    #[cfg(feature = "skill-watch")]
+    #[test]
+    fn watcher_setup_handles_missing_roots_and_containment() {
+        let temporary = tempfile::tempdir().expect("temporary directory");
+        let root = temporary.path().join("skills");
+        let state = DirectoryRefreshState::new();
+
+        state
+            .ensure_watcher(&root, Some(temporary.path()))
+            .expect("a missing watched root is allowed until it appears");
+
+        fs::create_dir_all(&root).expect("skills root");
+        let missing_containment = temporary.path().join("missing-containment");
+        let error = state
+            .ensure_watcher(&root, Some(&missing_containment))
+            .expect_err("missing containment should fail");
+        assert!(
+            error
+                .to_string()
+                .contains("cannot resolve watched skill containment root")
+        );
+
+        state
+            .ensure_watcher(&root, Some(temporary.path()))
+            .expect("watcher should be created");
+        assert!(
+            format!("{state:?}").contains("active"),
+            "debug output should report an active watcher"
+        );
+    }
+}

--- a/crates/autoagents-core/src/agent/skill/directory/scanner.rs
+++ b/crates/autoagents-core/src/agent/skill/directory/scanner.rs
@@ -1,0 +1,509 @@
+use super::SkillDiscoveryLimits;
+use super::cache::{
+    CachedDirectorySkill, DirectorySkillCache, SkillDirectoryFingerprint, SkillFileFingerprint,
+};
+use crate::agent::skill::resource::{SkillResourceBoundary, SkillResourceDirectory};
+use crate::agent::skill::{Skill, SkillError, SkillSourceSnapshot};
+use sha2::{Digest, Sha256};
+use std::fs;
+use std::io::{ErrorKind, Read};
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, RwLock};
+use walkdir::WalkDir;
+
+#[derive(Debug)]
+pub(super) struct DirectorySkillScanner {
+    root: PathBuf,
+    containment_root: Option<PathBuf>,
+    limits: SkillDiscoveryLimits,
+    cache: Arc<RwLock<DirectorySkillCache>>,
+    verify_contents: bool,
+}
+
+impl DirectorySkillScanner {
+    pub(super) fn new(
+        root: PathBuf,
+        containment_root: Option<PathBuf>,
+        limits: SkillDiscoveryLimits,
+        cache: Arc<RwLock<DirectorySkillCache>>,
+        verify_contents: bool,
+    ) -> Self {
+        Self {
+            root,
+            containment_root,
+            limits,
+            cache,
+            verify_contents,
+        }
+    }
+
+    pub(super) fn scan(&self) -> Result<SkillSourceSnapshot, SkillError> {
+        let canonical_root = match fs::canonicalize(&self.root) {
+            Ok(root) => root,
+            Err(error) if error.kind() == ErrorKind::NotFound => {
+                *self
+                    .cache
+                    .write()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner) =
+                    DirectorySkillCache::default();
+                return Ok(SkillSourceSnapshot::default());
+            }
+            Err(error) => {
+                return Err(SkillError::source_unavailable(
+                    self.root.display().to_string(),
+                    error.to_string(),
+                ));
+            }
+        };
+        let boundary_path = if let Some(containment_root) = &self.containment_root {
+            let canonical_containment = fs::canonicalize(containment_root).map_err(|error| {
+                SkillError::source_unavailable(
+                    containment_root.display().to_string(),
+                    format!("cannot resolve containment root: {error}"),
+                )
+            })?;
+            if !canonical_root.starts_with(&canonical_containment) {
+                return Err(SkillError::source_unavailable(
+                    self.root.display().to_string(),
+                    format!(
+                        "resolved source '{}' escapes containment root '{}'",
+                        canonical_root.display(),
+                        canonical_containment.display()
+                    ),
+                ));
+            }
+            canonical_containment
+        } else {
+            canonical_root.clone()
+        };
+        let resource_boundary = SkillResourceBoundary::open(boundary_path).map_err(|error| {
+            SkillError::source_unavailable(
+                self.root.display().to_string(),
+                format!("cannot open resource boundary: {error}"),
+            )
+        })?;
+        let entries = fs::read_dir(&self.root).map_err(|error| {
+            SkillError::source_unavailable(self.root.display().to_string(), error.to_string())
+        })?;
+
+        let mut directories = entries
+            .filter_map(Result::ok)
+            .filter_map(|entry| {
+                let file_type = entry.file_type().ok()?;
+                (file_type.is_dir() && !file_type.is_symlink()).then_some(entry.path())
+            })
+            .collect::<Vec<_>>();
+        directories.sort();
+
+        let mut snapshot = SkillSourceSnapshot::default();
+        let mut refreshed_cache = DirectorySkillCache::default();
+        #[cfg(feature = "skill-watch")]
+        refreshed_cache.capture_documents(&self.root);
+        if directories.len() > self.limits.max_skills {
+            snapshot.diagnostics.push(format!(
+                "skill directory '{}' contains {} entries; only the first {} are scanned",
+                self.root.display(),
+                directories.len(),
+                self.limits.max_skills
+            ));
+            directories.truncate(self.limits.max_skills);
+        }
+
+        let mut total_skill_file_bytes = 0usize;
+        for directory in directories {
+            match self.load_skill(&canonical_root, &resource_boundary, &directory) {
+                Ok(Some(loaded)) => {
+                    if total_skill_file_bytes.saturating_add(loaded.document_bytes)
+                        > self.limits.max_total_skill_file_bytes
+                    {
+                        snapshot.diagnostics.push(format!(
+                            "skill document '{}' exceeds the {} byte aggregate skill document limit",
+                            directory.join("SKILL.md").display(),
+                            self.limits.max_total_skill_file_bytes
+                        ));
+                        continue;
+                    }
+                    total_skill_file_bytes =
+                        total_skill_file_bytes.saturating_add(loaded.document_bytes);
+                    refreshed_cache.insert(
+                        loaded.skill.directory().to_path_buf(),
+                        CachedDirectorySkill::new(loaded.fingerprint, Arc::clone(&loaded.skill)),
+                    );
+                    snapshot.skills.push(loaded.skill);
+                }
+                Ok(None) => {}
+                Err(error) => {
+                    if let Some((path, cached)) = self.last_valid_skill(&canonical_root, &directory)
+                    {
+                        snapshot.skills.push(Arc::clone(cached.skill()));
+                        refreshed_cache.insert(path, cached);
+                        snapshot.diagnostics.push(format!(
+                            "{error}; retaining the last valid skill until the update becomes valid"
+                        ));
+                    } else {
+                        snapshot.diagnostics.push(error.to_string());
+                    }
+                }
+            }
+        }
+        *self
+            .cache
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = refreshed_cache;
+        Ok(snapshot)
+    }
+
+    fn last_valid_skill(
+        &self,
+        canonical_root: &Path,
+        directory: &Path,
+    ) -> Option<(PathBuf, CachedDirectorySkill)> {
+        let canonical_directory = fs::canonicalize(directory).ok()?;
+        if !canonical_directory.starts_with(canonical_root) {
+            return None;
+        }
+        let metadata = fs::symlink_metadata(canonical_directory.join("SKILL.md")).ok()?;
+        if !metadata.is_file() || metadata.file_type().is_symlink() {
+            return None;
+        }
+        let cached = self
+            .cache
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .cached_skill(&canonical_directory)
+            .cloned()?;
+        Some((canonical_directory, cached))
+    }
+
+    fn load_skill(
+        &self,
+        canonical_root: &Path,
+        resource_boundary: &SkillResourceBoundary,
+        directory: &Path,
+    ) -> Result<Option<LoadedDirectorySkill>, SkillError> {
+        let canonical_directory = fs::canonicalize(directory).map_err(|error| {
+            SkillError::invalid_document(directory, format!("cannot resolve directory: {error}"))
+        })?;
+        if !canonical_directory.starts_with(canonical_root) {
+            return Err(SkillError::invalid_document(
+                directory,
+                "skill directory escapes the configured source root",
+            ));
+        }
+        let resource_directory =
+            resource_boundary
+                .open_skill(&canonical_directory)
+                .map_err(|error| {
+                    SkillError::invalid_document(
+                        directory,
+                        format!("cannot open confined skill directory: {error}"),
+                    )
+                })?;
+
+        let skill_file = canonical_directory.join("SKILL.md");
+        let metadata = match fs::symlink_metadata(&skill_file) {
+            Ok(metadata) if metadata.file_type().is_symlink() => {
+                return Err(SkillError::invalid_document(
+                    &skill_file,
+                    "SKILL.md must not be a symbolic link",
+                ));
+            }
+            Ok(metadata) if metadata.is_file() => metadata,
+            Ok(_) => return Ok(None),
+            Err(error) if error.kind() == ErrorKind::NotFound => return Ok(None),
+            Err(error) => {
+                return Err(SkillError::invalid_document(
+                    &skill_file,
+                    format!("cannot inspect file: {error}"),
+                ));
+            }
+        };
+        let canonical_skill_file = fs::canonicalize(&skill_file).map_err(|error| {
+            SkillError::invalid_document(&skill_file, format!("cannot resolve file: {error}"))
+        })?;
+        if !canonical_skill_file.starts_with(&canonical_directory) {
+            return Err(SkillError::invalid_document(
+                &skill_file,
+                "SKILL.md escapes its skill directory",
+            ));
+        }
+        if metadata.len() > self.limits.max_skill_file_bytes as u64 {
+            return Err(SkillError::invalid_document(
+                &skill_file,
+                format!(
+                    "file exceeds the {} byte limit",
+                    self.limits.max_skill_file_bytes
+                ),
+            ));
+        }
+        let document_bytes = usize::try_from(metadata.len()).unwrap_or(usize::MAX);
+        let document_fingerprint =
+            SkillFileFingerprint::from_metadata(PathBuf::from("SKILL.md"), &metadata);
+        let resource_manifest =
+            self.discover_resource_manifest(&canonical_directory, &resource_directory)?;
+        let metadata_fingerprint = SkillDirectoryFingerprint::new(
+            document_fingerprint.clone(),
+            resource_manifest.fingerprints,
+        );
+        let cached = if self.verify_contents {
+            None
+        } else {
+            self.cache
+                .read()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .cached_skill(&canonical_directory)
+                .filter(|cached| cached.matches_metadata(&metadata_fingerprint))
+                .cloned()
+        };
+        if let Some(cached) = cached {
+            return Ok(Some(LoadedDirectorySkill {
+                fingerprint: cached.fingerprint().clone(),
+                skill: Arc::clone(cached.skill()),
+                document_bytes,
+            }));
+        }
+
+        let content = fs::read_to_string(&canonical_skill_file).map_err(|error| {
+            SkillError::invalid_document(&skill_file, format!("cannot read file: {error}"))
+        })?;
+        if content.len() > self.limits.max_skill_file_bytes {
+            return Err(SkillError::invalid_document(
+                &skill_file,
+                format!(
+                    "file exceeds the {} byte limit",
+                    self.limits.max_skill_file_bytes
+                ),
+            ));
+        }
+        let discovered_resources = self.load_resource_contents(
+            &canonical_directory,
+            &resource_directory,
+            resource_manifest.paths,
+        )?;
+        let fingerprint = SkillDirectoryFingerprint::new(
+            document_fingerprint.with_content(&content),
+            discovered_resources.fingerprints,
+        );
+        if let Some(cached) = self
+            .cache
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .cached_skill(&canonical_directory)
+            .filter(|cached| cached.matches_content(&fingerprint))
+        {
+            return Ok(Some(LoadedDirectorySkill {
+                fingerprint,
+                skill: Arc::clone(cached.skill()),
+                document_bytes,
+            }));
+        }
+
+        let skill = Skill::from_document(
+            canonical_skill_file,
+            canonical_directory,
+            &content,
+            discovered_resources.paths,
+        )?
+        .with_resource_digests(&discovered_resources.digests)
+        .with_resource_directory(resource_directory);
+        Ok(Some(LoadedDirectorySkill {
+            fingerprint,
+            skill: Arc::new(skill),
+            document_bytes,
+        }))
+    }
+
+    fn discover_resource_manifest(
+        &self,
+        skill_directory: &Path,
+        resource_directory: &SkillResourceDirectory,
+    ) -> Result<SkillResourceManifest, SkillError> {
+        let mut resources = Vec::new();
+        let mut fingerprints = Vec::new();
+        let mut total_resource_bytes = 0usize;
+        for entry in WalkDir::new(skill_directory)
+            .follow_links(false)
+            .max_depth(self.limits.max_resource_depth)
+            .into_iter()
+        {
+            let entry = entry.map_err(|error| {
+                SkillError::invalid_document(
+                    skill_directory,
+                    format!("cannot enumerate resources: {error}"),
+                )
+            })?;
+            if !entry.file_type().is_file() || entry.file_name() == "SKILL.md" {
+                continue;
+            }
+            if resources.len() >= self.limits.max_resources_per_skill {
+                break;
+            }
+            let relative = entry
+                .path()
+                .strip_prefix(skill_directory)
+                .map_err(|error| {
+                    SkillError::invalid_document(
+                        entry.path(),
+                        format!("cannot resolve resource path: {error}"),
+                    )
+                })?
+                .to_path_buf();
+            let file = resource_directory.open_file(&relative).map_err(|error| {
+                SkillError::invalid_document(
+                    entry.path(),
+                    format!("cannot open confined resource: {error}"),
+                )
+            })?;
+            let metadata = file.metadata().map_err(|error| {
+                SkillError::invalid_document(
+                    entry.path(),
+                    format!("cannot inspect resource: {error}"),
+                )
+            })?;
+            if !metadata.is_file() {
+                return Err(SkillError::invalid_document(
+                    entry.path(),
+                    "resource must be a regular file",
+                ));
+            }
+            let resource_bytes = usize::try_from(metadata.len()).unwrap_or(usize::MAX);
+            if resource_bytes > self.limits.max_resource_file_bytes {
+                return Err(SkillError::invalid_document(
+                    entry.path(),
+                    format!(
+                        "resource exceeds the {} byte limit",
+                        self.limits.max_resource_file_bytes
+                    ),
+                ));
+            }
+            if total_resource_bytes.saturating_add(resource_bytes)
+                > self.limits.max_total_resource_bytes
+            {
+                return Err(SkillError::invalid_document(
+                    skill_directory,
+                    format!(
+                        "resources exceed the {} byte aggregate limit",
+                        self.limits.max_total_resource_bytes
+                    ),
+                ));
+            }
+            total_resource_bytes = total_resource_bytes.saturating_add(resource_bytes);
+            fingerprints.push(SkillFileFingerprint::from_values(
+                relative.clone(),
+                metadata.len(),
+                metadata.modified().ok().map(|time| time.into_std()),
+                metadata.created().ok().map(|time| time.into_std()),
+            ));
+            resources.push(relative);
+        }
+        resources.sort();
+        fingerprints.sort_by(|left, right| left.path().cmp(right.path()));
+        Ok(SkillResourceManifest {
+            paths: resources,
+            fingerprints,
+        })
+    }
+
+    fn load_resource_contents(
+        &self,
+        skill_directory: &Path,
+        resource_directory: &SkillResourceDirectory,
+        paths: Vec<PathBuf>,
+    ) -> Result<DiscoveredSkillResources, SkillError> {
+        let mut fingerprints = Vec::with_capacity(paths.len());
+        let mut digests = Vec::with_capacity(paths.len());
+        let mut total_resource_bytes = 0usize;
+        for relative in &paths {
+            let resource_path = skill_directory.join(relative);
+            let file = resource_directory.open_file(relative).map_err(|error| {
+                SkillError::invalid_document(
+                    &resource_path,
+                    format!("cannot open confined resource: {error}"),
+                )
+            })?;
+            let metadata = file.metadata().map_err(|error| {
+                SkillError::invalid_document(
+                    &resource_path,
+                    format!("cannot inspect resource: {error}"),
+                )
+            })?;
+            let resource_bytes = usize::try_from(metadata.len()).unwrap_or(usize::MAX);
+            if resource_bytes > self.limits.max_resource_file_bytes {
+                return Err(SkillError::invalid_document(
+                    &resource_path,
+                    format!(
+                        "resource exceeds the {} byte limit",
+                        self.limits.max_resource_file_bytes
+                    ),
+                ));
+            }
+            let mut bytes = Vec::with_capacity(resource_bytes);
+            file.take(self.limits.max_resource_file_bytes.saturating_add(1) as u64)
+                .read_to_end(&mut bytes)
+                .map_err(|error| {
+                    SkillError::invalid_document(
+                        &resource_path,
+                        format!("cannot read resource: {error}"),
+                    )
+                })?;
+            if bytes.len() > self.limits.max_resource_file_bytes {
+                return Err(SkillError::invalid_document(
+                    &resource_path,
+                    format!(
+                        "resource exceeds the {} byte limit",
+                        self.limits.max_resource_file_bytes
+                    ),
+                ));
+            }
+            if total_resource_bytes.saturating_add(bytes.len())
+                > self.limits.max_total_resource_bytes
+            {
+                return Err(SkillError::invalid_document(
+                    skill_directory,
+                    format!(
+                        "resources exceed the {} byte aggregate limit",
+                        self.limits.max_total_resource_bytes
+                    ),
+                ));
+            }
+            total_resource_bytes = total_resource_bytes.saturating_add(bytes.len());
+            let digest: [u8; 32] = Sha256::digest(&bytes).into();
+            fingerprints.push(
+                SkillFileFingerprint::from_values(
+                    relative.clone(),
+                    metadata.len(),
+                    metadata.modified().ok().map(|time| time.into_std()),
+                    metadata.created().ok().map(|time| time.into_std()),
+                )
+                .with_digest(digest),
+            );
+            digests.push((relative.clone(), digest));
+        }
+        digests.sort_by(|left, right| left.0.cmp(&right.0));
+        Ok(DiscoveredSkillResources {
+            paths,
+            fingerprints,
+            digests,
+        })
+    }
+}
+
+#[derive(Debug)]
+struct LoadedDirectorySkill {
+    fingerprint: SkillDirectoryFingerprint,
+    skill: Arc<Skill>,
+    document_bytes: usize,
+}
+
+#[derive(Debug)]
+struct DiscoveredSkillResources {
+    paths: Vec<PathBuf>,
+    fingerprints: Vec<SkillFileFingerprint>,
+    digests: Vec<(PathBuf, [u8; 32])>,
+}
+
+#[derive(Debug)]
+struct SkillResourceManifest {
+    paths: Vec<PathBuf>,
+    fingerprints: Vec<SkillFileFingerprint>,
+}

--- a/crates/autoagents-core/src/agent/skill/error.rs
+++ b/crates/autoagents-core/src/agent/skill/error.rs
@@ -1,0 +1,62 @@
+use std::path::PathBuf;
+
+#[derive(Debug, thiserror::Error)]
+pub enum SkillError {
+    #[error("skill document at '{path}' is invalid: {message}")]
+    InvalidDocument { path: PathBuf, message: String },
+
+    #[error("skill source '{source_id}' is unavailable: {message}")]
+    SourceUnavailable { source_id: String, message: String },
+
+    #[error("skill source worker failed: {0}")]
+    SourceWorker(String),
+
+    #[error("watched skill refresh requires the 'skill-watch' Cargo feature")]
+    WatchUnavailable,
+
+    #[error("skill '{0}' was not found")]
+    UnknownSkill(String),
+
+    #[error("skill '{0}' is not active in this conversation")]
+    InactiveSkill(String),
+
+    #[error("skill operation was denied by policy: {0}")]
+    PolicyDenied(String),
+
+    #[error("skill tool selector '{0}' is invalid")]
+    InvalidToolSelector(String),
+
+    #[error("resource path '{0}' is invalid")]
+    InvalidResourcePath(String),
+
+    #[error("resource '{path}' exceeds the {limit} byte limit")]
+    ResourceTooLarge { path: PathBuf, limit: usize },
+
+    #[error("resource '{0}' is not valid UTF-8")]
+    ResourceNotUtf8(PathBuf),
+
+    #[error("resource '{0}' changed after skill discovery; refresh and reactivate the skill")]
+    ResourceChanged(PathBuf),
+
+    #[error("skill tool name '{0}' conflicts with an agent tool")]
+    ToolNameConflict(String),
+}
+
+impl SkillError {
+    pub(crate) fn invalid_document(path: impl Into<PathBuf>, message: impl Into<String>) -> Self {
+        Self::InvalidDocument {
+            path: path.into(),
+            message: message.into(),
+        }
+    }
+
+    pub(crate) fn source_unavailable(
+        source: impl Into<String>,
+        message: impl Into<String>,
+    ) -> Self {
+        Self::SourceUnavailable {
+            source_id: source.into(),
+            message: message.into(),
+        }
+    }
+}

--- a/crates/autoagents-core/src/agent/skill/lifecycle.rs
+++ b/crates/autoagents-core/src/agent/skill/lifecycle.rs
@@ -1,0 +1,36 @@
+use async_trait::async_trait;
+use autoagents_protocol::SkillEvent;
+use std::fmt::Debug;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SkillLifecycleDecision {
+    Continue,
+    Abort,
+}
+
+#[async_trait]
+pub trait SkillLifecycle: Debug + Send + Sync {
+    async fn on_catalog_changed(&self, _event: &SkillEvent) {}
+
+    async fn on_activation_requested(&self, _event: &SkillEvent) -> SkillLifecycleDecision {
+        SkillLifecycleDecision::Continue
+    }
+
+    async fn on_activated(&self, _event: &SkillEvent) {}
+
+    async fn on_deactivated(&self, _event: &SkillEvent) {}
+
+    async fn on_resource_access_requested(&self, _event: &SkillEvent) -> SkillLifecycleDecision {
+        SkillLifecycleDecision::Continue
+    }
+
+    async fn on_resource_accessed(&self, _event: &SkillEvent) {}
+
+    async fn on_operation_failed(&self, _event: &SkillEvent) {}
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct SilentSkillLifecycle;
+
+#[async_trait]
+impl SkillLifecycle for SilentSkillLifecycle {}

--- a/crates/autoagents-core/src/agent/skill/mod.rs
+++ b/crates/autoagents-core/src/agent/skill/mod.rs
@@ -1,0 +1,32 @@
+mod configuration;
+mod directory;
+mod error;
+mod lifecycle;
+mod model;
+mod policy;
+mod prompt;
+mod registry;
+#[cfg(not(target_arch = "wasm32"))]
+mod resource;
+pub(crate) mod runtime;
+mod session;
+mod source;
+mod tool_selector;
+
+pub use configuration::SkillConfiguration;
+pub use directory::{DirectorySkillSource, SkillDiscoveryLimits, SkillRefreshStrategy};
+pub use error::SkillError;
+pub use lifecycle::{SilentSkillLifecycle, SkillLifecycle, SkillLifecycleDecision};
+pub use model::{Skill, SkillMetadata, SkillRevision};
+pub use policy::{SkillActivationRequest, SkillPolicy, SkillResourceRequest, TrustedSkillPolicy};
+pub use registry::{SkillDiagnostic, SkillRefreshReport, SkillRegistry, SkillSnapshot};
+pub(crate) use runtime::SkillRuntimeIdentity;
+pub use runtime::{
+    SkillDeactivationReason, SkillEvent, SkillEventKind, SkillOperation, SkillRuntime,
+};
+pub use session::{SkillSession, SkillSessionReset};
+pub use source::{SkillSource, SkillSourceId, SkillSourceSnapshot};
+pub use tool_selector::SkillToolSelector;
+
+#[cfg(test)]
+mod tests;

--- a/crates/autoagents-core/src/agent/skill/model.rs
+++ b/crates/autoagents-core/src/agent/skill/model.rs
@@ -1,0 +1,337 @@
+use crate::agent::skill::{SkillError, SkillToolSelector};
+use serde::Deserialize;
+use sha2::{Digest, Sha256};
+use std::collections::BTreeMap;
+use std::path::Component;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+#[cfg(not(target_arch = "wasm32"))]
+use crate::agent::skill::resource::SkillResourceDirectory;
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub struct SkillRevision([u8; 32]);
+
+impl SkillRevision {
+    fn from_document(content: &str) -> Self {
+        Self(Sha256::digest(content.as_bytes()).into())
+    }
+
+    fn with_resources(self, resources: &[PathBuf]) -> Self {
+        let mut digest = Sha256::new();
+        digest.update(self.0);
+        for resource in resources {
+            let bytes = resource.as_os_str().as_encoded_bytes();
+            digest.update(bytes.len().to_le_bytes());
+            digest.update(bytes);
+        }
+        Self(digest.finalize().into())
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    fn with_resource_digests(self, resources: &[(PathBuf, [u8; 32])]) -> Self {
+        let mut digest = Sha256::new();
+        digest.update(self.0);
+        for (resource, resource_digest) in resources {
+            let bytes = resource.as_os_str().as_encoded_bytes();
+            digest.update(bytes.len().to_le_bytes());
+            digest.update(bytes);
+            digest.update(resource_digest);
+        }
+        Self(digest.finalize().into())
+    }
+}
+
+impl std::fmt::Display for SkillRevision {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        for byte in self.0 {
+            write!(formatter, "{byte:02x}")?;
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SkillMetadata {
+    name: String,
+    description: String,
+    license: Option<String>,
+    compatibility: Option<String>,
+    metadata: BTreeMap<String, String>,
+    allowed_tools: Arc<[SkillToolSelector]>,
+}
+
+impl SkillMetadata {
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    pub fn description(&self) -> &str {
+        &self.description
+    }
+
+    pub fn license(&self) -> Option<&str> {
+        self.license.as_deref()
+    }
+
+    pub fn compatibility(&self) -> Option<&str> {
+        self.compatibility.as_deref()
+    }
+
+    pub fn metadata(&self) -> &BTreeMap<String, String> {
+        &self.metadata
+    }
+
+    pub fn allowed_tools(&self) -> &[SkillToolSelector] {
+        &self.allowed_tools
+    }
+
+    fn validate(&self, directory_name: &str, path: &Path) -> Result<(), SkillError> {
+        let name_length = self.name.chars().count();
+        if !(1..=64).contains(&name_length) {
+            return Err(SkillError::invalid_document(
+                path,
+                "name must contain between 1 and 64 characters",
+            ));
+        }
+        if self.name.starts_with('-')
+            || self.name.ends_with('-')
+            || self.name.contains("--")
+            || !self
+                .name
+                .bytes()
+                .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-')
+        {
+            return Err(SkillError::invalid_document(
+                path,
+                "name must use lowercase ASCII letters, digits, and single hyphens",
+            ));
+        }
+        if self.name != directory_name {
+            return Err(SkillError::invalid_document(
+                path,
+                format!(
+                    "name '{}' must match parent directory '{directory_name}'",
+                    self.name
+                ),
+            ));
+        }
+
+        let description_length = self.description.chars().count();
+        if self.description.trim().is_empty() || description_length > 1024 {
+            return Err(SkillError::invalid_document(
+                path,
+                "description must contain between 1 and 1024 characters",
+            ));
+        }
+        if self
+            .compatibility
+            .as_ref()
+            .is_some_and(|value| value.trim().is_empty() || value.chars().count() > 500)
+        {
+            return Err(SkillError::invalid_document(
+                path,
+                "compatibility must contain between 1 and 500 characters",
+            ));
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Skill {
+    metadata: SkillMetadata,
+    instructions: Arc<str>,
+    directory: PathBuf,
+    skill_file: PathBuf,
+    resources: Arc<[PathBuf]>,
+    resource_digests: Arc<BTreeMap<PathBuf, [u8; 32]>>,
+    revision: SkillRevision,
+    #[cfg(not(target_arch = "wasm32"))]
+    resource_directory: Option<SkillResourceDirectory>,
+}
+
+impl Skill {
+    pub fn from_document(
+        skill_file: impl Into<PathBuf>,
+        directory: impl Into<PathBuf>,
+        content: &str,
+        resources: Vec<PathBuf>,
+    ) -> Result<Self, SkillError> {
+        SkillDocument::parse(skill_file.into(), directory.into(), content)?
+            .with_resources(resources)
+    }
+
+    pub fn metadata(&self) -> &SkillMetadata {
+        &self.metadata
+    }
+
+    pub fn instructions(&self) -> &str {
+        &self.instructions
+    }
+
+    pub fn directory(&self) -> &Path {
+        &self.directory
+    }
+
+    pub fn skill_file(&self) -> &Path {
+        &self.skill_file
+    }
+
+    pub fn resources(&self) -> &[PathBuf] {
+        &self.resources
+    }
+
+    pub fn revision(&self) -> SkillRevision {
+        self.revision
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    pub(crate) fn with_resource_digests(mut self, resources: &[(PathBuf, [u8; 32])]) -> Self {
+        self.revision = self.revision.with_resource_digests(resources);
+        self.resource_digests = Arc::new(resources.iter().cloned().collect());
+        self
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    pub(crate) fn resource_digest(&self, path: &Path) -> Option<[u8; 32]> {
+        self.resource_digests.get(path).copied()
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    pub(crate) fn with_resource_directory(
+        mut self,
+        resource_directory: SkillResourceDirectory,
+    ) -> Self {
+        self.resource_directory = Some(resource_directory);
+        self
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    pub(crate) fn resource_directory(&self) -> Option<SkillResourceDirectory> {
+        self.resource_directory.clone()
+    }
+
+    fn with_resources(mut self, mut resources: Vec<PathBuf>) -> Result<Self, SkillError> {
+        for resource in &resources {
+            if resource.as_os_str().is_empty()
+                || resource.is_absolute()
+                || resource.to_str().is_none()
+                || resource
+                    .components()
+                    .any(|component| !matches!(component, Component::Normal(_)))
+            {
+                return Err(SkillError::invalid_document(
+                    &self.skill_file,
+                    format!("resource path '{}' is invalid", resource.display()),
+                ));
+            }
+        }
+        resources.sort();
+        resources.dedup();
+        self.revision = self.revision.with_resources(&resources);
+        self.resources = resources.into();
+        Ok(self)
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct SkillFrontmatter {
+    name: String,
+    description: String,
+    license: Option<String>,
+    compatibility: Option<String>,
+    #[serde(default)]
+    metadata: BTreeMap<String, String>,
+    #[serde(rename = "allowed-tools")]
+    allowed_tools: Option<String>,
+}
+
+pub(crate) struct SkillDocument;
+
+impl SkillDocument {
+    pub(crate) fn parse(
+        skill_file: PathBuf,
+        directory: PathBuf,
+        content: &str,
+    ) -> Result<Skill, SkillError> {
+        let (frontmatter, instructions) = Self::split(content, &skill_file)?;
+        let parsed: SkillFrontmatter = serde_yaml_ng::from_str(frontmatter).map_err(|error| {
+            SkillError::invalid_document(&skill_file, format!("invalid YAML frontmatter: {error}"))
+        })?;
+        let metadata = SkillMetadata {
+            name: parsed.name,
+            description: parsed.description,
+            license: parsed.license,
+            compatibility: parsed.compatibility,
+            metadata: parsed.metadata,
+            allowed_tools: parsed
+                .allowed_tools
+                .as_deref()
+                .unwrap_or_default()
+                .split_whitespace()
+                .map(SkillToolSelector::parse)
+                .collect::<Result<Vec<_>, _>>()?
+                .into(),
+        };
+        let directory_name = directory
+            .file_name()
+            .and_then(|name| name.to_str())
+            .ok_or_else(|| {
+                SkillError::invalid_document(&skill_file, "parent directory is not valid UTF-8")
+            })?;
+        metadata.validate(directory_name, &skill_file)?;
+        if instructions.trim().is_empty() {
+            return Err(SkillError::invalid_document(
+                &skill_file,
+                "instructions must not be empty",
+            ));
+        }
+
+        Ok(Skill {
+            metadata,
+            instructions: Arc::from(instructions.trim()),
+            directory,
+            skill_file,
+            resources: Arc::from([]),
+            resource_digests: Arc::new(BTreeMap::new()),
+            revision: SkillRevision::from_document(content),
+            #[cfg(not(target_arch = "wasm32"))]
+            resource_directory: None,
+        })
+    }
+
+    fn split<'a>(content: &'a str, path: &Path) -> Result<(&'a str, &'a str), SkillError> {
+        let normalized = content.strip_prefix('\u{feff}').unwrap_or(content);
+        let mut lines = normalized.split_inclusive('\n');
+        let opening = lines
+            .next()
+            .unwrap_or_default()
+            .trim_end_matches(['\r', '\n']);
+        if opening != "---" {
+            return Err(SkillError::invalid_document(
+                path,
+                "SKILL.md must start with a YAML frontmatter delimiter",
+            ));
+        }
+
+        let frontmatter_start =
+            opening.len() + (normalized[opening.len()..].starts_with("\r\n") as usize) + 1;
+        let mut offset = frontmatter_start;
+        for line in lines {
+            let trimmed = line.trim_end_matches(['\r', '\n']);
+            if trimmed == "---" {
+                let frontmatter = &normalized[frontmatter_start..offset];
+                let body_start = offset + line.len();
+                return Ok((frontmatter, &normalized[body_start..]));
+            }
+            offset += line.len();
+        }
+
+        Err(SkillError::invalid_document(
+            path,
+            "YAML frontmatter is missing its closing delimiter",
+        ))
+    }
+}

--- a/crates/autoagents-core/src/agent/skill/policy.rs
+++ b/crates/autoagents-core/src/agent/skill/policy.rs
@@ -1,0 +1,126 @@
+use crate::agent::skill::{Skill, SkillError};
+use async_trait::async_trait;
+use autoagents_protocol::{ActorID, SkillSessionId, SubmissionId};
+use std::fmt::Debug;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+#[derive(Clone, Debug)]
+pub struct SkillActivationRequest {
+    actor_id: ActorID,
+    submission_id: SubmissionId,
+    session_id: SkillSessionId,
+    skill: Arc<Skill>,
+}
+
+impl SkillActivationRequest {
+    pub(crate) fn new(
+        actor_id: ActorID,
+        submission_id: SubmissionId,
+        session_id: SkillSessionId,
+        skill: Arc<Skill>,
+    ) -> Self {
+        Self {
+            actor_id,
+            submission_id,
+            session_id,
+            skill,
+        }
+    }
+
+    pub fn actor_id(&self) -> ActorID {
+        self.actor_id
+    }
+
+    pub fn submission_id(&self) -> SubmissionId {
+        self.submission_id
+    }
+
+    pub fn session_id(&self) -> SkillSessionId {
+        self.session_id
+    }
+
+    pub fn skill(&self) -> &Skill {
+        &self.skill
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct SkillResourceRequest {
+    actor_id: ActorID,
+    submission_id: SubmissionId,
+    session_id: SkillSessionId,
+    skill: Arc<Skill>,
+    path: PathBuf,
+}
+
+impl SkillResourceRequest {
+    pub(crate) fn new(
+        actor_id: ActorID,
+        submission_id: SubmissionId,
+        session_id: SkillSessionId,
+        skill: Arc<Skill>,
+        path: PathBuf,
+    ) -> Self {
+        Self {
+            actor_id,
+            submission_id,
+            session_id,
+            skill,
+            path,
+        }
+    }
+
+    pub fn actor_id(&self) -> ActorID {
+        self.actor_id
+    }
+
+    pub fn submission_id(&self) -> SubmissionId {
+        self.submission_id
+    }
+
+    pub fn session_id(&self) -> SkillSessionId {
+        self.session_id
+    }
+
+    pub fn skill(&self) -> &Skill {
+        &self.skill
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+#[async_trait]
+pub trait SkillPolicy: Debug + Send + Sync {
+    async fn authorize_activation(
+        &self,
+        request: &SkillActivationRequest,
+    ) -> Result<(), SkillError>;
+
+    async fn authorize_resource_read(
+        &self,
+        request: &SkillResourceRequest,
+    ) -> Result<(), SkillError>;
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct TrustedSkillPolicy;
+
+#[async_trait]
+impl SkillPolicy for TrustedSkillPolicy {
+    async fn authorize_activation(
+        &self,
+        _request: &SkillActivationRequest,
+    ) -> Result<(), SkillError> {
+        Ok(())
+    }
+
+    async fn authorize_resource_read(
+        &self,
+        _request: &SkillResourceRequest,
+    ) -> Result<(), SkillError> {
+        Ok(())
+    }
+}

--- a/crates/autoagents-core/src/agent/skill/prompt.rs
+++ b/crates/autoagents-core/src/agent/skill/prompt.rs
@@ -1,0 +1,87 @@
+use crate::agent::skill::SkillSnapshot;
+use std::collections::BTreeSet;
+use std::fmt::Write;
+
+pub(crate) struct SkillPromptRenderer;
+
+impl SkillPromptRenderer {
+    pub(crate) fn render(
+        base_prompt: &str,
+        snapshot: &SkillSnapshot,
+        active_skills: &BTreeSet<String>,
+    ) -> String {
+        if snapshot.is_empty() {
+            return base_prompt.to_string();
+        }
+
+        let catalog_bytes = snapshot
+            .skills()
+            .map(|skill| {
+                skill.metadata().name().len()
+                    + skill.metadata().description().len()
+                    + skill.metadata().compatibility().map_or(0, str::len)
+            })
+            .sum::<usize>();
+        let active_bytes = active_skills
+            .iter()
+            .filter_map(|name| snapshot.get_ref(name))
+            .map(|skill| {
+                skill.instructions().len()
+                    + skill
+                        .resources()
+                        .iter()
+                        .map(|resource| resource.as_os_str().as_encoded_bytes().len())
+                        .sum::<usize>()
+            })
+            .sum::<usize>();
+        let capacity = base_prompt
+            .len()
+            .saturating_add(catalog_bytes)
+            .saturating_add(active_bytes)
+            .saturating_add(snapshot.len().saturating_mul(64))
+            .saturating_add(512);
+        let mut prompt = String::with_capacity(capacity);
+        prompt.push_str(base_prompt);
+        prompt.push_str(
+            "\n\n# Agent Skills\n\
+             The skills below contain specialized instructions. When a task matches a skill \
+             description, call `activate_skill` with only that skill name before taking other \
+             actions. Do not call other tools in the same turn as `activate_skill`. Activated \
+             instructions remain authoritative for this conversation until `deactivate_skill` is \
+             called or the skill is removed. Use `read_skill_resource` only for resources belonging \
+             to an activated skill.\n\n\
+             ## Available skills\n",
+        );
+        for skill in snapshot.skills() {
+            prompt.push_str("- `");
+            prompt.push_str(skill.metadata().name());
+            prompt.push_str("`: ");
+            prompt.push_str(skill.metadata().description());
+            if let Some(compatibility) = skill.metadata().compatibility() {
+                prompt.push_str(" Compatibility: ");
+                prompt.push_str(compatibility);
+            }
+            prompt.push('\n');
+        }
+
+        for name in active_skills {
+            let Some(skill) = snapshot.get_ref(name) else {
+                continue;
+            };
+            prompt.push_str("\n## Active skill: `");
+            prompt.push_str(skill.metadata().name());
+            prompt.push_str("`\n\n");
+            prompt.push_str(skill.instructions());
+            prompt.push('\n');
+            if !skill.resources().is_empty() {
+                prompt.push_str("\nResources available through `read_skill_resource`:\n");
+                for resource in skill.resources() {
+                    prompt.push_str("- `");
+                    let _ = write!(prompt, "{}", resource.display());
+                    prompt.push_str("`\n");
+                }
+            }
+        }
+        prompt
+    }
+}

--- a/crates/autoagents-core/src/agent/skill/registry.rs
+++ b/crates/autoagents-core/src/agent/skill/registry.rs
@@ -1,0 +1,301 @@
+use crate::agent::skill::{Skill, SkillSource, SkillSourceId, SkillSourceSnapshot};
+use std::collections::{BTreeMap, BTreeSet};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, RwLock};
+
+#[cfg(target_arch = "wasm32")]
+use futures::lock::Mutex as RefreshMutex;
+#[cfg(not(target_arch = "wasm32"))]
+use tokio::sync::Mutex as RefreshMutex;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SkillDiagnostic {
+    source: SkillSourceId,
+    message: String,
+}
+
+impl SkillDiagnostic {
+    pub fn source(&self) -> &SkillSourceId {
+        &self.source
+    }
+
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct SkillRefreshReport {
+    generation: u64,
+    discovered: usize,
+    added: Vec<String>,
+    updated: Vec<String>,
+    removed: Vec<String>,
+    diagnostics: Vec<SkillDiagnostic>,
+}
+
+impl SkillRefreshReport {
+    pub fn generation(&self) -> u64 {
+        self.generation
+    }
+
+    pub fn discovered(&self) -> usize {
+        self.discovered
+    }
+
+    pub fn added(&self) -> &[String] {
+        &self.added
+    }
+
+    pub fn updated(&self) -> &[String] {
+        &self.updated
+    }
+
+    pub fn removed(&self) -> &[String] {
+        &self.removed
+    }
+
+    pub fn diagnostics(&self) -> &[SkillDiagnostic] {
+        &self.diagnostics
+    }
+
+    pub fn changed(&self) -> bool {
+        !(self.added.is_empty() && self.updated.is_empty() && self.removed.is_empty())
+    }
+
+    pub(crate) fn log_diagnostics(&self) {
+        for diagnostic in &self.diagnostics {
+            log::warn!(
+                "skill source '{}' reported: {}",
+                diagnostic.source.as_str(),
+                diagnostic.message
+            );
+        }
+    }
+
+    fn unchanged(snapshot: &SkillSnapshot) -> Self {
+        Self {
+            generation: snapshot.generation(),
+            discovered: snapshot.len(),
+            ..Self::default()
+        }
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct SkillSnapshot {
+    generation: u64,
+    skills: BTreeMap<String, Arc<Skill>>,
+}
+
+impl SkillSnapshot {
+    pub fn generation(&self) -> u64 {
+        self.generation
+    }
+
+    pub fn len(&self) -> usize {
+        self.skills.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.skills.is_empty()
+    }
+
+    pub fn get(&self, name: &str) -> Option<Arc<Skill>> {
+        self.skills.get(name).cloned()
+    }
+
+    pub(crate) fn get_ref(&self, name: &str) -> Option<&Skill> {
+        self.skills.get(name).map(Arc::as_ref)
+    }
+
+    pub fn skills(&self) -> impl Iterator<Item = &Arc<Skill>> {
+        self.skills.values()
+    }
+}
+
+#[derive(Debug)]
+struct StoredSourceSnapshot {
+    precedence: u16,
+    snapshot: SkillSourceSnapshot,
+}
+
+#[derive(Debug, Default)]
+struct SkillRegistryState {
+    source_snapshots: BTreeMap<SkillSourceId, StoredSourceSnapshot>,
+    merged: Arc<SkillSnapshot>,
+    diagnostics: BTreeSet<(SkillSourceId, String)>,
+}
+
+impl SkillRegistryState {
+    fn merged_skills(&self) -> BTreeMap<String, Arc<Skill>> {
+        let mut sources = self.source_snapshots.iter().collect::<Vec<_>>();
+        sources.sort_by(|(left_id, left), (right_id, right)| {
+            left.precedence
+                .cmp(&right.precedence)
+                .then_with(|| left_id.cmp(right_id))
+        });
+
+        let mut skills = BTreeMap::new();
+        for (_, source) in sources {
+            for skill in &source.snapshot.skills {
+                skills.insert(skill.metadata().name().to_string(), Arc::clone(skill));
+            }
+        }
+        skills
+    }
+
+    fn replace_merged(&mut self, skills: BTreeMap<String, Arc<Skill>>) -> SkillRefreshReport {
+        let previous = &self.merged.skills;
+        let added = skills
+            .keys()
+            .filter(|name| !previous.contains_key(*name))
+            .cloned()
+            .collect::<Vec<_>>();
+        let removed = previous
+            .keys()
+            .filter(|name| !skills.contains_key(*name))
+            .cloned()
+            .collect::<Vec<_>>();
+        let updated = skills
+            .iter()
+            .filter(|(name, skill)| previous.get(*name).is_some_and(|old| old != *skill))
+            .map(|(name, _)| name)
+            .cloned()
+            .collect::<Vec<_>>();
+        let changed = !(added.is_empty() && updated.is_empty() && removed.is_empty());
+        let generation = self.merged.generation + u64::from(changed);
+        let discovered = skills.len();
+        if changed {
+            self.merged = Arc::new(SkillSnapshot { generation, skills });
+        }
+
+        SkillRefreshReport {
+            generation,
+            discovered,
+            added,
+            updated,
+            removed,
+            diagnostics: Vec::new(),
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct SkillRegistry {
+    sources: Vec<Arc<dyn SkillSource>>,
+    state: RwLock<SkillRegistryState>,
+    refresh: RefreshMutex<()>,
+    refresh_epoch: AtomicU64,
+}
+
+impl SkillRegistry {
+    pub fn new(sources: Vec<Arc<dyn SkillSource>>) -> Self {
+        Self {
+            sources,
+            state: RwLock::new(SkillRegistryState::default()),
+            refresh: RefreshMutex::new(()),
+            refresh_epoch: AtomicU64::new(0),
+        }
+    }
+
+    pub fn from_directory(
+        path: impl Into<std::path::PathBuf>,
+        refresh_strategy: crate::agent::skill::SkillRefreshStrategy,
+    ) -> Self {
+        Self::new(vec![Arc::new(
+            crate::agent::skill::DirectorySkillSource::new(path, refresh_strategy),
+        )])
+    }
+
+    pub async fn refresh(&self) -> SkillRefreshReport {
+        let observed_epoch = self.refresh_epoch.load(Ordering::Acquire);
+        let _refresh_guard = self.refresh.lock().await;
+        if self.refresh_epoch.load(Ordering::Acquire) != observed_epoch {
+            return SkillRefreshReport::unchanged(&self.snapshot());
+        }
+        self.refresh_sources().await
+    }
+
+    pub async fn refresh_now(&self) -> SkillRefreshReport {
+        let _refresh_guard = self.refresh.lock().await;
+        for source in &self.sources {
+            source.invalidate();
+        }
+        self.refresh_sources().await
+    }
+
+    async fn refresh_sources(&self) -> SkillRefreshReport {
+        let discoveries = futures::future::join_all(self.sources.iter().map(|source| async move {
+            (
+                source.id().clone(),
+                source.precedence(),
+                source.discover().await,
+            )
+        }))
+        .await;
+
+        let mut state = self
+            .state
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let mut diagnostics = Vec::new();
+        for (source_id, precedence, discovery) in discoveries {
+            match discovery {
+                Ok(snapshot) => {
+                    diagnostics.extend(snapshot.diagnostics.iter().cloned().map(|message| {
+                        SkillDiagnostic {
+                            source: source_id.clone(),
+                            message,
+                        }
+                    }));
+                    state.source_snapshots.insert(
+                        source_id,
+                        StoredSourceSnapshot {
+                            precedence,
+                            snapshot,
+                        },
+                    );
+                }
+                Err(error) => diagnostics.push(SkillDiagnostic {
+                    source: source_id,
+                    message: error.to_string(),
+                }),
+            }
+        }
+
+        let current_diagnostics = diagnostics
+            .into_iter()
+            .map(|diagnostic| {
+                (
+                    (diagnostic.source.clone(), diagnostic.message.clone()),
+                    diagnostic,
+                )
+            })
+            .collect::<BTreeMap<_, _>>();
+        let new_diagnostics = current_diagnostics
+            .iter()
+            .filter(|(key, _)| !state.diagnostics.contains(*key))
+            .map(|(_, diagnostic)| diagnostic.clone())
+            .collect::<Vec<_>>();
+        state.diagnostics = current_diagnostics.into_keys().collect();
+
+        let skills = state.merged_skills();
+        let mut report = state.replace_merged(skills);
+        report.diagnostics = new_diagnostics;
+        self.refresh_epoch.fetch_add(1, Ordering::Release);
+        report
+    }
+
+    pub fn snapshot(&self) -> Arc<SkillSnapshot> {
+        self.state
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .merged
+            .clone()
+    }
+
+    pub fn get(&self, name: &str) -> Option<Arc<Skill>> {
+        self.snapshot().get(name)
+    }
+}

--- a/crates/autoagents-core/src/agent/skill/resource.rs
+++ b/crates/autoagents-core/src/agent/skill/resource.rs
@@ -1,0 +1,132 @@
+use cap_fs_ext::{DirExt, FollowSymlinks, OpenOptionsFollowExt};
+use cap_std::fs::{Dir, File, OpenOptions};
+use std::io;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+#[derive(Debug)]
+pub(crate) struct SkillResourceBoundary {
+    directory: Dir,
+    path: PathBuf,
+}
+
+impl SkillResourceBoundary {
+    pub(crate) fn open(path: PathBuf) -> io::Result<Self> {
+        let directory = Dir::open_ambient_dir(&path, cap_std::ambient_authority())?;
+        Ok(Self { directory, path })
+    }
+
+    pub(crate) fn open_skill(&self, skill_directory: &Path) -> io::Result<SkillResourceDirectory> {
+        let relative = skill_directory.strip_prefix(&self.path).map_err(|_| {
+            io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "skill directory is outside its resource boundary",
+            )
+        })?;
+        if relative.as_os_str().is_empty() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "skill directory must be below its resource boundary",
+            ));
+        }
+        self.directory
+            .open_dir_nofollow(relative)
+            .map(SkillResourceDirectory::new)
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct SkillResourceDirectory {
+    directory: Arc<Dir>,
+}
+
+impl SkillResourceDirectory {
+    fn new(directory: Dir) -> Self {
+        Self {
+            directory: Arc::new(directory),
+        }
+    }
+
+    pub(crate) fn open_file(&self, relative: &Path) -> io::Result<File> {
+        let mut options = OpenOptions::new();
+        options.read(true).follow(FollowSymlinks::No);
+        self.directory.open_with(relative, &options)
+    }
+}
+
+impl std::fmt::Debug for SkillResourceDirectory {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("SkillResourceDirectory")
+            .finish_non_exhaustive()
+    }
+}
+
+impl PartialEq for SkillResourceDirectory {
+    fn eq(&self, _other: &Self) -> bool {
+        true
+    }
+}
+
+impl Eq for SkillResourceDirectory {}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::SkillResourceBoundary;
+    use std::fs;
+    use std::io::ErrorKind;
+    use std::os::unix::fs::symlink;
+
+    #[test]
+    fn captured_directory_is_not_redirected_by_a_path_replacement() {
+        let fixture = tempfile::tempdir().expect("fixture");
+        let boundary_path = fixture.path().join("boundary");
+        let original = boundary_path.join("skill");
+        fs::create_dir_all(&original).expect("original skill directory");
+        fs::write(original.join("resource.md"), "trusted content").expect("original resource");
+        let boundary = SkillResourceBoundary::open(boundary_path.clone()).expect("boundary");
+        let captured = boundary.open_skill(&original).expect("captured directory");
+
+        let displaced = boundary_path.join("displaced");
+        fs::rename(&original, &displaced).expect("displace original directory");
+        let outside = fixture.path().join("outside");
+        fs::create_dir(&outside).expect("outside directory");
+        fs::write(outside.join("resource.md"), "untrusted content").expect("outside resource");
+        symlink(&outside, &original).expect("replacement symlink");
+
+        let content = std::io::read_to_string(
+            captured
+                .open_file(std::path::Path::new("resource.md"))
+                .expect("captured resource"),
+        )
+        .expect("resource content");
+
+        assert_eq!(content, "trusted content");
+    }
+
+    #[test]
+    fn resource_boundary_rejects_itself_and_outside_directories() {
+        let fixture = tempfile::tempdir().expect("fixture");
+        let boundary_path = fixture.path().join("boundary");
+        let first_skill = boundary_path.join("first");
+        let second_skill = boundary_path.join("second");
+        fs::create_dir_all(&first_skill).expect("first skill directory");
+        fs::create_dir_all(&second_skill).expect("second skill directory");
+        let boundary = SkillResourceBoundary::open(boundary_path.clone()).expect("boundary");
+
+        let outside_error = boundary
+            .open_skill(fixture.path())
+            .expect_err("outside directory must be rejected");
+        assert_eq!(outside_error.kind(), ErrorKind::PermissionDenied);
+
+        let boundary_error = boundary
+            .open_skill(&boundary_path)
+            .expect_err("boundary root is not a skill directory");
+        assert_eq!(boundary_error.kind(), ErrorKind::InvalidInput);
+
+        let first = boundary.open_skill(&first_skill).expect("first skill");
+        let second = boundary.open_skill(&second_skill).expect("second skill");
+        assert_eq!(first, second);
+        assert!(format!("{first:?}").contains("SkillResourceDirectory"));
+    }
+}

--- a/crates/autoagents-core/src/agent/skill/runtime.rs
+++ b/crates/autoagents-core/src/agent/skill/runtime.rs
@@ -1,0 +1,725 @@
+use crate::agent::skill::prompt::SkillPromptRenderer;
+use crate::agent::skill::{
+    SkillActivationRequest, SkillConfiguration, SkillError, SkillLifecycle, SkillLifecycleDecision,
+    SkillRefreshReport, SkillResourceRequest, SkillSnapshot,
+};
+use crate::tool::{ToolCallError, ToolRuntime, ToolT, to_llm_tool};
+use async_trait::async_trait;
+use autoagents_llm::chat::Tool;
+use autoagents_protocol::{ActorID, Event, SubmissionId};
+use serde::Deserialize;
+use serde_json::{Value, json};
+#[cfg(not(target_arch = "wasm32"))]
+use sha2::{Digest, Sha256};
+use std::path::{Component, Path};
+use std::sync::Arc;
+
+#[cfg(not(target_arch = "wasm32"))]
+use std::io::Read;
+#[cfg(not(target_arch = "wasm32"))]
+use std::path::PathBuf;
+#[cfg(not(target_arch = "wasm32"))]
+use tokio::sync::mpsc;
+
+#[cfg(not(target_arch = "wasm32"))]
+use crate::agent::skill::resource::SkillResourceDirectory;
+
+#[cfg(target_arch = "wasm32")]
+use futures::SinkExt;
+#[cfg(target_arch = "wasm32")]
+use futures::channel::mpsc;
+
+pub use autoagents_protocol::{
+    SkillDeactivationReason, SkillEvent, SkillEventKind, SkillOperation,
+};
+
+#[derive(Clone)]
+pub(crate) struct SkillRuntimeIdentity {
+    actor_id: ActorID,
+    submission_id: Option<SubmissionId>,
+    events: Option<mpsc::Sender<Event>>,
+}
+
+impl std::fmt::Debug for SkillRuntimeIdentity {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("SkillRuntimeIdentity")
+            .field("actor_id", &self.actor_id)
+            .field("submission_id", &self.submission_id)
+            .field("events", &self.events.as_ref().map(|_| "configured"))
+            .finish()
+    }
+}
+
+impl SkillRuntimeIdentity {
+    pub(crate) fn new(
+        actor_id: ActorID,
+        submission_id: Option<SubmissionId>,
+        events: Option<mpsc::Sender<Event>>,
+    ) -> Self {
+        Self {
+            actor_id,
+            submission_id,
+            events,
+        }
+    }
+
+    fn submission_id(&self) -> Result<SubmissionId, SkillError> {
+        self.submission_id.ok_or_else(|| {
+            SkillError::PolicyDenied("skill operation requires an active task".to_string())
+        })
+    }
+}
+
+#[derive(Debug)]
+struct SkillEventDispatcher {
+    identity: SkillRuntimeIdentity,
+    session: Arc<crate::agent::skill::SkillSession>,
+    lifecycle: Arc<dyn SkillLifecycle>,
+}
+
+impl SkillEventDispatcher {
+    fn new(
+        identity: SkillRuntimeIdentity,
+        session: Arc<crate::agent::skill::SkillSession>,
+        lifecycle: Arc<dyn SkillLifecycle>,
+    ) -> Self {
+        Self {
+            identity,
+            session,
+            lifecycle,
+        }
+    }
+
+    fn event(&self, event: SkillEventKind) -> SkillEvent {
+        SkillEvent::new(
+            self.identity.actor_id,
+            self.identity.submission_id,
+            self.session.id(),
+            event,
+        )
+    }
+
+    async fn publish(&self, event: &SkillEvent) {
+        let Some(events) = &self.identity.events else {
+            return;
+        };
+
+        #[cfg(not(target_arch = "wasm32"))]
+        let _ = events
+            .send(Event::Skill {
+                event: event.clone(),
+            })
+            .await;
+
+        #[cfg(target_arch = "wasm32")]
+        {
+            let mut events = events.clone();
+            let _ = events
+                .send(Event::Skill {
+                    event: event.clone(),
+                })
+                .await;
+        }
+    }
+
+    async fn catalog_changed(&self, event: SkillEvent) {
+        self.publish(&event).await;
+        self.lifecycle.on_catalog_changed(&event).await;
+    }
+
+    async fn activation_requested(&self, event: SkillEvent) -> Result<(), SkillError> {
+        self.publish(&event).await;
+        match self.lifecycle.on_activation_requested(&event).await {
+            SkillLifecycleDecision::Continue => Ok(()),
+            SkillLifecycleDecision::Abort => Err(SkillError::PolicyDenied(
+                "skill activation aborted by lifecycle hook".to_string(),
+            )),
+        }
+    }
+
+    async fn activated(&self, event: SkillEvent) {
+        self.publish(&event).await;
+        self.lifecycle.on_activated(&event).await;
+    }
+
+    async fn deactivated(&self, event: SkillEvent) {
+        self.publish(&event).await;
+        self.lifecycle.on_deactivated(&event).await;
+    }
+
+    async fn resource_access_requested(&self, event: SkillEvent) -> Result<(), SkillError> {
+        self.publish(&event).await;
+        match self.lifecycle.on_resource_access_requested(&event).await {
+            SkillLifecycleDecision::Continue => Ok(()),
+            SkillLifecycleDecision::Abort => Err(SkillError::PolicyDenied(
+                "skill resource access aborted by lifecycle hook".to_string(),
+            )),
+        }
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    async fn resource_accessed(&self, event: SkillEvent) {
+        self.publish(&event).await;
+        self.lifecycle.on_resource_accessed(&event).await;
+    }
+
+    async fn operation_failed(&self, event: SkillEvent) {
+        self.publish(&event).await;
+        self.lifecycle.on_operation_failed(&event).await;
+    }
+}
+
+#[derive(Debug)]
+pub struct SkillRuntime {
+    configuration: SkillConfiguration,
+    events: SkillEventDispatcher,
+}
+
+impl SkillRuntime {
+    pub const ACTIVATE_TOOL_NAME: &'static str = "activate_skill";
+    pub const DEACTIVATE_TOOL_NAME: &'static str = "deactivate_skill";
+    pub const READ_RESOURCE_TOOL_NAME: &'static str = "read_skill_resource";
+
+    pub(crate) fn new(
+        configuration: SkillConfiguration,
+        identity: SkillRuntimeIdentity,
+        lifecycle: Arc<dyn SkillLifecycle>,
+    ) -> Arc<Self> {
+        let session = configuration.session();
+        Arc::new(Self {
+            events: SkillEventDispatcher::new(identity, session, lifecycle),
+            configuration,
+        })
+    }
+
+    pub fn tools(self: &Arc<Self>) -> Vec<Box<dyn ToolT>> {
+        vec![
+            Box::new(ActivateSkillTool {
+                runtime: Arc::clone(self),
+            }),
+            Box::new(DeactivateSkillTool {
+                runtime: Arc::clone(self),
+            }),
+            Box::new(ReadSkillResourceTool {
+                runtime: Arc::clone(self),
+            }),
+        ]
+    }
+
+    pub fn serialized_tools(self: &Arc<Self>) -> Vec<Tool> {
+        self.tools().iter().map(to_llm_tool).collect()
+    }
+
+    pub fn configuration(&self) -> &SkillConfiguration {
+        &self.configuration
+    }
+
+    pub async fn compose_system_prompt(&self, base_prompt: &str) -> String {
+        let snapshot = self.refresh_catalog().await;
+        let active = self.configuration.session_ref().active();
+        SkillPromptRenderer::render(base_prompt, &snapshot, &active)
+    }
+
+    pub async fn refresh_now(&self) -> SkillRefreshReport {
+        let report = self.configuration.registry_ref().refresh_now().await;
+        self.apply_refresh(&report).await;
+        report
+    }
+
+    pub(crate) async fn initialize(&self) {
+        let report = self.configuration.registry_ref().refresh().await;
+        self.apply_refresh(&report).await;
+    }
+
+    pub async fn reset_session(&self) {
+        let reset = self.configuration.session_ref().reset();
+        for skill_name in reset.deactivated() {
+            let event = SkillEvent::new(
+                self.events.identity.actor_id,
+                self.events.identity.submission_id,
+                reset.previous_id(),
+                SkillEventKind::Deactivated {
+                    skill_name: skill_name.clone(),
+                    reason: SkillDeactivationReason::SessionReset,
+                },
+            );
+            self.events.deactivated(event).await;
+        }
+    }
+
+    pub fn validate_agent_tools(tools: &[Box<dyn ToolT>]) -> Result<(), SkillError> {
+        for tool in tools {
+            if matches!(
+                tool.name(),
+                Self::ACTIVATE_TOOL_NAME
+                    | Self::DEACTIVATE_TOOL_NAME
+                    | Self::READ_RESOURCE_TOOL_NAME
+            ) {
+                return Err(SkillError::ToolNameConflict(tool.name().to_string()));
+            }
+        }
+        Ok(())
+    }
+
+    async fn refresh_catalog(&self) -> Arc<SkillSnapshot> {
+        let registry = self.configuration.registry_ref();
+        let report = registry.refresh().await;
+        self.apply_refresh(&report).await;
+        registry.snapshot()
+    }
+
+    async fn apply_refresh(&self, report: &SkillRefreshReport) {
+        report.log_diagnostics();
+
+        if report.changed() {
+            let event = self.events.event(SkillEventKind::CatalogChanged {
+                generation: report.generation(),
+                added: report.added().to_vec(),
+                updated: report.updated().to_vec(),
+                removed: report.removed().to_vec(),
+            });
+            self.events.catalog_changed(event).await;
+        }
+
+        for diagnostic in report.diagnostics() {
+            let event = self.events.event(SkillEventKind::OperationFailed {
+                operation: SkillOperation::RefreshCatalog,
+                skill_name: None,
+                message: format!("{}: {}", diagnostic.source().as_str(), diagnostic.message()),
+            });
+            self.events.operation_failed(event).await;
+        }
+
+        let snapshot = self.configuration.registry_ref().snapshot();
+        let reconciliation = self.configuration.session_ref().reconcile(&snapshot);
+        for skill_name in reconciliation.updated() {
+            let event = self.events.event(SkillEventKind::Deactivated {
+                skill_name: skill_name.clone(),
+                reason: SkillDeactivationReason::Updated,
+            });
+            self.events.deactivated(event).await;
+        }
+        for skill_name in reconciliation.removed() {
+            let event = self.events.event(SkillEventKind::Deactivated {
+                skill_name: skill_name.clone(),
+                reason: SkillDeactivationReason::Removed,
+            });
+            self.events.deactivated(event).await;
+        }
+    }
+
+    async fn activate(&self, name: String) -> Result<Value, SkillError> {
+        let snapshot = self.refresh_catalog().await;
+        let skill = snapshot
+            .get(&name)
+            .ok_or_else(|| SkillError::UnknownSkill(name.clone()))?;
+        let requested = self.events.event(SkillEventKind::ActivationRequested {
+            skill_name: name.clone(),
+        });
+        self.events.activation_requested(requested).await?;
+
+        let request = SkillActivationRequest::new(
+            self.events.identity.actor_id,
+            self.events.identity.submission_id()?,
+            self.configuration.session_ref().id(),
+            Arc::clone(&skill),
+        );
+        self.configuration
+            .policy_ref()
+            .authorize_activation(&request)
+            .await?;
+
+        let newly_activated = self
+            .configuration
+            .session_ref()
+            .activate(name.clone(), skill.revision());
+        let activated = self.events.event(SkillEventKind::Activated {
+            skill_name: name,
+            newly_activated,
+        });
+        self.events.activated(activated).await;
+        let resources = skill
+            .resources()
+            .iter()
+            .map(|path| path.display().to_string())
+            .collect::<Vec<_>>();
+        let allowed_tools = skill
+            .metadata()
+            .allowed_tools()
+            .iter()
+            .map(|selector| selector.expression())
+            .collect::<Vec<_>>();
+
+        Ok(json!({
+            "activated": skill.metadata().name(),
+            "newly_activated": newly_activated,
+            "resources": resources,
+            "allowed_tools": allowed_tools,
+            "next_step": "The skill instructions are now present in the system prompt. Follow them before taking other actions."
+        }))
+    }
+
+    async fn deactivate(&self, name: String) -> Result<Value, SkillError> {
+        if !self.configuration.session_ref().deactivate(&name) {
+            return Err(SkillError::InactiveSkill(name));
+        }
+        let event = self.events.event(SkillEventKind::Deactivated {
+            skill_name: name.clone(),
+            reason: SkillDeactivationReason::Requested,
+        });
+        self.events.deactivated(event).await;
+        Ok(json!({"deactivated": name}))
+    }
+
+    async fn read_resource(
+        &self,
+        skill_name: String,
+        resource: String,
+    ) -> Result<Value, SkillError> {
+        let relative = SkillResourcePath::parse(&resource)?;
+        let snapshot = self.refresh_catalog().await;
+        let skill = snapshot
+            .get(&skill_name)
+            .ok_or_else(|| SkillError::UnknownSkill(skill_name.clone()))?;
+        if !self.configuration.session_ref().is_active(&skill_name) {
+            return Err(SkillError::InactiveSkill(skill_name));
+        }
+        if !skill
+            .resources()
+            .iter()
+            .any(|path| path == relative.as_path())
+        {
+            return Err(SkillError::InvalidResourcePath(resource));
+        }
+
+        let requested = self.events.event(SkillEventKind::ResourceAccessRequested {
+            skill_name: skill_name.clone(),
+            path: resource.clone(),
+        });
+        self.events.resource_access_requested(requested).await?;
+        let request = SkillResourceRequest::new(
+            self.events.identity.actor_id,
+            self.events.identity.submission_id()?,
+            self.configuration.session_ref().id(),
+            Arc::clone(&skill),
+            relative.as_path().to_path_buf(),
+        );
+        self.configuration
+            .policy_ref()
+            .authorize_resource_read(&request)
+            .await?;
+
+        let relative_path = relative.as_path().to_path_buf();
+
+        #[cfg(target_arch = "wasm32")]
+        {
+            let _ = relative_path;
+            return Err(SkillError::source_unavailable(
+                skill_name,
+                "filesystem skill resources are unavailable on wasm32",
+            ));
+        }
+
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            let reader = SkillResourceReader {
+                skill_name: skill_name.clone(),
+                directory: skill.resource_directory().ok_or_else(|| {
+                    SkillError::source_unavailable(
+                        &skill_name,
+                        "skill source did not provide a confined resource directory",
+                    )
+                })?,
+                display_directory: skill.directory().to_path_buf(),
+                relative: relative_path.clone(),
+                expected_digest: skill.resource_digest(&relative_path).ok_or_else(|| {
+                    SkillError::source_unavailable(
+                        &skill_name,
+                        "skill source did not provide a resource revision",
+                    )
+                })?,
+                max_bytes: self.configuration.max_resource_bytes(),
+            };
+            let bytes = tokio::task::spawn_blocking(move || reader.read())
+                .await
+                .map_err(|error| SkillError::SourceWorker(error.to_string()))??;
+
+            let byte_count = bytes.len();
+            let content = String::from_utf8(bytes)
+                .map_err(|_| SkillError::ResourceNotUtf8(skill.directory().join(&relative_path)))?;
+            let accessed = self.events.event(SkillEventKind::ResourceAccessed {
+                skill_name: skill_name.clone(),
+                path: resource.clone(),
+                bytes: byte_count,
+            });
+            self.events.resource_accessed(accessed).await;
+            Ok(json!({
+                "skill": skill_name,
+                "path": resource,
+                "content": content
+            }))
+        }
+    }
+
+    async fn report_failure(
+        &self,
+        operation: SkillOperation,
+        skill_name: Option<String>,
+        error: &SkillError,
+    ) {
+        let event = self.events.event(SkillEventKind::OperationFailed {
+            operation,
+            skill_name,
+            message: error.to_string(),
+        });
+        self.events.operation_failed(event).await;
+    }
+}
+
+#[derive(Debug)]
+struct SkillResourcePath {
+    path: std::path::PathBuf,
+}
+
+impl SkillResourcePath {
+    fn parse(path: &str) -> Result<Self, SkillError> {
+        let path = Path::new(path);
+        if path.as_os_str().is_empty()
+            || path.is_absolute()
+            || path
+                .components()
+                .any(|component| !matches!(component, Component::Normal(_)))
+        {
+            return Err(SkillError::InvalidResourcePath(path.display().to_string()));
+        }
+        Ok(Self {
+            path: path.to_path_buf(),
+        })
+    }
+
+    fn as_path(&self) -> &Path {
+        &self.path
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[derive(Debug)]
+struct SkillResourceReader {
+    skill_name: String,
+    directory: SkillResourceDirectory,
+    display_directory: PathBuf,
+    relative: PathBuf,
+    expected_digest: [u8; 32],
+    max_bytes: usize,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl SkillResourceReader {
+    fn read(self) -> Result<Vec<u8>, SkillError> {
+        let requested = self.display_directory.join(&self.relative);
+        let file = self.directory.open_file(&self.relative).map_err(|error| {
+            SkillError::source_unavailable(
+                &self.skill_name,
+                format!("cannot open resource '{}': {error}", requested.display()),
+            )
+        })?;
+        let metadata = file.metadata().map_err(|error| {
+            SkillError::source_unavailable(
+                &self.skill_name,
+                format!("cannot inspect resource '{}': {error}", requested.display()),
+            )
+        })?;
+        if !metadata.is_file() {
+            return Err(SkillError::InvalidResourcePath(
+                self.relative.display().to_string(),
+            ));
+        }
+        if metadata.len() > self.max_bytes as u64 {
+            return Err(SkillError::ResourceTooLarge {
+                path: requested,
+                limit: self.max_bytes,
+            });
+        }
+
+        let mut bytes = Vec::with_capacity((metadata.len() as usize).min(self.max_bytes));
+        file.take(self.max_bytes.saturating_add(1) as u64)
+            .read_to_end(&mut bytes)
+            .map_err(|error| {
+                SkillError::source_unavailable(
+                    &self.skill_name,
+                    format!("cannot read resource '{}': {error}", requested.display()),
+                )
+            })?;
+        if bytes.len() > self.max_bytes {
+            return Err(SkillError::ResourceTooLarge {
+                path: requested,
+                limit: self.max_bytes,
+            });
+        }
+        let observed_digest: [u8; 32] = Sha256::digest(&bytes).into();
+        if observed_digest != self.expected_digest {
+            return Err(SkillError::ResourceChanged(requested));
+        }
+        Ok(bytes)
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct ActivateSkillArgs {
+    name: String,
+}
+
+#[derive(Debug)]
+struct ActivateSkillTool {
+    runtime: Arc<SkillRuntime>,
+}
+
+impl ToolT for ActivateSkillTool {
+    fn name(&self) -> &str {
+        SkillRuntime::ACTIVATE_TOOL_NAME
+    }
+
+    fn description(&self) -> &str {
+        "Activate one available Agent Skill by its exact name. Call this before using the skill's instructions or resources."
+    }
+
+    fn args_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "Exact skill name from the available skills catalog"
+                }
+            },
+            "required": ["name"],
+            "additionalProperties": false
+        })
+    }
+}
+
+#[async_trait]
+impl ToolRuntime for ActivateSkillTool {
+    async fn execute(&self, args: Value) -> Result<Value, ToolCallError> {
+        let args: ActivateSkillArgs = serde_json::from_value(args)?;
+        match self.runtime.activate(args.name.clone()).await {
+            Ok(value) => Ok(value),
+            Err(error) => {
+                self.runtime
+                    .report_failure(SkillOperation::Activate, Some(args.name), &error)
+                    .await;
+                Err(ToolCallError::RuntimeError(Box::new(error)))
+            }
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct DeactivateSkillArgs {
+    name: String,
+}
+
+#[derive(Debug)]
+struct DeactivateSkillTool {
+    runtime: Arc<SkillRuntime>,
+}
+
+impl ToolT for DeactivateSkillTool {
+    fn name(&self) -> &str {
+        SkillRuntime::DEACTIVATE_TOOL_NAME
+    }
+
+    fn description(&self) -> &str {
+        "Deactivate one Agent Skill for the current conversation when its instructions no longer apply."
+    }
+
+    fn args_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "Exact name of an active skill"
+                }
+            },
+            "required": ["name"],
+            "additionalProperties": false
+        })
+    }
+}
+
+#[async_trait]
+impl ToolRuntime for DeactivateSkillTool {
+    async fn execute(&self, args: Value) -> Result<Value, ToolCallError> {
+        let args: DeactivateSkillArgs = serde_json::from_value(args)?;
+        match self.runtime.deactivate(args.name.clone()).await {
+            Ok(value) => Ok(value),
+            Err(error) => {
+                self.runtime
+                    .report_failure(SkillOperation::Deactivate, Some(args.name), &error)
+                    .await;
+                Err(ToolCallError::RuntimeError(Box::new(error)))
+            }
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct ReadSkillResourceArgs {
+    skill: String,
+    path: String,
+}
+
+#[derive(Debug)]
+struct ReadSkillResourceTool {
+    runtime: Arc<SkillRuntime>,
+}
+
+impl ToolT for ReadSkillResourceTool {
+    fn name(&self) -> &str {
+        SkillRuntime::READ_RESOURCE_TOOL_NAME
+    }
+
+    fn description(&self) -> &str {
+        "Read one UTF-8 resource file from an activated Agent Skill. The path must exactly match a resource listed for that skill."
+    }
+
+    fn args_schema(&self) -> Value {
+        json!({
+            "type": "object",
+            "properties": {
+                "skill": {
+                    "type": "string",
+                    "description": "Exact name of an activated skill"
+                },
+                "path": {
+                    "type": "string",
+                    "description": "Relative resource path listed by the activated skill"
+                }
+            },
+            "required": ["skill", "path"],
+            "additionalProperties": false
+        })
+    }
+}
+
+#[async_trait]
+impl ToolRuntime for ReadSkillResourceTool {
+    async fn execute(&self, args: Value) -> Result<Value, ToolCallError> {
+        let args: ReadSkillResourceArgs = serde_json::from_value(args)?;
+        match self
+            .runtime
+            .read_resource(args.skill.clone(), args.path)
+            .await
+        {
+            Ok(value) => Ok(value),
+            Err(error) => {
+                self.runtime
+                    .report_failure(SkillOperation::ReadResource, Some(args.skill), &error)
+                    .await;
+                Err(ToolCallError::RuntimeError(Box::new(error)))
+            }
+        }
+    }
+}

--- a/crates/autoagents-core/src/agent/skill/session.rs
+++ b/crates/autoagents-core/src/agent/skill/session.rs
@@ -1,0 +1,158 @@
+use crate::agent::skill::{SkillRevision, SkillSnapshot};
+use autoagents_protocol::SkillSessionId;
+use std::collections::{BTreeMap, BTreeSet};
+use std::sync::RwLock;
+use uuid::Uuid;
+
+#[derive(Debug)]
+struct SkillSessionState {
+    id: SkillSessionId,
+    active: BTreeMap<String, SkillRevision>,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub(crate) struct SkillSessionReconciliation {
+    updated: Vec<String>,
+    removed: Vec<String>,
+}
+
+impl SkillSessionReconciliation {
+    pub(crate) fn updated(&self) -> &[String] {
+        &self.updated
+    }
+
+    pub(crate) fn removed(&self) -> &[String] {
+        &self.removed
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SkillSessionReset {
+    previous_id: SkillSessionId,
+    current_id: SkillSessionId,
+    deactivated: Vec<String>,
+}
+
+impl SkillSessionReset {
+    pub fn previous_id(&self) -> SkillSessionId {
+        self.previous_id
+    }
+
+    pub fn current_id(&self) -> SkillSessionId {
+        self.current_id
+    }
+
+    pub fn deactivated(&self) -> &[String] {
+        &self.deactivated
+    }
+}
+
+#[derive(Debug)]
+pub struct SkillSession {
+    state: RwLock<SkillSessionState>,
+}
+
+impl Default for SkillSession {
+    fn default() -> Self {
+        Self {
+            state: RwLock::new(SkillSessionState {
+                id: Uuid::new_v4(),
+                active: BTreeMap::new(),
+            }),
+        }
+    }
+}
+
+impl SkillSession {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn id(&self) -> SkillSessionId {
+        self.state
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .id
+    }
+
+    pub fn active(&self) -> BTreeSet<String> {
+        self.state
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .active
+            .keys()
+            .cloned()
+            .collect()
+    }
+
+    pub fn is_active(&self, name: &str) -> bool {
+        self.state
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .active
+            .contains_key(name)
+    }
+
+    pub fn reset(&self) -> SkillSessionReset {
+        let mut state = self
+            .state
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let previous_id = state.id;
+        let deactivated = state.active.keys().cloned().collect();
+        state.id = Uuid::new_v4();
+        state.active.clear();
+        SkillSessionReset {
+            previous_id,
+            current_id: state.id,
+            deactivated,
+        }
+    }
+
+    pub(crate) fn activate(&self, name: String, revision: SkillRevision) -> bool {
+        self.state
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .active
+            .insert(name, revision)
+            .is_none_or(|active_revision| active_revision != revision)
+    }
+
+    pub(crate) fn deactivate(&self, name: &str) -> bool {
+        self.state
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .active
+            .remove(name)
+            .is_some()
+    }
+
+    pub(crate) fn reconcile(&self, available: &SkillSnapshot) -> SkillSessionReconciliation {
+        let mut state = self
+            .state
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let removed = state
+            .active
+            .keys()
+            .filter(|name| available.get_ref(name).is_none())
+            .cloned()
+            .collect::<Vec<_>>();
+        let updated = state
+            .active
+            .iter()
+            .filter(|(name, revision)| {
+                available
+                    .get_ref(name)
+                    .is_some_and(|skill| skill.revision() != **revision)
+            })
+            .map(|(name, _)| name.clone())
+            .collect::<Vec<_>>();
+        state.active.retain(|name, revision| {
+            available
+                .get_ref(name)
+                .is_some_and(|skill| skill.revision() == *revision)
+        });
+        SkillSessionReconciliation { updated, removed }
+    }
+}

--- a/crates/autoagents-core/src/agent/skill/source.rs
+++ b/crates/autoagents-core/src/agent/skill/source.rs
@@ -1,0 +1,51 @@
+use crate::agent::skill::{Skill, SkillError};
+use async_trait::async_trait;
+use std::fmt::Debug;
+use std::sync::Arc;
+
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct SkillSourceId(Arc<str>);
+
+impl SkillSourceId {
+    pub fn new(value: impl Into<String>) -> Self {
+        Self(Arc::from(value.into()))
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct SkillSourceSnapshot {
+    pub(crate) skills: Vec<Arc<Skill>>,
+    pub(crate) diagnostics: Vec<String>,
+}
+
+impl SkillSourceSnapshot {
+    pub fn new(skills: Vec<Arc<Skill>>, diagnostics: Vec<String>) -> Self {
+        Self {
+            skills,
+            diagnostics,
+        }
+    }
+
+    pub fn skills(&self) -> &[Arc<Skill>] {
+        &self.skills
+    }
+
+    pub fn diagnostics(&self) -> &[String] {
+        &self.diagnostics
+    }
+}
+
+#[async_trait]
+pub trait SkillSource: Debug + Send + Sync {
+    fn id(&self) -> &SkillSourceId;
+
+    fn precedence(&self) -> u16;
+
+    fn invalidate(&self) {}
+
+    async fn discover(&self) -> Result<SkillSourceSnapshot, SkillError>;
+}

--- a/crates/autoagents-core/src/agent/skill/tests.rs
+++ b/crates/autoagents-core/src/agent/skill/tests.rs
@@ -1,0 +1,1690 @@
+use super::SkillRuntimeIdentity;
+use super::{
+    DirectorySkillSource, SilentSkillLifecycle, SkillActivationRequest, SkillConfiguration,
+    SkillDiscoveryLimits, SkillError, SkillLifecycle, SkillLifecycleDecision, SkillPolicy,
+    SkillRefreshStrategy, SkillRegistry, SkillResourceRequest, SkillRuntime, SkillSession,
+    SkillSource, SkillSourceId, SkillSourceSnapshot, TrustedSkillPolicy,
+};
+use crate::agent::memory::SlidingWindowMemory;
+use crate::agent::prebuilt::executor::ReActAgent;
+use crate::agent::{AgentBuilder, AgentDeriveT, AgentHooks, DirectAgent};
+use crate::tests::{MockAgentImpl, MockLLMProvider, StaticChatResponse};
+use crate::tool::{ToolCallError, ToolRuntime, ToolT};
+use async_trait::async_trait;
+use autoagents_llm::chat::{ChatMessage, ChatProvider, ChatResponse, StructuredOutputFormat, Tool};
+use autoagents_llm::completion::{CompletionProvider, CompletionRequest, CompletionResponse};
+use autoagents_llm::embedding::EmbeddingProvider;
+use autoagents_llm::error::LLMError;
+use autoagents_llm::models::ModelsProvider;
+use autoagents_llm::{FunctionCall, LLMProvider, ToolCall};
+use autoagents_protocol::{Event, SkillEvent, SkillEventKind};
+use serde_json::json;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use tempfile::TempDir;
+use uuid::Uuid;
+
+const TEST_REFRESH: SkillRefreshStrategy = SkillRefreshStrategy::Poll {
+    interval: std::time::Duration::ZERO,
+};
+
+struct SkillFixture {
+    _temporary: TempDir,
+    root: PathBuf,
+}
+
+#[derive(Clone, Debug)]
+struct StringSkillsAgent;
+
+impl AgentDeriveT for StringSkillsAgent {
+    type Output = String;
+
+    fn description(&self) -> &str {
+        "Use matching skills."
+    }
+
+    fn output_schema(&self) -> Option<serde_json::Value> {
+        None
+    }
+
+    fn name(&self) -> &str {
+        "string_skills_agent"
+    }
+
+    fn tools(&self) -> Vec<Box<dyn ToolT>> {
+        Vec::new()
+    }
+}
+
+impl AgentHooks for StringSkillsAgent {}
+
+#[derive(Debug, Default)]
+struct ScriptedSkillsProvider {
+    turn: AtomicUsize,
+    active_prompt_seen: AtomicBool,
+}
+
+#[derive(Debug)]
+struct CountingSkillSource {
+    id: SkillSourceId,
+    calls: Arc<AtomicUsize>,
+}
+
+#[derive(Debug)]
+struct HighVolumeDiagnosticSkillSource {
+    id: SkillSourceId,
+    diagnostic_count: usize,
+}
+
+#[derive(Debug)]
+struct ReservedNameTool;
+
+#[derive(Debug)]
+struct DenyActivationPolicy;
+
+#[derive(Debug, Default)]
+struct PausingActivationPolicy {
+    entered: tokio::sync::Notify,
+    proceed: tokio::sync::Notify,
+}
+
+#[async_trait]
+impl SkillPolicy for DenyActivationPolicy {
+    async fn authorize_activation(
+        &self,
+        request: &SkillActivationRequest,
+    ) -> Result<(), SkillError> {
+        Err(SkillError::PolicyDenied(format!(
+            "{} is not approved",
+            request.skill().metadata().name()
+        )))
+    }
+
+    async fn authorize_resource_read(
+        &self,
+        _request: &SkillResourceRequest,
+    ) -> Result<(), SkillError> {
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl SkillPolicy for PausingActivationPolicy {
+    async fn authorize_activation(
+        &self,
+        _request: &SkillActivationRequest,
+    ) -> Result<(), SkillError> {
+        self.entered.notify_one();
+        self.proceed.notified().await;
+        Ok(())
+    }
+
+    async fn authorize_resource_read(
+        &self,
+        _request: &SkillResourceRequest,
+    ) -> Result<(), SkillError> {
+        Ok(())
+    }
+}
+
+#[derive(Debug, Default)]
+struct RecordingSkillLifecycle {
+    events: Mutex<Vec<SkillEventKind>>,
+}
+
+impl RecordingSkillLifecycle {
+    fn record(&self, event: &SkillEvent) {
+        self.events
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .push(event.event.clone());
+    }
+
+    fn observed(&self) -> Vec<SkillEventKind> {
+        self.events
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone()
+    }
+}
+
+#[async_trait]
+impl SkillLifecycle for RecordingSkillLifecycle {
+    async fn on_catalog_changed(&self, event: &SkillEvent) {
+        self.record(event);
+    }
+
+    async fn on_activation_requested(&self, event: &SkillEvent) -> SkillLifecycleDecision {
+        self.record(event);
+        SkillLifecycleDecision::Continue
+    }
+
+    async fn on_activated(&self, event: &SkillEvent) {
+        self.record(event);
+    }
+
+    async fn on_deactivated(&self, event: &SkillEvent) {
+        self.record(event);
+    }
+
+    async fn on_resource_access_requested(&self, event: &SkillEvent) -> SkillLifecycleDecision {
+        self.record(event);
+        SkillLifecycleDecision::Continue
+    }
+
+    async fn on_resource_accessed(&self, event: &SkillEvent) {
+        self.record(event);
+    }
+
+    async fn on_operation_failed(&self, event: &SkillEvent) {
+        self.record(event);
+    }
+}
+
+impl ToolT for ReservedNameTool {
+    fn name(&self) -> &str {
+        SkillRuntime::ACTIVATE_TOOL_NAME
+    }
+
+    fn description(&self) -> &str {
+        "Conflicts with the Agent Skills activation tool."
+    }
+
+    fn args_schema(&self) -> serde_json::Value {
+        json!({"type": "object"})
+    }
+}
+
+#[async_trait]
+impl ToolRuntime for ReservedNameTool {
+    async fn execute(&self, _args: serde_json::Value) -> Result<serde_json::Value, ToolCallError> {
+        Ok(serde_json::Value::Null)
+    }
+}
+
+#[async_trait]
+impl SkillSource for CountingSkillSource {
+    fn id(&self) -> &SkillSourceId {
+        &self.id
+    }
+
+    fn precedence(&self) -> u16 {
+        0
+    }
+
+    async fn discover(&self) -> Result<SkillSourceSnapshot, SkillError> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        Ok(SkillSourceSnapshot::default())
+    }
+}
+
+#[async_trait]
+impl SkillSource for HighVolumeDiagnosticSkillSource {
+    fn id(&self) -> &SkillSourceId {
+        &self.id
+    }
+
+    fn precedence(&self) -> u16 {
+        0
+    }
+
+    async fn discover(&self) -> Result<SkillSourceSnapshot, SkillError> {
+        let diagnostics = (0..self.diagnostic_count)
+            .map(|index| format!("initial diagnostic {index}"))
+            .collect();
+        Ok(SkillSourceSnapshot::new(Vec::new(), diagnostics))
+    }
+}
+
+impl ScriptedSkillsProvider {
+    fn active_prompt_seen(&self) -> bool {
+        self.active_prompt_seen.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait]
+impl ChatProvider for ScriptedSkillsProvider {
+    async fn chat(
+        &self,
+        messages: &[ChatMessage],
+        json_schema: Option<StructuredOutputFormat>,
+    ) -> Result<Box<dyn ChatResponse>, LLMError> {
+        self.chat_with_tools(messages, None, json_schema).await
+    }
+
+    async fn chat_with_tools(
+        &self,
+        messages: &[ChatMessage],
+        _tools: Option<&[Tool]>,
+        _json_schema: Option<StructuredOutputFormat>,
+    ) -> Result<Box<dyn ChatResponse>, LLMError> {
+        let turn = self.turn.fetch_add(1, Ordering::SeqCst);
+        if turn == 0 {
+            return Ok(Box::new(StaticChatResponse {
+                text: None,
+                tool_calls: Some(vec![ToolCall {
+                    id: "activate-1".to_string(),
+                    call_type: "function".to_string(),
+                    function: FunctionCall {
+                        name: SkillRuntime::ACTIVATE_TOOL_NAME.to_string(),
+                        arguments: r#"{"name":"release-notes"}"#.to_string(),
+                    },
+                }]),
+                usage: None,
+                thinking: None,
+            }));
+        }
+
+        let active_prompt_seen = messages
+            .first()
+            .is_some_and(|message| message.content.contains("Use active voice."));
+        self.active_prompt_seen
+            .store(active_prompt_seen, Ordering::SeqCst);
+        Ok(Box::new(StaticChatResponse {
+            text: Some("skill applied".to_string()),
+            tool_calls: None,
+            usage: None,
+            thinking: None,
+        }))
+    }
+}
+
+#[async_trait]
+impl CompletionProvider for ScriptedSkillsProvider {
+    async fn complete(
+        &self,
+        _request: &CompletionRequest,
+        _json_schema: Option<StructuredOutputFormat>,
+    ) -> Result<CompletionResponse, LLMError> {
+        Ok(CompletionResponse {
+            text: "unused".to_string(),
+        })
+    }
+}
+
+#[async_trait]
+impl EmbeddingProvider for ScriptedSkillsProvider {
+    async fn embed(&self, _text: Vec<String>) -> Result<Vec<Vec<f32>>, LLMError> {
+        Ok(Vec::new())
+    }
+}
+
+#[async_trait]
+impl ModelsProvider for ScriptedSkillsProvider {}
+
+impl LLMProvider for ScriptedSkillsProvider {}
+
+impl SkillFixture {
+    fn new() -> Self {
+        let temporary = tempfile::tempdir().expect("temporary directory should be created");
+        let root = temporary.path().join("skills");
+        fs::create_dir_all(&root).expect("skills directory should be created");
+        Self {
+            _temporary: temporary,
+            root,
+        }
+    }
+
+    fn root(&self) -> &Path {
+        &self.root
+    }
+
+    fn write_skill(&self, name: &str, description: &str, instructions: &str) {
+        let directory = self.root.join(name);
+        fs::create_dir_all(directory.join("references"))
+            .expect("skill directories should be created");
+        fs::write(
+            directory.join("SKILL.md"),
+            format!("---\nname: {name}\ndescription: {description}\n---\n\n{instructions}\n"),
+        )
+        .expect("SKILL.md should be written");
+        fs::write(
+            directory.join("references/details.md"),
+            format!("Reference for {name}"),
+        )
+        .expect("skill resource should be written");
+    }
+
+    fn remove_skill(&self, name: &str) {
+        fs::remove_dir_all(self.root.join(name)).expect("skill directory should be removed");
+    }
+
+    fn overwrite_document(&self, name: &str, document: &str) {
+        fs::write(self.root.join(name).join("SKILL.md"), document)
+            .expect("SKILL.md should be overwritten");
+    }
+
+    fn configuration(&self, registry: Arc<SkillRegistry>) -> SkillConfiguration {
+        SkillConfiguration::new(
+            registry,
+            Arc::new(SkillSession::new()),
+            Arc::new(TrustedSkillPolicy),
+        )
+    }
+
+    fn runtime(&self, registry: Arc<SkillRegistry>) -> Arc<SkillRuntime> {
+        SkillRuntime::new(
+            self.configuration(registry),
+            SkillRuntimeIdentity::new(Uuid::new_v4(), Some(Uuid::new_v4()), None),
+            Arc::new(SilentSkillLifecycle),
+        )
+    }
+
+    fn runtime_with_resource_limit(
+        &self,
+        registry: Arc<SkillRegistry>,
+        max_resource_bytes: usize,
+    ) -> Arc<SkillRuntime> {
+        let configuration = self
+            .configuration(registry)
+            .with_max_resource_bytes(max_resource_bytes);
+        SkillRuntime::new(
+            configuration,
+            SkillRuntimeIdentity::new(Uuid::new_v4(), Some(Uuid::new_v4()), None),
+            Arc::new(SilentSkillLifecycle),
+        )
+    }
+}
+
+#[tokio::test]
+async fn agent_build_discovers_skills_at_boot() {
+    let fixture = SkillFixture::new();
+    fixture.write_skill(
+        "release-notes",
+        "Write product release notes.",
+        "Use active voice.",
+    );
+    let registry = Arc::new(SkillRegistry::from_directory(fixture.root(), TEST_REFRESH));
+
+    let handle = AgentBuilder::<_, DirectAgent>::new(ReActAgent::new(MockAgentImpl::new(
+        "skills",
+        "Use skills",
+    )))
+    .llm(Arc::new(MockLLMProvider))
+    .memory(Box::new(SlidingWindowMemory::new(8)))
+    .skills(fixture.configuration(Arc::clone(&registry)))
+    .build()
+    .await
+    .expect("agent should build");
+
+    assert_eq!(registry.snapshot().len(), 1);
+    assert!(registry.get("release-notes").is_some());
+    assert_eq!(handle.agent.tools().len(), 0);
+}
+
+#[tokio::test]
+async fn direct_agent_build_does_not_block_when_initial_skill_events_exceed_channel_capacity() {
+    use futures_util::StreamExt;
+
+    let diagnostic_count = crate::agent::constants::DEFAULT_CHANNEL_BUFFER + 1;
+    let registry = Arc::new(SkillRegistry::new(vec![Arc::new(
+        HighVolumeDiagnosticSkillSource {
+            id: SkillSourceId::new("high-volume-diagnostics"),
+            diagnostic_count,
+        },
+    )]));
+    let configuration = SkillConfiguration::new(
+        Arc::clone(&registry),
+        Arc::new(SkillSession::new()),
+        Arc::new(TrustedSkillPolicy),
+    );
+    let build = AgentBuilder::<_, DirectAgent>::new(ReActAgent::new(MockAgentImpl::new(
+        "skills",
+        "Use skills",
+    )))
+    .llm(Arc::new(MockLLMProvider))
+    .skills(configuration)
+    .build();
+
+    let mut handle = tokio::time::timeout(std::time::Duration::from_secs(5), build)
+        .await
+        .expect("initial skill events must not block direct-agent construction")
+        .expect("agent should build");
+
+    assert!(registry.snapshot().is_empty());
+    let events = tokio::time::timeout(
+        std::time::Duration::from_secs(5),
+        handle
+            .rx
+            .by_ref()
+            .take(diagnostic_count)
+            .collect::<Vec<_>>(),
+    )
+    .await
+    .expect("every initial diagnostic event should be delivered");
+    assert_eq!(events.len(), diagnostic_count);
+    let mut messages = std::collections::BTreeSet::new();
+    for (index, event) in events.into_iter().enumerate() {
+        let message = match event {
+            Event::Skill {
+                event:
+                    SkillEvent {
+                        event: SkillEventKind::OperationFailed { message, .. },
+                        ..
+                    },
+            } => message,
+            other => panic!("expected diagnostic event {index}, got {other:?}"),
+        };
+        assert!(
+            messages.insert(message.clone()),
+            "diagnostic event was delivered more than once: {message}"
+        );
+    }
+    for index in 0..diagnostic_count {
+        assert!(
+            messages.contains(&format!(
+                "high-volume-diagnostics: initial diagnostic {index}"
+            )),
+            "initial diagnostic {index} was not delivered"
+        );
+    }
+
+    tokio::time::timeout(std::time::Duration::from_millis(100), handle.rx.next())
+        .await
+        .expect_err("startup replay should contain no duplicate events");
+    drop(handle);
+}
+
+#[tokio::test]
+async fn unsupported_executor_is_rejected_when_skills_are_configured() {
+    let fixture = SkillFixture::new();
+    fixture.write_skill("release-notes", "Write release notes.", "Be concise.");
+    let registry = Arc::new(SkillRegistry::from_directory(fixture.root(), TEST_REFRESH));
+
+    let error = match AgentBuilder::<_, DirectAgent>::new(MockAgentImpl::new("basic", "basic"))
+        .llm(Arc::new(MockLLMProvider))
+        .skills(fixture.configuration(registry))
+        .build()
+        .await
+    {
+        Ok(_) => panic!("unsupported executor should fail"),
+        Err(error) => error,
+    };
+
+    assert!(error.to_string().contains("does not support Agent Skills"));
+}
+
+#[tokio::test]
+async fn react_agent_activates_skill_and_receives_instructions_next_turn() {
+    let fixture = SkillFixture::new();
+    fixture.write_skill(
+        "release-notes",
+        "Write product release notes.",
+        "Use active voice.",
+    );
+    let registry = Arc::new(SkillRegistry::from_directory(fixture.root(), TEST_REFRESH));
+    let provider = Arc::new(ScriptedSkillsProvider::default());
+    let llm: Arc<dyn LLMProvider> = provider.clone();
+    let handle = AgentBuilder::<_, DirectAgent>::new(ReActAgent::new(StringSkillsAgent))
+        .llm(llm)
+        .memory(Box::new(SlidingWindowMemory::new(8)))
+        .skills(fixture.configuration(registry))
+        .build()
+        .await
+        .expect("agent should build");
+
+    let result = handle
+        .agent
+        .run(crate::agent::task::Task::new("Write a release note"))
+        .await
+        .expect("agent should complete");
+
+    assert_eq!(result, "skill applied");
+    assert!(provider.active_prompt_seen());
+
+    provider.active_prompt_seen.store(false, Ordering::SeqCst);
+    handle
+        .agent
+        .run(crate::agent::task::Task::new("Revise the release note"))
+        .await
+        .expect("second conversation turn should complete");
+    assert!(
+        provider.active_prompt_seen(),
+        "activation must survive a second agent.run call"
+    );
+
+    handle.agent.reset_skill_session().await;
+    provider.active_prompt_seen.store(false, Ordering::SeqCst);
+    handle
+        .agent
+        .run(crate::agent::task::Task::new("Start another conversation"))
+        .await
+        .expect("turn after reset should complete");
+    assert!(!provider.active_prompt_seen());
+}
+
+#[tokio::test]
+async fn runtime_refreshes_added_updated_and_removed_skills() {
+    let fixture = SkillFixture::new();
+    let registry = Arc::new(SkillRegistry::from_directory(fixture.root(), TEST_REFRESH));
+    let runtime = fixture.runtime(Arc::clone(&registry));
+
+    let initial = runtime.compose_system_prompt("base prompt").await;
+    assert_eq!(initial, "base prompt");
+
+    fixture.write_skill(
+        "release-notes",
+        "Write product release notes.",
+        "Use active voice.",
+    );
+    let added = runtime.compose_system_prompt("base prompt").await;
+    assert!(added.contains("`release-notes`: Write product release notes."));
+
+    let activate = runtime
+        .tools()
+        .into_iter()
+        .find(|tool| tool.name() == SkillRuntime::ACTIVATE_TOOL_NAME)
+        .expect("activation tool should exist");
+    activate
+        .execute(json!({"name": "release-notes"}))
+        .await
+        .expect("skill should activate");
+    let active = runtime.compose_system_prompt("base prompt").await;
+    assert!(active.contains("## Active skill: `release-notes`"));
+    assert!(active.contains("Use active voice."));
+
+    fixture.write_skill(
+        "release-notes",
+        "Write product release notes.",
+        "Use short declarative sentences.",
+    );
+    let updated = runtime.compose_system_prompt("base prompt").await;
+    assert!(!updated.contains("## Active skill: `release-notes`"));
+    assert!(!updated.contains("Use short declarative sentences."));
+    assert!(!updated.contains("Use active voice."));
+
+    activate
+        .execute(json!({"name": "release-notes"}))
+        .await
+        .expect("updated skill should require reactivation");
+    let reactivated = runtime.compose_system_prompt("base prompt").await;
+    assert!(reactivated.contains("Use short declarative sentences."));
+
+    fixture.write_skill("incident-review", "Review incidents.", "Start with impact.");
+    let second = runtime.compose_system_prompt("base prompt").await;
+    assert!(second.contains("`incident-review`: Review incidents."));
+
+    fixture.remove_skill("release-notes");
+    let removed = runtime.compose_system_prompt("base prompt").await;
+    assert!(!removed.contains("release-notes"));
+    assert!(removed.contains("incident-review"));
+}
+
+#[tokio::test]
+async fn approval_for_an_old_revision_cannot_activate_a_new_revision() {
+    let fixture = SkillFixture::new();
+    fixture.write_skill("review", "Review changes.", "Use revision A.");
+    let registry = Arc::new(SkillRegistry::from_directory(fixture.root(), TEST_REFRESH));
+    let policy = Arc::new(PausingActivationPolicy::default());
+    let configuration = SkillConfiguration::new(
+        Arc::clone(&registry),
+        Arc::new(SkillSession::new()),
+        policy.clone(),
+    );
+    let runtime = SkillRuntime::new(
+        configuration,
+        SkillRuntimeIdentity::new(Uuid::new_v4(), Some(Uuid::new_v4()), None),
+        Arc::new(SilentSkillLifecycle),
+    );
+    runtime.compose_system_prompt("base").await;
+    let activation = runtime
+        .tools()
+        .into_iter()
+        .find(|tool| tool.name() == SkillRuntime::ACTIVATE_TOOL_NAME)
+        .expect("activation tool");
+    let worker = tokio::spawn(async move { activation.execute(json!({"name": "review"})).await });
+    policy.entered.notified().await;
+
+    fixture.write_skill("review", "Review changes.", "Use revision B.");
+    let report = runtime.refresh_now().await;
+    assert_eq!(report.updated(), &["review"]);
+    policy.proceed.notify_one();
+    worker
+        .await
+        .expect("activation worker")
+        .expect("the old revision approval can complete");
+
+    let prompt = runtime.compose_system_prompt("base").await;
+    assert!(!prompt.contains("## Active skill: `review`"));
+    assert!(!prompt.contains("Use revision B."));
+}
+
+#[tokio::test]
+async fn activated_skill_resource_is_read_through_scoped_tool() {
+    let fixture = SkillFixture::new();
+    fixture.write_skill("research", "Research a topic.", "Read the reference.");
+    let registry = Arc::new(SkillRegistry::from_directory(fixture.root(), TEST_REFRESH));
+    let runtime = fixture.runtime(registry);
+    runtime.compose_system_prompt("base").await;
+    let tools = runtime.tools();
+    let activate = tools
+        .iter()
+        .find(|tool| tool.name() == SkillRuntime::ACTIVATE_TOOL_NAME)
+        .expect("activation tool should exist");
+    let read = tools
+        .iter()
+        .find(|tool| tool.name() == SkillRuntime::READ_RESOURCE_TOOL_NAME)
+        .expect("resource tool should exist");
+
+    let inactive = read
+        .execute(json!({"skill": "research", "path": "references/details.md"}))
+        .await;
+    assert!(inactive.is_err());
+    activate
+        .execute(json!({"name": "research"}))
+        .await
+        .expect("skill should activate");
+    let resource = read
+        .execute(json!({"skill": "research", "path": "references/details.md"}))
+        .await
+        .expect("resource should be readable");
+    assert_eq!(resource["content"], "Reference for research");
+
+    fs::write(
+        fixture.root.join("research/references/details.md"),
+        "changed after discovery",
+    )
+    .expect("resource mutation");
+    let changed = read
+        .execute(json!({"skill": "research", "path": "references/details.md"}))
+        .await;
+    assert!(
+        changed.is_err(),
+        "undiscovered resource bytes must never reach the model"
+    );
+
+    let traversal = read
+        .execute(json!({"skill": "research", "path": "../outside.md"}))
+        .await;
+    assert!(traversal.is_err());
+}
+
+#[tokio::test]
+async fn skill_policy_denial_is_fail_closed_and_observable() {
+    let fixture = SkillFixture::new();
+    fixture.write_skill("research", "Research a topic.", "Read the reference.");
+    let registry = Arc::new(SkillRegistry::from_directory(fixture.root(), TEST_REFRESH));
+    let configuration = SkillConfiguration::new(
+        registry,
+        Arc::new(SkillSession::new()),
+        Arc::new(DenyActivationPolicy),
+    );
+    let (events, mut receiver) = tokio::sync::mpsc::channel(16);
+    let runtime = SkillRuntime::new(
+        configuration,
+        SkillRuntimeIdentity::new(Uuid::new_v4(), Some(Uuid::new_v4()), Some(events)),
+        Arc::new(SilentSkillLifecycle),
+    );
+    runtime.compose_system_prompt("base").await;
+    let activate = runtime
+        .tools()
+        .into_iter()
+        .find(|tool| tool.name() == SkillRuntime::ACTIVATE_TOOL_NAME)
+        .expect("activation tool should exist");
+
+    let denied = activate.execute(json!({"name": "research"})).await;
+    assert!(denied.is_err());
+    assert!(!runtime.configuration().session().is_active("research"));
+
+    let mut requested = false;
+    let mut failed = false;
+    while let Ok(event) = receiver.try_recv() {
+        match event {
+            Event::Skill {
+                event:
+                    autoagents_protocol::SkillEvent {
+                        event: SkillEventKind::ActivationRequested { .. },
+                        ..
+                    },
+            } => requested = true,
+            Event::Skill {
+                event:
+                    autoagents_protocol::SkillEvent {
+                        event: SkillEventKind::OperationFailed { .. },
+                        ..
+                    },
+            } => failed = true,
+            _ => {}
+        }
+    }
+    assert!(requested);
+    assert!(failed);
+}
+
+#[tokio::test]
+async fn skill_lifecycle_receives_catalog_activation_resource_and_deactivation_events() {
+    let fixture = SkillFixture::new();
+    fixture.write_skill("research", "Research a topic.", "Read the reference.");
+    let configuration = fixture.configuration(Arc::new(SkillRegistry::from_directory(
+        fixture.root(),
+        TEST_REFRESH,
+    )));
+    let lifecycle = Arc::new(RecordingSkillLifecycle::default());
+    let runtime = SkillRuntime::new(
+        configuration,
+        SkillRuntimeIdentity::new(Uuid::new_v4(), Some(Uuid::new_v4()), None),
+        lifecycle.clone(),
+    );
+    runtime.compose_system_prompt("base").await;
+    let tools = runtime.tools();
+    tools
+        .iter()
+        .find(|tool| tool.name() == SkillRuntime::ACTIVATE_TOOL_NAME)
+        .expect("activation tool should exist")
+        .execute(json!({"name": "research"}))
+        .await
+        .expect("activation should succeed");
+    tools
+        .iter()
+        .find(|tool| tool.name() == SkillRuntime::READ_RESOURCE_TOOL_NAME)
+        .expect("resource tool should exist")
+        .execute(json!({"skill": "research", "path": "references/details.md"}))
+        .await
+        .expect("resource read should succeed");
+    tools
+        .iter()
+        .find(|tool| tool.name() == SkillRuntime::DEACTIVATE_TOOL_NAME)
+        .expect("deactivation tool should exist")
+        .execute(json!({"name": "research"}))
+        .await
+        .expect("deactivation should succeed");
+
+    let observed = lifecycle.observed();
+    assert!(matches!(observed[0], SkillEventKind::CatalogChanged { .. }));
+    assert!(
+        observed
+            .iter()
+            .any(|event| matches!(event, SkillEventKind::ActivationRequested { .. }))
+    );
+    assert!(
+        observed
+            .iter()
+            .any(|event| matches!(event, SkillEventKind::Activated { .. }))
+    );
+    assert!(
+        observed
+            .iter()
+            .any(|event| matches!(event, SkillEventKind::ResourceAccessRequested { .. }))
+    );
+    assert!(
+        observed
+            .iter()
+            .any(|event| matches!(event, SkillEventKind::ResourceAccessed { .. }))
+    );
+    assert!(
+        observed
+            .iter()
+            .any(|event| matches!(event, SkillEventKind::Deactivated { .. }))
+    );
+}
+
+#[tokio::test]
+async fn explicit_deactivation_removes_instructions_from_following_prompts() {
+    let fixture = SkillFixture::new();
+    fixture.write_skill("research", "Research a topic.", "Read the reference.");
+    let runtime = fixture.runtime(Arc::new(SkillRegistry::from_directory(
+        fixture.root(),
+        TEST_REFRESH,
+    )));
+    runtime.compose_system_prompt("base").await;
+    let tools = runtime.tools();
+    tools
+        .iter()
+        .find(|tool| tool.name() == SkillRuntime::ACTIVATE_TOOL_NAME)
+        .expect("activation tool should exist")
+        .execute(json!({"name": "research"}))
+        .await
+        .expect("activation should succeed");
+    tools
+        .iter()
+        .find(|tool| tool.name() == SkillRuntime::DEACTIVATE_TOOL_NAME)
+        .expect("deactivation tool should exist")
+        .execute(json!({"name": "research"}))
+        .await
+        .expect("deactivation should succeed");
+
+    let prompt = runtime.compose_system_prompt("base").await;
+    assert!(!prompt.contains("## Active skill: `research`"));
+}
+
+#[tokio::test]
+async fn invalid_live_edit_retains_last_valid_skill_until_repaired() {
+    let fixture = SkillFixture::new();
+    fixture.write_skill(
+        "research",
+        "Research a topic.",
+        "Use the valid instructions.",
+    );
+    let registry = Arc::new(SkillRegistry::from_directory(fixture.root(), TEST_REFRESH));
+    registry.refresh().await;
+    let original = registry.get("research").expect("valid skill should load");
+
+    fixture.overwrite_document("research", "not valid frontmatter");
+    let invalid = registry.refresh_now().await;
+    assert!(!invalid.diagnostics().is_empty());
+    let retained = registry
+        .get("research")
+        .expect("last valid skill should remain");
+    assert!(Arc::ptr_eq(&original, &retained));
+
+    fixture.overwrite_document(
+        "research",
+        "---\nname: research\ndescription: Research a topic.\n---\n\nUse repaired instructions.\n",
+    );
+    let repaired = registry.refresh_now().await;
+    assert_eq!(repaired.updated(), &["research"]);
+    assert_eq!(
+        registry
+            .get("research")
+            .expect("repaired skill should load")
+            .instructions(),
+        "Use repaired instructions."
+    );
+}
+
+#[cfg(feature = "skill-watch")]
+#[tokio::test]
+async fn forced_refresh_bypasses_watcher_debounce_for_resource_changes() {
+    let fixture = SkillFixture::new();
+    fixture.write_skill("resources", "Resource test.", "Read the resources.");
+    let registry = SkillRegistry::from_directory(
+        fixture.root(),
+        SkillRefreshStrategy::Watch {
+            debounce: std::time::Duration::from_secs(60),
+            fallback_interval: std::time::Duration::from_secs(60),
+        },
+    );
+    registry.refresh().await;
+
+    fs::write(
+        fixture.root.join("resources/references/just-added.md"),
+        "new resource",
+    )
+    .expect("new resource");
+    let report = registry.refresh_now().await;
+
+    assert_eq!(report.updated(), &["resources"]);
+    assert!(
+        registry
+            .get("resources")
+            .expect("resource skill")
+            .resources()
+            .contains(&PathBuf::from("references/just-added.md"))
+    );
+}
+
+#[tokio::test]
+async fn manual_refresh_ignores_changes_until_explicitly_invalidated() {
+    let fixture = SkillFixture::new();
+    fixture.write_skill("initial", "Initial skill.", "Initial instructions.");
+    let registry = SkillRegistry::from_directory(fixture.root(), SkillRefreshStrategy::Manual);
+    registry.refresh().await;
+
+    fixture.write_skill("added", "Added skill.", "Added instructions.");
+    let unchanged = registry.refresh().await;
+    assert!(!unchanged.changed());
+    assert!(registry.get("added").is_none());
+
+    let refreshed = registry.refresh_now().await;
+    assert_eq!(refreshed.added(), &["added"]);
+    assert!(registry.get("added").is_some());
+}
+
+#[tokio::test]
+async fn zero_interval_poll_refreshes_at_the_next_registry_boundary() {
+    let fixture = SkillFixture::new();
+    let registry = SkillRegistry::from_directory(fixture.root(), TEST_REFRESH);
+    registry.refresh().await;
+
+    fixture.write_skill("added", "Added skill.", "Added instructions.");
+    let refreshed = registry.refresh().await;
+
+    assert_eq!(refreshed.added(), &["added"]);
+}
+
+#[cfg(not(feature = "skill-watch"))]
+#[tokio::test]
+async fn watch_strategy_requires_the_optional_cargo_feature() {
+    let fixture = SkillFixture::new();
+    let source = DirectorySkillSource::new(
+        fixture.root(),
+        SkillRefreshStrategy::Watch {
+            debounce: std::time::Duration::from_millis(150),
+            fallback_interval: std::time::Duration::from_secs(30),
+        },
+    );
+
+    let error = source
+        .discover()
+        .await
+        .expect_err("watching must fail explicitly when it was not compiled");
+
+    assert!(matches!(error, SkillError::WatchUnavailable));
+}
+
+#[tokio::test]
+async fn resource_content_updates_change_revision_and_deactivate_the_skill() {
+    let fixture = SkillFixture::new();
+    fixture.write_skill("resources", "Resource test.", "Read the resources.");
+    let registry = Arc::new(SkillRegistry::from_directory(fixture.root(), TEST_REFRESH));
+    let runtime = fixture.runtime(Arc::clone(&registry));
+    runtime.compose_system_prompt("base").await;
+    let activation = runtime
+        .tools()
+        .into_iter()
+        .find(|tool| tool.name() == SkillRuntime::ACTIVATE_TOOL_NAME)
+        .expect("activation tool");
+    activation
+        .execute(json!({"name": "resources"}))
+        .await
+        .expect("skill activation");
+    let original_revision = registry.get("resources").expect("skill").revision();
+
+    fs::write(
+        fixture.root.join("resources/references/details.md"),
+        "replacement resource content",
+    )
+    .expect("resource update");
+    let report = runtime.refresh_now().await;
+
+    assert_eq!(report.updated(), &["resources"]);
+    assert_ne!(
+        original_revision,
+        registry.get("resources").expect("updated skill").revision()
+    );
+    assert!(
+        !runtime
+            .compose_system_prompt("base")
+            .await
+            .contains("## Active skill: `resources`")
+    );
+}
+
+#[test]
+fn allowed_tools_are_parsed_into_typed_selectors() {
+    let fixture = SkillFixture::new();
+    let directory = fixture.root.join("tool-aware");
+    fs::create_dir_all(&directory).expect("skill directory should be created");
+    let document = "---\nname: tool-aware\ndescription: Uses selected tools.\nallowed-tools: Bash(git:*) Read mcp.server/tool\n---\n\nUse only declared capabilities.\n";
+    let skill =
+        super::Skill::from_document(directory.join("SKILL.md"), directory, document, Vec::new())
+            .expect("tool selectors should parse");
+
+    let selectors = skill.metadata().allowed_tools();
+    assert_eq!(selectors.len(), 3);
+    assert_eq!(selectors[0].tool_name(), "Bash");
+    assert_eq!(selectors[0].qualifier(), Some("git:*"));
+    assert_eq!(selectors[2].tool_name(), "mcp.server/tool");
+}
+
+#[tokio::test]
+async fn oversized_skill_resources_are_rejected_without_full_reads() {
+    let fixture = SkillFixture::new();
+    fixture.write_skill("research", "Research a topic.", "Read the reference.");
+    let registry = Arc::new(SkillRegistry::from_directory(fixture.root(), TEST_REFRESH));
+    let runtime = fixture.runtime_with_resource_limit(registry, 4);
+    runtime.compose_system_prompt("base").await;
+    let tools = runtime.tools();
+    let activate = tools
+        .iter()
+        .find(|tool| tool.name() == SkillRuntime::ACTIVATE_TOOL_NAME)
+        .expect("activation tool should exist");
+    let read = tools
+        .iter()
+        .find(|tool| tool.name() == SkillRuntime::READ_RESOURCE_TOOL_NAME)
+        .expect("resource tool should exist");
+    activate
+        .execute(json!({"name": "research"}))
+        .await
+        .expect("skill should activate");
+
+    let error = read
+        .execute(json!({"skill": "research", "path": "references/details.md"}))
+        .await
+        .expect_err("oversized resource should be rejected");
+
+    assert!(error.to_string().contains("exceeds the 4 byte limit"));
+}
+
+#[test]
+fn reserved_skill_tool_names_are_rejected() {
+    let tools: Vec<Box<dyn ToolT>> = vec![Box::new(ReservedNameTool)];
+
+    let error = SkillRuntime::validate_agent_tools(&tools)
+        .expect_err("reserved skill tool name should be rejected");
+
+    assert!(matches!(error, SkillError::ToolNameConflict(_)));
+}
+
+#[tokio::test]
+async fn discovery_limits_skill_document_and_resource_counts() {
+    let fixture = SkillFixture::new();
+    fixture.write_skill("limited", "A limited skill.", "instructions");
+    let limits = SkillDiscoveryLimits {
+        max_skills: 1,
+        max_skill_file_bytes: 10,
+        max_resources_per_skill: 0,
+        max_resource_depth: 1,
+        ..SkillDiscoveryLimits::default()
+    };
+    let registry = SkillRegistry::new(vec![Arc::new(
+        DirectorySkillSource::new(fixture.root(), TEST_REFRESH).with_limits(limits),
+    )]);
+
+    let oversized = registry.refresh().await;
+    assert_eq!(oversized.discovered(), 0);
+    assert!(oversized.diagnostics()[0].message().contains("byte limit"));
+
+    let aggregate_limited = SkillRegistry::new(vec![Arc::new(
+        DirectorySkillSource::new(fixture.root(), TEST_REFRESH).with_limits(SkillDiscoveryLimits {
+            max_total_skill_file_bytes: 1,
+            ..SkillDiscoveryLimits::default()
+        }),
+    )]);
+    let aggregate = aggregate_limited.refresh().await;
+    assert_eq!(aggregate.discovered(), 0);
+    assert!(
+        aggregate
+            .diagnostics()
+            .iter()
+            .any(|diagnostic| diagnostic.message().contains("aggregate"))
+    );
+
+    let resource_limited = SkillRegistry::new(vec![Arc::new(
+        DirectorySkillSource::new(fixture.root(), TEST_REFRESH).with_limits(SkillDiscoveryLimits {
+            max_resources_per_skill: 0,
+            ..SkillDiscoveryLimits::default()
+        }),
+    )]);
+    resource_limited.refresh().await;
+    assert!(
+        resource_limited
+            .get("limited")
+            .expect("skill should be discovered")
+            .resources()
+            .is_empty()
+    );
+
+    let resource_size_limited = SkillRegistry::new(vec![Arc::new(
+        DirectorySkillSource::new(fixture.root(), TEST_REFRESH).with_limits(SkillDiscoveryLimits {
+            max_resource_file_bytes: 4,
+            ..SkillDiscoveryLimits::default()
+        }),
+    )]);
+    let resource_size_report = resource_size_limited.refresh().await;
+    assert_eq!(resource_size_report.discovered(), 0);
+    assert!(
+        resource_size_report
+            .diagnostics()
+            .iter()
+            .any(|diagnostic| diagnostic.message().contains("resource exceeds"))
+    );
+}
+
+#[tokio::test]
+async fn higher_precedence_source_overrides_lower_precedence_skill() {
+    let lower = SkillFixture::new();
+    lower.write_skill("review", "Lower precedence.", "lower");
+    let higher = SkillFixture::new();
+    higher.write_skill("review", "Higher precedence.", "higher");
+    let sources: Vec<Arc<dyn SkillSource>> = vec![
+        Arc::new(DirectorySkillSource::new(lower.root(), TEST_REFRESH).with_precedence(10)),
+        Arc::new(DirectorySkillSource::new(higher.root(), TEST_REFRESH).with_precedence(20)),
+    ];
+    let registry = SkillRegistry::new(sources);
+
+    let report = registry.refresh().await;
+
+    assert_eq!(report.discovered(), 1);
+    assert_eq!(
+        registry
+            .get("review")
+            .expect("review skill should exist")
+            .metadata()
+            .description(),
+        "Higher precedence."
+    );
+}
+
+#[tokio::test]
+async fn malformed_skill_is_diagnosed_without_hiding_valid_skills() {
+    let fixture = SkillFixture::new();
+    fixture.write_skill("valid-skill", "A valid skill.", "valid");
+    let malformed = fixture.root().join("malformed");
+    fs::create_dir_all(&malformed).expect("malformed directory should be created");
+    fs::write(
+        malformed.join("SKILL.md"),
+        "---\nname: Wrong_Name\ndescription: invalid\n---\nbody",
+    )
+    .expect("malformed skill should be written");
+    let registry = SkillRegistry::from_directory(fixture.root(), TEST_REFRESH);
+
+    let report = registry.refresh().await;
+
+    assert_eq!(report.discovered(), 1);
+    assert_eq!(report.diagnostics().len(), 1);
+    assert!(registry.get("valid-skill").is_some());
+
+    let unchanged = registry.refresh().await;
+    assert!(unchanged.diagnostics().is_empty());
+}
+
+#[tokio::test]
+async fn unchanged_refresh_reuses_skill_and_snapshot_allocations() {
+    let fixture = SkillFixture::new();
+    fixture.write_skill("cached-skill", "A cached skill.", "cached instructions");
+    let registry = SkillRegistry::from_directory(fixture.root(), TEST_REFRESH);
+    registry.refresh().await;
+    let initial_snapshot = registry.snapshot();
+    let initial_skill = registry
+        .get("cached-skill")
+        .expect("cached skill should exist");
+
+    let report = registry.refresh().await;
+    let refreshed_snapshot = registry.snapshot();
+    let refreshed_skill = registry
+        .get("cached-skill")
+        .expect("cached skill should still exist");
+
+    assert!(!report.changed());
+    assert!(Arc::ptr_eq(&initial_snapshot, &refreshed_snapshot));
+    assert!(Arc::ptr_eq(&initial_skill, &refreshed_skill));
+
+    let forced = registry.refresh_now().await;
+    let verified_skill = registry
+        .get("cached-skill")
+        .expect("verified skill should still exist");
+
+    assert!(!forced.changed());
+    assert!(Arc::ptr_eq(&initial_skill, &verified_skill));
+}
+
+#[tokio::test]
+async fn concurrent_refresh_requests_share_one_discovery_pass() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let registry = Arc::new(SkillRegistry::new(vec![Arc::new(CountingSkillSource {
+        id: SkillSourceId::new("counting"),
+        calls: Arc::clone(&calls),
+    })]));
+    let first = Arc::clone(&registry);
+    let second = Arc::clone(&registry);
+
+    let (first_report, second_report) = tokio::join!(first.refresh(), second.refresh());
+
+    assert_eq!(calls.load(Ordering::SeqCst), 1);
+    assert_eq!(first_report.generation(), second_report.generation());
+}
+
+#[tokio::test]
+async fn forced_refresh_waits_for_and_follows_an_in_flight_discovery() {
+    let calls = Arc::new(AtomicUsize::new(0));
+    let registry = Arc::new(SkillRegistry::new(vec![Arc::new(CountingSkillSource {
+        id: SkillSourceId::new("counting"),
+        calls: Arc::clone(&calls),
+    })]));
+    let first_registry = Arc::clone(&registry);
+    let first = tokio::spawn(async move { first_registry.refresh().await });
+    while calls.load(Ordering::SeqCst) == 0 {
+        tokio::task::yield_now().await;
+    }
+
+    registry.refresh_now().await;
+    first.await.expect("initial refresh should complete");
+
+    assert_eq!(calls.load(Ordering::SeqCst), 2);
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn symbolic_link_skill_document_is_rejected() {
+    use std::os::unix::fs::symlink;
+
+    let fixture = SkillFixture::new();
+    let outside = fixture._temporary.path().join("outside-skill-document.md");
+    fs::write(
+        &outside,
+        "---\nname: linked-skill\ndescription: Escapes the root.\n---\nbody",
+    )
+    .expect("outside document should be written");
+    let skill_directory = fixture.root().join("linked-skill");
+    fs::create_dir_all(&skill_directory).expect("skill directory should be created");
+    symlink(&outside, skill_directory.join("SKILL.md")).expect("symlink should be created");
+    let registry = SkillRegistry::from_directory(fixture.root(), TEST_REFRESH);
+
+    let report = registry.refresh().await;
+
+    assert_eq!(report.discovered(), 0);
+    assert_eq!(report.diagnostics().len(), 1);
+    assert!(report.diagnostics()[0].message().contains("symbolic link"));
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn symbolic_link_skill_resource_is_not_readable() {
+    use std::os::unix::fs::symlink;
+
+    let fixture = SkillFixture::new();
+    fixture.write_skill("research", "Research a topic.", "Read the reference.");
+    let outside = fixture._temporary.path().join("outside-resource.md");
+    fs::write(&outside, "outside secret").expect("outside resource should be written");
+    let registry = Arc::new(SkillRegistry::from_directory(fixture.root(), TEST_REFRESH));
+    let runtime = fixture.runtime(registry);
+    runtime.compose_system_prompt("base").await;
+    let tools = runtime.tools();
+    let activate = tools
+        .iter()
+        .find(|tool| tool.name() == SkillRuntime::ACTIVATE_TOOL_NAME)
+        .expect("activation tool should exist");
+    let read = tools
+        .iter()
+        .find(|tool| tool.name() == SkillRuntime::READ_RESOURCE_TOOL_NAME)
+        .expect("resource tool should exist");
+    activate
+        .execute(json!({"name": "research"}))
+        .await
+        .expect("skill should activate");
+
+    let resource = fixture.root().join("research/references/details.md");
+    fs::remove_file(&resource).expect("original resource should be removed");
+    symlink(&outside, &resource).expect("resource symlink should be created");
+    let result = read
+        .execute(json!({"skill": "research", "path": "references/details.md"}))
+        .await;
+
+    assert!(result.is_err());
+}
+
+#[cfg(unix)]
+#[tokio::test]
+async fn contained_directory_source_rejects_a_symlinked_root_escape() {
+    use std::os::unix::fs::symlink;
+
+    let workspace = tempfile::tempdir().expect("workspace");
+    let outside = SkillFixture::new();
+    outside.write_skill("external", "External instructions.", "Do not load this.");
+    fs::create_dir_all(workspace.path().join(".agents")).expect("agent directory");
+    let source_root = workspace.path().join(".agents/skills");
+    symlink(outside.root(), &source_root).expect("skill root symlink");
+
+    let source = DirectorySkillSource::new(&source_root, TEST_REFRESH)
+        .with_containment_root(workspace.path().to_path_buf());
+    let error = source
+        .discover()
+        .await
+        .expect_err("containment must reject a source root that resolves outside the workspace");
+
+    assert!(error.to_string().contains("escapes containment root"));
+
+    #[cfg(feature = "skill-watch")]
+    {
+        let watched_source = DirectorySkillSource::new(
+            &source_root,
+            SkillRefreshStrategy::Watch {
+                debounce: std::time::Duration::from_millis(150),
+                fallback_interval: std::time::Duration::from_secs(30),
+            },
+        )
+        .with_containment_root(workspace.path().to_path_buf());
+        let watched_error = watched_source
+            .discover()
+            .await
+            .expect_err("watch setup must reject an escaped source before observing it");
+
+        assert!(
+            watched_error
+                .to_string()
+                .contains("escapes containment root")
+        );
+    }
+}
+
+#[test]
+fn skill_revision_changes_with_document_or_resource_manifest() {
+    let directory = PathBuf::from("revisioned");
+    let first = super::Skill::from_document(
+        directory.join("SKILL.md"),
+        directory.clone(),
+        "---\nname: revisioned\ndescription: Revision test.\n---\n\nFirst instructions.",
+        vec![PathBuf::from("reference.md")],
+    )
+    .expect("first skill");
+    let same = super::Skill::from_document(
+        directory.join("SKILL.md"),
+        directory.clone(),
+        "---\nname: revisioned\ndescription: Revision test.\n---\n\nFirst instructions.",
+        vec![PathBuf::from("reference.md")],
+    )
+    .expect("same skill");
+    let changed_document = super::Skill::from_document(
+        directory.join("SKILL.md"),
+        directory.clone(),
+        "---\nname: revisioned\ndescription: Revision test.\n---\n\nChanged instructions.",
+        vec![PathBuf::from("reference.md")],
+    )
+    .expect("changed document");
+    let changed_resources = super::Skill::from_document(
+        directory.join("SKILL.md"),
+        directory,
+        "---\nname: revisioned\ndescription: Revision test.\n---\n\nFirst instructions.",
+        vec![PathBuf::from("other.md")],
+    )
+    .expect("changed resources");
+
+    assert_eq!(first.revision(), same.revision());
+    assert_ne!(first.revision(), changed_document.revision());
+    assert_ne!(first.revision(), changed_resources.revision());
+}
+
+#[test]
+fn skill_model_exposes_metadata_paths_and_revision() {
+    let directory = PathBuf::from("documented-skill");
+    let skill = super::Skill::from_document(
+        directory.join("SKILL.md"),
+        directory.clone(),
+        "---\nname: documented-skill\ndescription: A documented skill.\nlicense: Apache-2.0\ncompatibility: Native and wasm.\nmetadata:\n  author: autoagents\n---\n\nFollow the documented process.\n",
+        vec![
+            PathBuf::from("references/zeta.md"),
+            PathBuf::from("references/alpha.md"),
+            PathBuf::from("references/alpha.md"),
+        ],
+    )
+    .expect("valid skill document");
+
+    assert_eq!(skill.metadata().license(), Some("Apache-2.0"));
+    assert_eq!(skill.metadata().compatibility(), Some("Native and wasm."));
+    assert_eq!(
+        skill
+            .metadata()
+            .metadata()
+            .get("author")
+            .map(String::as_str),
+        Some("autoagents")
+    );
+    assert_eq!(skill.skill_file(), directory.join("SKILL.md"));
+    assert_eq!(
+        skill.resources(),
+        &[
+            PathBuf::from("references/alpha.md"),
+            PathBuf::from("references/zeta.md"),
+        ]
+    );
+    let revision = skill.revision().to_string();
+    assert_eq!(revision.len(), 64);
+    assert!(revision.bytes().all(|byte| byte.is_ascii_hexdigit()));
+}
+
+#[test]
+fn skill_document_validation_rejects_invalid_metadata_and_body() {
+    fn parse(name: &str, document: &str) -> Result<super::Skill, SkillError> {
+        let directory = PathBuf::from(name);
+        super::Skill::from_document(directory.join("SKILL.md"), directory, document, Vec::new())
+    }
+
+    let cases = [
+        (
+            "empty-name",
+            "---\nname: ''\ndescription: Description.\n---\nbody",
+            "name must contain",
+        ),
+        (
+            "leading-hyphen",
+            "---\nname: -leading-hyphen\ndescription: Description.\n---\nbody",
+            "name must use lowercase",
+        ),
+        (
+            "directory-name",
+            "---\nname: another-name\ndescription: Description.\n---\nbody",
+            "must match parent directory",
+        ),
+        (
+            "empty-description",
+            "---\nname: empty-description\ndescription: '   '\n---\nbody",
+            "description must contain",
+        ),
+        (
+            "empty-compatibility",
+            "---\nname: empty-compatibility\ndescription: Description.\ncompatibility: '   '\n---\nbody",
+            "compatibility must contain",
+        ),
+        (
+            "invalid-yaml",
+            "---\nname: [invalid\ndescription: Description.\n---\nbody",
+            "invalid YAML frontmatter",
+        ),
+        (
+            "empty-instructions",
+            "---\nname: empty-instructions\ndescription: Description.\n---\n   ",
+            "instructions must not be empty",
+        ),
+        (
+            "missing-closing-delimiter",
+            "---\nname: missing-closing-delimiter\ndescription: Description.\nbody",
+            "missing its closing delimiter",
+        ),
+    ];
+
+    for (directory, document, expected) in cases {
+        let error = parse(directory, document).expect_err("document should be rejected");
+        assert!(
+            error.to_string().contains(expected),
+            "expected {expected:?} in {error}"
+        );
+    }
+
+    let valid_document = "---\nname: invalid-resource\ndescription: Description.\n---\nbody";
+    let invalid_resource = super::Skill::from_document(
+        "invalid-resource/SKILL.md",
+        "invalid-resource",
+        valid_document,
+        vec![PathBuf::from("../outside.md")],
+    )
+    .expect_err("parent resource path should be rejected");
+    assert!(invalid_resource.to_string().contains("resource path"));
+}
+
+#[cfg(unix)]
+#[test]
+fn skill_document_rejects_a_non_utf8_parent_directory() {
+    use std::ffi::OsString;
+    use std::os::unix::ffi::OsStringExt;
+
+    let directory = PathBuf::from(OsString::from_vec(vec![0xff]));
+    let error = super::Skill::from_document(
+        directory.join("SKILL.md"),
+        directory,
+        "---\nname: valid-name\ndescription: Description.\n---\nbody",
+        Vec::new(),
+    )
+    .expect_err("non-UTF-8 parent should be rejected");
+
+    assert!(
+        error
+            .to_string()
+            .contains("parent directory is not valid UTF-8")
+    );
+}
+
+#[tokio::test]
+async fn skill_policy_requests_and_configuration_expose_their_context() {
+    let directory = PathBuf::from("request-skill");
+    let skill = Arc::new(
+        super::Skill::from_document(
+            directory.join("SKILL.md"),
+            directory,
+            "---\nname: request-skill\ndescription: Request context.\n---\nbody",
+            vec![PathBuf::from("reference.md")],
+        )
+        .expect("request skill"),
+    );
+    let actor_id = Uuid::new_v4();
+    let submission_id = Uuid::new_v4();
+    let session_id = Uuid::new_v4();
+    let activation =
+        SkillActivationRequest::new(actor_id, submission_id, session_id, Arc::clone(&skill));
+    assert_eq!(activation.actor_id(), actor_id);
+    assert_eq!(activation.submission_id(), submission_id);
+    assert_eq!(activation.session_id(), session_id);
+    assert_eq!(activation.skill().metadata().name(), "request-skill");
+
+    let resource = SkillResourceRequest::new(
+        actor_id,
+        submission_id,
+        session_id,
+        Arc::clone(&skill),
+        PathBuf::from("reference.md"),
+    );
+    assert_eq!(resource.actor_id(), actor_id);
+    assert_eq!(resource.submission_id(), submission_id);
+    assert_eq!(resource.session_id(), session_id);
+    assert_eq!(resource.skill().revision(), skill.revision());
+    assert_eq!(resource.path(), Path::new("reference.md"));
+
+    let registry = Arc::new(SkillRegistry::new(Vec::new()));
+    let session = Arc::new(SkillSession::new());
+    let policy: Arc<dyn SkillPolicy> = Arc::new(TrustedSkillPolicy);
+    let configuration = SkillConfiguration::new(
+        Arc::clone(&registry),
+        Arc::clone(&session),
+        Arc::clone(&policy),
+    );
+    assert!(Arc::ptr_eq(&configuration.registry(), &registry));
+    assert!(Arc::ptr_eq(&configuration.session(), &session));
+    assert!(Arc::ptr_eq(&configuration.policy(), &policy));
+    let debug = format!("{configuration:?}");
+    assert!(debug.contains("SkillConfiguration"));
+    assert!(debug.contains("max_resource_bytes"));
+
+    policy
+        .authorize_activation(&activation)
+        .await
+        .expect("trusted activation");
+    policy
+        .authorize_resource_read(&resource)
+        .await
+        .expect("trusted resource read");
+}
+
+#[tokio::test]
+async fn directory_source_handles_missing_roots_containment_and_entry_limits() {
+    let fixture = SkillFixture::new();
+    fixture.write_skill("first", "First skill.", "First instructions.");
+    fixture.write_skill("second", "Second skill.", "Second instructions.");
+    fs::create_dir_all(fixture.root().join("without-document")).expect("empty skill directory");
+
+    let limited =
+        DirectorySkillSource::new(fixture.root(), TEST_REFRESH).with_limits(SkillDiscoveryLimits {
+            max_skills: 2,
+            ..SkillDiscoveryLimits::default()
+        });
+    let limited_snapshot = limited.discover().await.expect("limited discovery");
+    assert_eq!(limited_snapshot.skills.len(), 2);
+    assert!(
+        limited_snapshot
+            .diagnostics
+            .iter()
+            .any(|message| message.contains("only the first 2 are scanned"))
+    );
+
+    let contained = DirectorySkillSource::new(fixture.root(), TEST_REFRESH)
+        .with_containment_root(fixture._temporary.path());
+    assert_eq!(
+        contained
+            .discover()
+            .await
+            .expect("contained discovery")
+            .skills
+            .len(),
+        2
+    );
+
+    let missing_containment = fixture._temporary.path().join("missing-containment");
+    let containment_error = DirectorySkillSource::new(fixture.root(), TEST_REFRESH)
+        .with_containment_root(missing_containment)
+        .discover()
+        .await
+        .expect_err("missing containment root should fail");
+    assert!(
+        containment_error
+            .to_string()
+            .contains("cannot resolve containment root")
+    );
+
+    let disappearing_root = fixture._temporary.path().join("disappearing-skills");
+    fs::create_dir_all(&disappearing_root).expect("disappearing root");
+    let source = DirectorySkillSource::new(&disappearing_root, SkillRefreshStrategy::Manual);
+    assert!(
+        source
+            .discover()
+            .await
+            .expect("initial discovery")
+            .skills
+            .is_empty()
+    );
+    fs::remove_dir_all(&disappearing_root).expect("remove disappearing root");
+    source.invalidate();
+    assert!(
+        source
+            .discover()
+            .await
+            .expect("missing root is empty")
+            .skills
+            .is_empty()
+    );
+}
+
+#[tokio::test]
+async fn directory_source_enforces_the_aggregate_resource_budget() {
+    let fixture = SkillFixture::new();
+    fixture.write_skill("resources", "Resource limits.", "Read both resources.");
+    fs::write(
+        fixture.root().join("resources/references/second.md"),
+        "second resource",
+    )
+    .expect("second resource");
+    let source =
+        DirectorySkillSource::new(fixture.root(), TEST_REFRESH).with_limits(SkillDiscoveryLimits {
+            max_total_resource_bytes: 1,
+            ..SkillDiscoveryLimits::default()
+        });
+
+    let snapshot = source.discover().await.expect("bounded discovery");
+
+    assert!(snapshot.skills.is_empty());
+    assert!(
+        snapshot
+            .diagnostics
+            .iter()
+            .any(|message| message.contains("aggregate limit"))
+    );
+}
+
+#[test]
+fn skill_tool_selector_exposes_expression_and_rejects_invalid_forms() {
+    let selector = super::SkillToolSelector::parse("Bash(git:*)").expect("valid selector");
+    assert_eq!(selector.expression(), "Bash(git:*)");
+
+    for invalid in ["", "two tools", "Bash(", "bad$name"] {
+        let error = super::SkillToolSelector::parse(invalid)
+            .expect_err("invalid selector should be rejected");
+        assert!(matches!(error, SkillError::InvalidToolSelector(_)));
+    }
+}
+
+#[test]
+fn skill_runtime_exposes_debug_configuration_and_serialized_tools() {
+    let fixture = SkillFixture::new();
+    let registry = Arc::new(SkillRegistry::from_directory(fixture.root(), TEST_REFRESH));
+    let runtime = fixture.runtime(registry);
+    let (events, _receiver) = tokio::sync::mpsc::channel(1);
+    let identity = SkillRuntimeIdentity::new(Uuid::new_v4(), Some(Uuid::new_v4()), Some(events));
+
+    let debug = format!("{identity:?}");
+    assert!(debug.contains("SkillRuntimeIdentity"));
+    assert!(debug.contains("configured"));
+    assert_eq!(runtime.serialized_tools().len(), 3);
+    assert_eq!(runtime.configuration().max_resource_bytes(), 1024 * 1024);
+}

--- a/crates/autoagents-core/src/agent/skill/tool_selector.rs
+++ b/crates/autoagents-core/src/agent/skill/tool_selector.rs
@@ -1,0 +1,58 @@
+use crate::agent::skill::SkillError;
+use std::sync::Arc;
+
+#[derive(Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+pub struct SkillToolSelector {
+    expression: Arc<str>,
+    tool_name: Arc<str>,
+    qualifier: Option<Arc<str>>,
+}
+
+impl SkillToolSelector {
+    pub fn parse(expression: &str) -> Result<Self, SkillError> {
+        let expression = expression.trim();
+        if expression.is_empty() || expression.chars().any(char::is_whitespace) {
+            return Err(SkillError::InvalidToolSelector(expression.to_string()));
+        }
+
+        let (tool_name, qualifier) = match expression.split_once('(') {
+            Some((tool_name, qualifier))
+                if !tool_name.is_empty()
+                    && qualifier.ends_with(')')
+                    && qualifier.len() > 1
+                    && !qualifier[..qualifier.len() - 1].contains(['(', ')']) =>
+            {
+                (
+                    tool_name,
+                    Some(Arc::from(&qualifier[..qualifier.len() - 1])),
+                )
+            }
+            Some(_) => return Err(SkillError::InvalidToolSelector(expression.to_string())),
+            None => (expression, None),
+        };
+
+        if !tool_name.chars().all(|character| {
+            character.is_ascii_alphanumeric() || matches!(character, '_' | '-' | '.' | ':' | '/')
+        }) {
+            return Err(SkillError::InvalidToolSelector(expression.to_string()));
+        }
+
+        Ok(Self {
+            expression: Arc::from(expression),
+            tool_name: Arc::from(tool_name),
+            qualifier,
+        })
+    }
+
+    pub fn expression(&self) -> &str {
+        &self.expression
+    }
+
+    pub fn tool_name(&self) -> &str {
+        &self.tool_name
+    }
+
+    pub fn qualifier(&self) -> Option<&str> {
+        self.qualifier.as_deref()
+    }
+}

--- a/crates/autoagents-protocol/src/lib.rs
+++ b/crates/autoagents-protocol/src/lib.rs
@@ -8,7 +8,8 @@ pub use llm::{
     Usage,
 };
 pub use protocol::{
-    ActorID, Event, EventId, InternalEvent, RuntimeID, StreamingTurnResult, SubmissionId,
+    ActorID, Event, EventId, InternalEvent, RuntimeID, SkillDeactivationReason, SkillEvent,
+    SkillEventKind, SkillOperation, SkillSessionId, StreamingTurnResult, SubmissionId,
 };
 pub use task::Task;
 pub use tool::ToolCallResult;

--- a/crates/autoagents-protocol/src/protocol.rs
+++ b/crates/autoagents-protocol/src/protocol.rs
@@ -16,6 +16,9 @@ pub type ActorID = Uuid;
 /// Session IDs are used to identify sessions
 pub type RuntimeID = Uuid;
 
+/// Skill session IDs isolate activated instructions between conversations.
+pub type SkillSessionId = Uuid;
+
 /// Event IDs are used to correlate events with their responses
 pub type EventId = Uuid;
 
@@ -90,6 +93,11 @@ pub enum Event {
         error: String,
     },
 
+    /// Agent Skill catalog or activation lifecycle activity.
+    Skill {
+        event: SkillEvent,
+    },
+
     /// Sandbox code execution has started
     CodeExecutionStarted {
         sub_id: SubmissionId,
@@ -159,6 +167,84 @@ pub enum Event {
     },
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum SkillEventKind {
+    CatalogChanged {
+        generation: u64,
+        added: Vec<String>,
+        updated: Vec<String>,
+        removed: Vec<String>,
+    },
+    ActivationRequested {
+        skill_name: String,
+    },
+    Activated {
+        skill_name: String,
+        newly_activated: bool,
+    },
+    Deactivated {
+        skill_name: String,
+        reason: SkillDeactivationReason,
+    },
+    ResourceAccessRequested {
+        skill_name: String,
+        path: String,
+    },
+    ResourceAccessed {
+        skill_name: String,
+        path: String,
+        bytes: usize,
+    },
+    OperationFailed {
+        operation: SkillOperation,
+        skill_name: Option<String>,
+        message: String,
+    },
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum SkillOperation {
+    RefreshCatalog,
+    Activate,
+    Deactivate,
+    ReadResource,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum SkillDeactivationReason {
+    Requested,
+    Updated,
+    Removed,
+    SessionReset,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SkillEvent {
+    pub actor_id: ActorID,
+    pub submission_id: Option<SubmissionId>,
+    pub session_id: SkillSessionId,
+    pub event: SkillEventKind,
+}
+
+impl SkillEvent {
+    pub fn new(
+        actor_id: ActorID,
+        submission_id: Option<SubmissionId>,
+        session_id: SkillSessionId,
+        event: SkillEventKind,
+    ) -> Self {
+        Self {
+            actor_id,
+            submission_id,
+            session_id,
+            event,
+        }
+    }
+}
+
 /// Internal events that are processed within the runtime
 #[derive(Debug)]
 pub enum InternalEvent {
@@ -218,6 +304,44 @@ mod tests {
                 assert_eq!(task_description, "Started task");
             }
             _ => panic!("Expected TaskStarted variant"),
+        }
+    }
+
+    #[test]
+    fn skill_event_round_trips_with_typed_lifecycle_payload() {
+        let actor_id = Uuid::new_v4();
+        let submission_id = Uuid::new_v4();
+        let session_id = Uuid::new_v4();
+        let event = Event::Skill {
+            event: SkillEvent::new(
+                actor_id,
+                Some(submission_id),
+                session_id,
+                SkillEventKind::Activated {
+                    skill_name: "release-notes".to_string(),
+                    newly_activated: true,
+                },
+            ),
+        };
+
+        let serialized = serde_json::to_string(&event).expect("skill event should serialize");
+        let deserialized: Event =
+            serde_json::from_str(&serialized).expect("skill event should deserialize");
+
+        match deserialized {
+            Event::Skill { event } => {
+                assert_eq!(event.actor_id, actor_id);
+                assert_eq!(event.submission_id, Some(submission_id));
+                assert_eq!(event.session_id, session_id);
+                assert_eq!(
+                    event.event,
+                    SkillEventKind::Activated {
+                        skill_name: "release-notes".to_string(),
+                        newly_activated: true,
+                    }
+                );
+            }
+            _ => panic!("expected skill event"),
         }
     }
 

--- a/crates/autoagents/Cargo.toml
+++ b/crates/autoagents/Cargo.toml
@@ -11,7 +11,8 @@ readme.workspace = true
 
 [features]
 default = []
-full = ["autoagents-core/full", "autoagents-llm/full", "wasmtime", "logging", "codeact"]
+full = ["autoagents-core/full", "autoagents-llm/full", "wasmtime", "logging", "codeact", "skill-watch"]
+skill-watch = ["autoagents-core/skill-watch"]
 openai = ["autoagents-llm/openai"]
 anthropic = ["autoagents-llm/anthropic"]
 ollama = ["autoagents-llm/ollama"]

--- a/crates/autoagents/src/prelude.rs
+++ b/crates/autoagents/src/prelude.rs
@@ -12,6 +12,12 @@ pub use crate::core::agent::prebuilt::executor::{
 pub use crate::core::agent::prebuilt::executor::{
     CodeActAgent, CodeActAgentOutput, CodeActExecutionRecord, CodeActSandboxLimits,
 };
+pub use crate::core::agent::skill::{
+    DirectorySkillSource, SkillActivationRequest, SkillConfiguration, SkillDeactivationReason,
+    SkillDiscoveryLimits, SkillEvent, SkillEventKind, SkillOperation, SkillPolicy,
+    SkillRefreshStrategy, SkillRegistry, SkillResourceRequest, SkillRevision, SkillSession,
+    SkillSource, SkillToolSelector, TrustedSkillPolicy,
+};
 pub use crate::core::agent::task::Task;
 pub use crate::core::agent::{ActorAgent, AgentBuilder, DirectAgent};
 pub use crate::core::agent::{AgentHooks as _, AgentOutputT, Context};

--- a/docs/content/core-concepts/skills.md
+++ b/docs/content/core-concepts/skills.md
@@ -1,0 +1,130 @@
+---
+title: Agent Skills
+description: Add progressively disclosed SKILL.md instructions and resources to ReAct and CodeAct agents.
+---
+
+# Agent Skills
+
+Agent Skills let an AutoAgents agent discover specialized instructions without placing every instruction in every prompt. The system prompt initially contains only each skill's name and description. When a task matches, the model calls `activate_skill`; the full instructions are injected on the following turn and remain active for the caller-owned conversation session.
+
+## Skill layout
+
+Each direct child of the configured directory is one skill. Its directory name must match the frontmatter `name`.
+
+```text
+skills/
+└── release-notes/
+    ├── SKILL.md
+    └── references/
+        └── style.md
+```
+
+```markdown
+---
+name: release-notes
+description: Write concise product release notes.
+license: Apache-2.0
+compatibility: Requires access to the supplied style reference.
+metadata:
+  owner: product
+allowed-tools: read_skill_resource
+---
+
+Read `references/style.md`, then lead with user impact and use active voice.
+```
+
+`name` and `description` are required. `license`, `compatibility`, string-valued `metadata`, and `allowed-tools` are optional. `allowed-tools` is parsed into typed selectors and supplied to the configured `SkillPolicy`. A skill file never grants itself authority: policy approval and the normal permission check for each eventual tool call still apply.
+
+## Attach a registry
+
+Agent Skills require a multi-turn executor. ReAct and CodeAct support them; configuring skills on an unsupported executor fails while building the agent.
+
+```rust
+use autoagents::prelude::*;
+use std::sync::Arc;
+
+let registry = Arc::new(SkillRegistry::from_directory(
+    "./skills",
+    SkillRefreshStrategy::Manual,
+));
+let session = Arc::new(SkillSession::new());
+let skills = SkillConfiguration::new(
+    registry,
+    session,
+    Arc::new(TrustedSkillPolicy),
+);
+
+let handle = AgentBuilder::<_, DirectAgent>::new(ReActAgent::new(MyAgent))
+    .llm(llm)
+    .skills(skills)
+    .build()
+    .await?;
+```
+
+The registry scans at build time. Reload behavior is explicit; constructing or importing AutoAgents does not start a watcher. Changes are applied atomically before a model turn or Agent Skills tool call. Routine polling scans compare the `SKILL.md` and resource manifests with cached file metadata first, so unchanged skill files are not read or parsed again. Explicit refreshes and watcher-reported changes verify file contents, including same-size edits on filesystems with coarse timestamps. Invalid in-progress edits retain the last valid skill until the package becomes valid. Updating `SKILL.md` or any resource changes the skill revision and deactivates an active skill at the next boundary, so changed content must pass policy again; deletion deactivates it as well.
+
+## Reload strategies
+
+`DirectorySkillSource::new` and `SkillRegistry::from_directory` require a `SkillRefreshStrategy`:
+
+- `Manual` performs initial discovery and then reuses its cache until `SkillRegistry::refresh_now` or `BaseAgent::refresh_skills` explicitly invalidates it.
+- `Poll { interval }` performs another scan at a safe registry boundary after the interval has elapsed. It does not create a filesystem watcher.
+- `Watch { debounce, fallback_interval }` uses recursive filesystem notifications, applies settled changes at safe boundaries, and retains polling as a recovery path.
+
+Watcher support is optional. Enable the `skill-watch` feature when declaring AutoAgents:
+
+```toml
+autoagents = { version = "0.4", features = ["skill-watch"] }
+```
+
+```rust
+use std::time::Duration;
+
+let registry = Arc::new(SkillRegistry::from_directory(
+    "./skills",
+    SkillRefreshStrategy::Watch {
+        debounce: Duration::from_millis(150),
+        fallback_interval: Duration::from_secs(30),
+    },
+));
+```
+
+Selecting `Watch` without compiling `skill-watch` returns `SkillError::WatchUnavailable`. Without that feature, manual and polling modes do not pull in `notify`; neither mode initializes a watcher even when watcher support is compiled.
+
+`SkillSession` is caller-owned. Reusing it across `agent.run()` calls keeps activated instructions in a conversation; call `BaseAgent::reset_skill_session` when starting or restoring another conversation. `BaseAgent::refresh_skills` forces an immediate source refresh, and `BaseAgent::skill_snapshot` exposes the current immutable catalog. The model can also call `deactivate_skill` when instructions no longer apply.
+
+An active skill is not loaded from disk on every model turn. Its parsed instructions are retained in the immutable registry snapshot and selected by the session's name/revision entry. AutoAgents still includes those instructions in the system message sent on each chat-completions request: OpenAI-compatible chat APIs are request-stateless, so omitting them after the activation turn would make later turns lose the skill. Providers may reuse that stable prefix through their own prompt/KV cache.
+
+`SkillPolicy` gates activation and resource access. `TrustedSkillPolicy` explicitly approves both operations and is intended only for sources the host already trusts; implement `SkillPolicy` when activation or resource reads need an approval boundary. `AgentHooks` exposes skill catalog, activation, deactivation, resource, and error callbacks, while protocol `Event::Skill` provides the corresponding observable lifecycle stream.
+
+Use `DirectorySkillSource::with_precedence` and `SkillRegistry::new` to combine directories. A higher precedence source wins when names collide. Implement `SkillSource` for another source type and construct validated entries with `Skill::from_document` and `SkillSourceSnapshot::new`.
+
+## WASM compatibility
+
+The skill control plane is portable, but the built-in filesystem backend is currently native-only.
+
+| Capability | Native targets | `wasm32` targets |
+| --- | --- | --- |
+| Skill metadata, parsing, and revisions | Supported | Supported |
+| Custom or in-memory `SkillSource` implementations | Supported | Supported |
+| Registry refresh, precedence, and immutable snapshots | Supported | Supported |
+| Activation policy and conversation-scoped `SkillSession` | Supported | Supported |
+| Prompt composition, lifecycle hooks, and protocol events | Supported | Supported |
+| `DirectorySkillSource` discovery | Supported | Unavailable; discovery returns `SkillError::SourceUnavailable` |
+| Recursive filesystem watching | Supported | Unavailable |
+| Filesystem-backed `read_skill_resource` | Supported | Unavailable; the tool returns `SkillError::SourceUnavailable` |
+| Capability-scoped and no-follow filesystem reads | Supported | Not compiled |
+
+On `wasm32`, provide a custom `SkillSource` to populate the catalog from application-owned or remote data. Catalog discovery and instruction activation will work, but the current `read_skill_resource` implementation cannot read those resources because resource loading does not yet have a non-filesystem backend.
+
+The current target gate applies to every `wasm32` target, including WASI. The `skill-watch` feature does not change that boundary. Supporting WASI filesystem skills requires a separate WASI resource and watcher implementation rather than enabling the native ambient-filesystem code unchanged.
+
+## Resources and trust
+
+The model can read only a resource that was discovered under an activated skill, using `read_skill_resource`. Paths must be normalized and relative. Directory discovery rejects linked `SKILL.md` files, skips linked resources, bounds document and resource counts and bytes, and captures a capability-scoped directory handle that cannot be redirected by later path replacement. Reads are no-follow, bounded, and checked against the resource digest recorded in the approved skill revision before bytes reach the model.
+
+Default discovery limits are 256 skills, 256 KiB per `SKILL.md` with a 4 MiB aggregate document budget, 512 resources per skill, 1 MiB per resource with a 16 MiB aggregate resource budget, and six resource-directory levels. Override them with `SkillDiscoveryLimits` when the host has a different trusted workload.
+
+Skill instructions are executable prompt content. Configure only trusted skill sources; AutoAgents does not implicitly scan user or system directories. Resource access does not grant arbitrary filesystem access, and Agent Skills reserve the tool names `activate_skill`, `deactivate_skill`, and `read_skill_resource`.
+
+See the runnable [`skills-agent` example](https://github.com/liquidos-ai/AutoAgents/tree/main/examples/skills_agent) for a complete setup.

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -20,6 +20,7 @@ const sidebars: SidebarsConfig = {
         'core-concepts/architecture',
         'core-concepts/agents',
         'core-concepts/tools',
+        'core-concepts/skills',
         'core-concepts/memory',
         'core-concepts/executors',
         'core-concepts/executors_guide',

--- a/examples/skills_agent/Cargo.toml
+++ b/examples/skills_agent/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "skills-agent"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description.workspace = true
+repository.workspace = true
+keywords.workspace = true
+categories.workspace = true
+publish = false
+
+[dependencies]
+autoagents = { workspace = true, features = ["openai", "logging", "skill-watch"] }
+autoagents-derive.workspace = true
+tokio.workspace = true
+tokio-stream.workspace = true
+env_logger.workspace = true
+serde_json.workspace = true

--- a/examples/skills_agent/README.md
+++ b/examples/skills_agent/README.md
@@ -1,0 +1,25 @@
+# Agent Skills example
+
+This example explicitly enables AutoAgents' optional `skill-watch` feature and selects `SkillRefreshStrategy::Watch`. It discovers `SKILL.md` directories when the agent is built and keeps a watched catalog for the lifetime of an interactive conversation. Add, edit, or remove a skill below the configured directory while the process is running; the next prompt or `/skills` command uses the new registry snapshot without restarting.
+
+The example currently defaults to a local OpenAI-compatible llama server at
+`http://127.0.0.1:8880/v1` using the model loaded on that server:
+
+```bash
+cargo run -p skills-agent
+```
+
+Enter prompts at `skills>`. Use `/skills` to inspect the live catalog,
+`/reset-skills` to clear conversation activations, and `/exit` to stop. Pass a
+prompt after `--` for one-shot operation.
+
+Override `LLAMA_SERVER_URL`, `LLAMA_SERVER_MODEL`, or `LLAMA_SERVER_API_KEY`
+when the endpoint, served model name, or authentication differs. The API key
+falls back to `OPENAI_API_KEY` and then to the harmless local value `local`.
+
+The console prints boot discovery, each agent turn, `activate_skill` and
+`read_skill_resource` arguments/results, and the final model response.
+
+Set `AUTOAGENTS_SKILLS_DIR` to use a different directory. The caller-owned skill session persists across direct `run` calls and is reset explicitly at the conversation boundary.
+
+Only point the registry at trusted content: activated skill Markdown becomes part of the agent's system prompt. Skill resource reads remain scoped to discovered relative files under the activated skill.

--- a/examples/skills_agent/skills/release-notes/SKILL.md
+++ b/examples/skills_agent/skills/release-notes/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: release-notes
+description: Write concise product and engineering release notes. Use when announcing a feature, fix, launch, changelog entry, or version update.
+license: Apache-2.0
+metadata:
+  author: autoagents
+  version: "1.0"
+---
+
+# Release notes
+
+Before writing, read `references/style.md` with `read_skill_resource`.
+
+Then produce:
+
+1. A title of at most eight words.
+2. One sentence describing the user-visible outcome.
+3. Up to three bullets covering the most important behavior.
+
+Do not include implementation details unless the user asks for them.

--- a/examples/skills_agent/skills/release-notes/references/style.md
+++ b/examples/skills_agent/skills/release-notes/references/style.md
@@ -1,0 +1,6 @@
+# AutoAgents release-note style
+
+- Lead with what users can now do.
+- Prefer active voice and concrete verbs.
+- Keep each bullet under twenty words.
+- Avoid hype, filler, and claims that cannot be verified.

--- a/examples/skills_agent/src/main.rs
+++ b/examples/skills_agent/src/main.rs
@@ -1,0 +1,265 @@
+use autoagents::core::agent::memory::SlidingWindowMemory;
+use autoagents::core::agent::prebuilt::executor::ReActAgent;
+use autoagents::core::agent::skill::{
+    SkillConfiguration, SkillRefreshStrategy, SkillRegistry, SkillSession, TrustedSkillPolicy,
+};
+use autoagents::core::agent::task::Task;
+use autoagents::core::agent::{AgentBuilder, AgentDeriveT, DirectAgent, DirectAgentHandle};
+use autoagents::core::error::Error;
+use autoagents::core::tool::ToolT;
+use autoagents::core::utils::BoxEventStream;
+use autoagents::llm::backends::openai::{OpenAI, OpenAIApiMode};
+use autoagents::llm::builder::LLMBuilder;
+use autoagents::protocol::{Event, SkillEventKind};
+use autoagents_derive::AgentHooks;
+use serde_json::Value;
+use std::env;
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Duration;
+use tokio_stream::StreamExt;
+
+#[derive(Clone, Debug, AgentHooks)]
+struct SkillsAgent;
+
+impl AgentDeriveT for SkillsAgent {
+    type Output = String;
+
+    fn name(&self) -> &str {
+        "skills_agent"
+    }
+
+    fn description(&self) -> &str {
+        "Answer the user's request accurately. Use an available Agent Skill whenever its description matches the request."
+    }
+
+    fn output_schema(&self) -> Option<serde_json::Value> {
+        None
+    }
+
+    fn tools(&self) -> Vec<Box<dyn ToolT>> {
+        Vec::new()
+    }
+}
+
+struct SkillsExample;
+
+struct SkillsConsole;
+
+impl SkillsConsole {
+    fn print_configuration(base_url: &str, model: &str, skills_directory: &Path) {
+        println!("[server] {base_url}");
+        println!("[model]  {model}");
+        println!("[skills] {}", skills_directory.display());
+    }
+
+    fn print_discovered_skills(registry: &SkillRegistry) {
+        let snapshot = registry.snapshot();
+        println!("[skills] discovered {} skill(s) at boot", snapshot.len());
+        for skill in snapshot.skills() {
+            println!(
+                "         - {}: {}",
+                skill.metadata().name(),
+                skill.metadata().description()
+            );
+        }
+    }
+
+    fn print_json(value: &Value) {
+        match serde_json::to_string_pretty(value) {
+            Ok(formatted) => println!("{formatted}"),
+            Err(_) => println!("{value}"),
+        }
+    }
+
+    async fn report_events(mut events: BoxEventStream<Event>) {
+        while let Some(event) = events.next().await {
+            match event {
+                Event::TaskStarted {
+                    task_description, ..
+                } => println!("\n[agent] task started: {task_description}"),
+                Event::TurnStarted {
+                    turn_number,
+                    max_turns,
+                    ..
+                } => println!("[agent] turn {turn_number}/{max_turns}"),
+                Event::ToolCallRequested {
+                    tool_name,
+                    arguments,
+                    ..
+                } => {
+                    println!("[tool →] {tool_name}");
+                    match serde_json::from_str::<Value>(&arguments) {
+                        Ok(arguments) => Self::print_json(&arguments),
+                        Err(_) => println!("{arguments}"),
+                    }
+                }
+                Event::ToolCallCompleted {
+                    tool_name, result, ..
+                } => {
+                    println!("[tool ✓] {tool_name}");
+                    Self::print_json(&result);
+                }
+                Event::ToolCallFailed {
+                    tool_name, error, ..
+                } => println!("[tool ✗] {tool_name}: {error}"),
+                Event::Skill { event } => match event.event {
+                    SkillEventKind::CatalogChanged {
+                        generation,
+                        added,
+                        updated,
+                        removed,
+                    } => println!(
+                        "[skills] generation {generation}: +{:?} ~{:?} -{:?}",
+                        added, updated, removed
+                    ),
+                    SkillEventKind::ActivationRequested { skill_name } => {
+                        println!("[skill →] activate {skill_name}")
+                    }
+                    SkillEventKind::Activated {
+                        skill_name,
+                        newly_activated,
+                    } => println!("[skill ✓] active {skill_name} (new: {newly_activated})"),
+                    SkillEventKind::Deactivated { skill_name, reason } => {
+                        println!("[skill] deactivated {skill_name} ({reason:?})")
+                    }
+                    SkillEventKind::ResourceAccessRequested { skill_name, path } => {
+                        println!("[skill →] read {skill_name}/{path}")
+                    }
+                    SkillEventKind::ResourceAccessed {
+                        skill_name,
+                        path,
+                        bytes,
+                    } => println!("[skill ✓] read {skill_name}/{path} ({bytes} bytes)"),
+                    SkillEventKind::OperationFailed { message, .. } => {
+                        println!("[skill ✗] {message}")
+                    }
+                },
+                Event::TurnCompleted {
+                    turn_number,
+                    final_turn,
+                    ..
+                } => println!("[agent] turn {turn_number} complete (final: {final_turn})"),
+                Event::TaskComplete { .. } => {
+                    println!("[agent] task complete");
+                    return;
+                }
+                Event::TaskError { error, .. } => {
+                    println!("[agent] task failed: {error}");
+                    return;
+                }
+                _ => {}
+            }
+        }
+    }
+
+    fn read_prompt() -> Result<Option<String>, Error> {
+        print!("\nskills> ");
+        io::stdout()
+            .flush()
+            .map_err(|error| Error::CustomError(format!("cannot flush prompt: {error}")))?;
+        let mut prompt = String::new();
+        let read = io::stdin()
+            .read_line(&mut prompt)
+            .map_err(|error| Error::CustomError(format!("cannot read prompt: {error}")))?;
+        if read == 0 {
+            return Ok(None);
+        }
+        Ok(Some(prompt.trim().to_string()))
+    }
+}
+
+impl SkillsExample {
+    async fn run() -> Result<(), Error> {
+        env_logger::init();
+        let api_key = env::var("LLAMA_SERVER_API_KEY")
+            .or_else(|_| env::var("OPENAI_API_KEY"))
+            .unwrap_or_else(|_| "local".to_string());
+        let base_url =
+            env::var("LLAMA_SERVER_URL").unwrap_or_else(|_| "http://127.0.0.1:8880/v1".to_string());
+        let model = env::var("LLAMA_SERVER_MODEL")
+            .unwrap_or_else(|_| "Qwen3.6-35B-A3B-UD-Q5_K_XL.gguf".to_string());
+        let skills_directory = env::var_os("AUTOAGENTS_SKILLS_DIR")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| PathBuf::from("examples/skills_agent/skills"));
+        let prompt = env::args().skip(1).collect::<Vec<_>>().join(" ");
+
+        let llm = LLMBuilder::<OpenAI>::new()
+            .api_key(api_key)
+            .base_url(&base_url)
+            .model(&model)
+            .api_mode(OpenAIApiMode::ChatCompletions)
+            .max_tokens(1024)
+            .temperature(0.2)
+            .build()?;
+        let skills = Arc::new(SkillRegistry::from_directory(
+            &skills_directory,
+            SkillRefreshStrategy::Watch {
+                debounce: Duration::from_millis(150),
+                fallback_interval: Duration::from_secs(30),
+            },
+        ));
+        let session = Arc::new(SkillSession::new());
+        let skill_configuration =
+            SkillConfiguration::new(Arc::clone(&skills), session, Arc::new(TrustedSkillPolicy));
+        SkillsConsole::print_configuration(&base_url, &model, &skills_directory);
+        let mut handle = AgentBuilder::<_, DirectAgent>::new(ReActAgent::new(SkillsAgent))
+            .llm(llm)
+            .memory(Box::new(SlidingWindowMemory::new(20)))
+            .skills(skill_configuration)
+            .build()
+            .await?;
+        SkillsConsole::print_discovered_skills(&skills);
+        if !prompt.is_empty() {
+            Self::run_prompt(&mut handle, prompt).await?;
+            return Ok(());
+        }
+
+        println!(
+            "[ready] enter a prompt, `/skills` to refresh the catalog, `/reset-skills`, or `/exit`"
+        );
+        while let Some(prompt) = SkillsConsole::read_prompt()? {
+            match prompt.as_str() {
+                "" => {}
+                "/exit" => break,
+                "/skills" => {
+                    let report = skills.refresh_now().await;
+                    println!(
+                        "[skills] generation {}: {} discovered, +{:?} ~{:?} -{:?}",
+                        report.generation(),
+                        report.discovered(),
+                        report.added(),
+                        report.updated(),
+                        report.removed()
+                    );
+                    SkillsConsole::print_discovered_skills(&skills);
+                }
+                "/reset-skills" => {
+                    handle.agent.reset_skill_session().await;
+                    println!("[skills] conversation activation state reset");
+                }
+                _ => Self::run_prompt(&mut handle, prompt).await?,
+            }
+        }
+        Ok(())
+    }
+
+    async fn run_prompt(
+        handle: &mut DirectAgentHandle<ReActAgent<SkillsAgent>>,
+        prompt: String,
+    ) -> Result<(), Error> {
+        let reporter = tokio::spawn(SkillsConsole::report_events(handle.subscribe_events()));
+        let response = handle.agent.run(Task::new(prompt)).await?;
+        reporter
+            .await
+            .map_err(|error| Error::CustomError(format!("console reporter failed: {error}")))?;
+        println!("\n[response]\n{response}");
+        Ok(())
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Error> {
+    SkillsExample::run().await
+}


### PR DESCRIPTION
# Summary
Adds **first-class Agent Skills** support to AutoAgents using SKILL.md packages with progressive instruction disclosure, conversation-scoped activation, runtime reloading, policy controls, lifecycle events, and confined resource access.

Skills are supported by ReAct and CodeAct executors. The initial system prompt exposes only skill names and descriptions; complete instructions are injected after the model activates a skill.

# What changed
- Added typed skill models, metadata parsing, revisions, registries, sources, snapshots, and diagnostics.
- Added conversation-scoped SkillSession activation and deactivation.
- Added the built-in activate_skill, deactivate_skill, and read_skill_resource tools.
- Added explicit reload strategies: Manual, Poll and Watch (through the optional skill-watch feature)
- Added source precedence and atomic catalog refreshes.
- Added SkillPolicy authorization for activation and resource access.
- Parsed allowed-tools into typed selectors without treating declarations as authority grants.
- Added lifecycle hooks and typed protocol events for catalog, activation, deactivation, resource, and failure activity.
- Exposed skill events through the Python event bridge.
- Integrated skill prompt composition with ReAct and CodeAct.
- Added a documented WASM compatibility boundary.
- Added an interactive example targeting an OpenAI-compatible llama server on port 8880, including console lifecycle output and live catalog inspection.

# Security
Filesystem-backed skills use:
- configurable document and resource limits;
- source-root containment checks;
- symlink rejection and no-follow reads;
- capability-scoped resource directory handles;
- discovered-path validation;
- resource digest verification before returning content;
- revision-based deactivation after instruction or resource changes.

Skill manifests never grant tool authority. Normal policy and tool permission checks still apply.

# Compatibility notes
- Filesystem discovery, watching, and resource reads are native-only.
- Registry, activation, policy, prompt composition, custom sources, and lifecycle events remain available on wasm32.
- notify is included only when skill-watch is enabled.
- Protocol consumers using exhaustive Event matching must handle the new Event::Skill variant.

# Validation
- cargo test -p autoagents-core --no-default-features — 540 passed
- cargo test -p autoagents-core --features skill-watch — 540 passed
- Clippy passed for default and all-feature configurations
- WASM checks passed with and without skill-watch
- The skills-agent example compiles successfully
- Formatting and diff checks passed

Thanks for the amazing work!

Best regards

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds runtime-loadable Agent Skills, including discovery, scoped activation, resource access, lifecycle events, and ReAct/CodeAct integration. The startup deadlock was removed, but the replacement delivery path can silently discard initial lifecycle events when discovery exceeds channel capacity.

- Adds typed skill registries, sessions, policies, sources, refresh strategies, and diagnostics.
- Adds built-in activation, deactivation, and confined resource-reading tools.
- Integrates skill prompts and events with Rust executors and the Python event bridge.
- Uses non-blocking event delivery during agent construction to avoid waiting on an unavailable direct-agent receiver.

<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because high-volume initial discovery can silently omit catalog and diagnostic lifecycle events.

Initialization no longer waits indefinitely for event-channel capacity, but it now discards try_send failures while the direct-agent receiver remains unavailable, leaving subscribers with an incomplete startup event stream whenever the initial refresh exceeds the 1,000-event buffer.

**Files Needing Attention:** crates/autoagents-core/src/agent/skill/runtime.rs, crates/autoagents-core/src/agent/base.rs, crates/autoagents-core/src/agent/direct.rs

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/autoagents-core/src/agent/skill/runtime.rs | Implements skill operations and lifecycle dispatch; startup dispatch avoids deadlock by using try_send but silently loses overflow events. |
| crates/autoagents-core/src/agent/base.rs | Initializes the configured skill runtime during BaseAgent construction, before a direct-agent event receiver can be consumed. |
| crates/autoagents-core/src/agent/direct.rs | Creates the bounded event channel and exposes its receiver only after BaseAgent initialization completes. |
| crates/autoagents-core/src/agent/skill/registry.rs | Adds atomic multi-source catalog refresh and diagnostic aggregation consumed by startup lifecycle dispatch. |
| crates/autoagents-core/src/agent/skill/directory/scanner.rs | Adds bounded filesystem skill discovery and resource metadata collection. |
| crates/autoagents-protocol/src/protocol.rs | Adds typed skill lifecycle events to the shared protocol. |
| bindings/python/autoagents/src/events/mod.rs | Serializes skill lifecycle events for Python consumers. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Builder as DirectAgent::build
  participant Base as BaseAgent::new
  participant Skills as SkillRuntime::initialize
  participant Channel as Event channel (capacity 1000)
  participant Consumer as Event subscriber
  Builder->>Base: construct with sender
  Base->>Skills: initialize before receiver is exposed
  loop Initial catalog and diagnostic events
    Skills->>Channel: try_send(event)
    Channel-->>Skills: Full after 1000 events
    Note over Skills,Channel: Error is discarded
  end
  Base-->>Builder: construction completes
  Builder-->>Consumer: expose receiver
  Note over Consumer: Overflow events are permanently missing
```
</details>

<a href="https://app.greptile.com/api/ide/cursor?prompt=%23%23%23%20Issue%201%0Acrates%2Fautoagents-core%2Fsrc%2Fagent%2Fskill%2Fruntime.rs%3A143%0A**Startup%20lifecycle%20events%20are%20dropped**%0A%0AWhen%20initial%20skill%20discovery%20produces%20more%20than%201%2C000%20catalog%20and%20diagnostic%20events%2C%20%60initialize%28%29%60%20dispatches%20them%20before%20the%20direct-agent%20receiver%20is%20exposed%2C%20and%20%60try_send%60%20silently%20discards%20every%20event%20beyond%20the%20channel%20capacity.%20The%20agent%20therefore%20builds%20successfully%20while%20subscribers%20receive%20an%20incomplete%20initial%20catalog%20and%20diagnostic%20lifecycle%20stream.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&pr=298&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursorDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"><img alt="Fix All in Cursor" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCursor.svg?v=6"></picture></a> <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22liquidos-ai%2Fautoagents%22%20on%20the%20existing%20branch%20%22skills-support%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22skills-support%22.%0A%0A%23%23%23%20Issue%201%0Acrates%2Fautoagents-core%2Fsrc%2Fagent%2Fskill%2Fruntime.rs%3A143%0A**Startup%20lifecycle%20events%20are%20dropped**%0A%0AWhen%20initial%20skill%20discovery%20produces%20more%20than%201%2C000%20catalog%20and%20diagnostic%20events%2C%20%60initialize%28%29%60%20dispatches%20them%20before%20the%20direct-agent%20receiver%20is%20exposed%2C%20and%20%60try_send%60%20silently%20discards%20every%20event%20beyond%20the%20channel%20capacity.%20The%20agent%20therefore%20builds%20successfully%20while%20subscribers%20receive%20an%20incomplete%20initial%20catalog%20and%20diagnostic%20lifecycle%20stream.%0A%0A---%0A%0AFor%20each%20issue%20above%2C%20determine%20whether%20it%20is%20valid%20and%20should%20be%20fixed.%20If%20so%2C%20fix%20it%20directly.&repo=liquidos-ai%2Fautoagents&pr=298&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
crates/autoagents-core/src/agent/skill/runtime.rs:143
**Startup lifecycle events are dropped**

When initial skill discovery produces more than 1,000 catalog and diagnostic events, `initialize()` dispatches them before the direct-agent receiver is exposed, and `try_send` silently discards every event beyond the channel capacity. The agent therefore builds successfully while subscribers receive an incomplete initial catalog and diagnostic lifecycle stream.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (3): Last reviewed commit: ["skills support"](https://github.com/liquidos-ai/autoagents/commit/fcd40c5fb50d0c5c7c990d15f31dfa35c7715b64) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49341692)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Core Agent Runtime](https://app.greptile.com/liquidos/-/custom-context/knowledge-base/liquidos-ai/autoagents/-/docs/core-agent-runtime.md)

<!-- /greptile_comment -->