### PR TITLE
feat(core): add timeout-aware runtime shutdown

### DIFF
--- a/crates/autoagents-core/src/environment.rs
+++ b/crates/autoagents-core/src/environment.rs
@@ -38,6 +38,12 @@ pub enum EnvironmentError {
     /// finish in time.
     #[error("Run task did not finish within {0:?}")]
     ShutdownTimeout(Duration),
+
+    /// A previous [`Environment::shutdown_with_timeout`] missed its deadline, so
+    /// runtimes may still be stopping. Relaunching would race that detached
+    /// work; shut down again and only relaunch once it succeeds.
+    #[error("Previous shutdown did not complete within {0:?}; runtimes may still be stopping")]
+    ShutdownIncomplete(Duration),
 }
 
 /// Configuration for the process environment that owns one or more runtimes.
@@ -67,6 +73,9 @@ impl Default for EnvironmentConfig {
 ///   Await it with [`wait`](Self::wait) or stop with [`shutdown`](Self::shutdown).
 /// - **`Background`** — [`run_background`](Self::run_background) started runtimes without storing
 ///   a handle on the environment. Call [`shutdown`](Self::shutdown) before `run()`.
+/// - **`ShutdownIncomplete`** — [`shutdown_with_timeout`](Self::shutdown_with_timeout) missed its
+///   deadline, so lifecycle work is still detached. `run()` and `run_background()` refuse to
+///   relaunch with [`EnvironmentError::ShutdownIncomplete`] until a later shutdown completes.
 ///
 /// `run()` and `run_background()` both call [`reconcile_finished_managed_launch`](Self::reconcile_finished_managed_launch)
 /// first. When a managed run task finished without `wait()` or `shutdown()`, that helper joins the
@@ -93,6 +102,10 @@ enum RuntimeLaunchState {
     Managed,
     /// [`Environment::run_background`] started runtimes without a stored join handle.
     Background,
+    /// [`Environment::shutdown_with_timeout`] missed the carried deadline. Stop
+    /// operations, and possibly the run task, are still running detached, so the
+    /// environment must not be relaunched until a shutdown completes.
+    ShutdownIncomplete(Duration),
 }
 
 impl Environment {
@@ -160,9 +173,13 @@ impl Environment {
     ///
     /// Use [`wait`](Self::wait) to await the background run task, or
     /// [`shutdown`](Self::shutdown) to stop runtimes and join the task.
-    #[allow(clippy::result_large_err)] // Only `AlreadyRunning` is returned from this method.
+    #[allow(clippy::result_large_err)] // Only unit-sized variants are returned from this method.
     pub fn run(&mut self) -> Result<(), EnvironmentError> {
         self.reconcile_finished_managed_launch()?;
+
+        if let RuntimeLaunchState::ShutdownIncomplete(timeout) = self.launch_state {
+            return Err(EnvironmentError::ShutdownIncomplete(timeout));
+        }
 
         if self.launch_state == RuntimeLaunchState::Background {
             return Err(EnvironmentError::AlreadyRunning);
@@ -215,6 +232,10 @@ impl Environment {
     /// instance without calling [`shutdown`](Self::shutdown) first.
     pub async fn run_background(&mut self) -> Result<(), EnvironmentError> {
         self.reconcile_finished_managed_launch()?;
+
+        if let RuntimeLaunchState::ShutdownIncomplete(timeout) = self.launch_state {
+            return Err(EnvironmentError::ShutdownIncomplete(timeout));
+        }
 
         if self.launch_state != RuntimeLaunchState::Idle || self.is_running() {
             return Err(EnvironmentError::AlreadyRunning);
@@ -283,53 +304,59 @@ impl Environment {
         Self::resolve_shutdown_outcome(stop_result, join_result)
     }
 
-    /// Request shutdown on all runtimes and await the run handle if present,
-    /// bounding both steps by `timeout`.
-    ///
-    /// The deadline applies to each runtime's [`Runtime::stop`] individually and
-    /// then, once the runtimes stopped in time, to joining the run task started
-    /// by [`run`](Self::run).
-    ///
-    /// The launch state returns to idle in every case, so the environment can be
-    /// started again even when shutdown timed out.
-    ///
-    /// # Errors
-    ///
-    /// - [`RuntimeError::ShutdownTimeout`] (wrapped in
-    ///   [`EnvironmentError::RuntimeError`]) when a runtime missed the deadline.
-    /// - [`EnvironmentError::ShutdownTimeout`] when the runtimes stopped in time
-    ///   but the run task did not finish within the deadline.
-    ///
-    /// # Cancellation
-    ///
-    /// A missed deadline only stops this call from waiting. Neither the runtime
-    /// `stop()` operations nor the run task are aborted; both keep running
-    /// detached, and the run task result is discarded once its join times out.
     pub async fn shutdown_with_timeout(
         &mut self,
         timeout: Duration,
     ) -> Result<(), EnvironmentError> {
         let stop_result = self.runtime_manager.stop_with_timeout(timeout).await;
 
-        let mut join_timed_out = false;
-        let join_result = match self.handle.take() {
-            Some(handle) => match tokio::time::timeout(timeout, handle).await {
-                Ok(join_result) => Some(join_result),
-                Err(_elapsed) => {
-                    join_timed_out = true;
-                    None
-                }
-            },
-            None => None,
-        };
+        // Runtime shutdown timed out. Keep the existing managed handle untouched
+        // and prevent the environment from being relaunched.
+        if let Err(error @ RuntimeError::ShutdownTimeout { .. }) = stop_result {
+            self.launch_state = RuntimeLaunchState::ShutdownIncomplete(timeout);
 
-        self.launch_state = RuntimeLaunchState::Idle;
-
-        if stop_result.is_ok() && join_timed_out {
-            return Err(EnvironmentError::ShutdownTimeout(timeout));
+            return Err(EnvironmentError::RuntimeError(Box::new(error)));
         }
 
-        Self::resolve_shutdown_outcome(stop_result, join_result)
+        let handle = match self.handle.take() {
+            Some(handle) => handle,
+            None => {
+                self.launch_state = RuntimeLaunchState::Idle;
+                return Self::resolve_shutdown_outcome(stop_result, None);
+            }
+        };
+
+        // Restore the handle if waiting is cancelled or exceeds the deadline.
+        let mut guard = RestoreRunHandleOnDrop {
+            environment: self,
+            handle: Some(handle),
+        };
+
+        let join_result = match tokio::time::timeout(
+            timeout,
+            guard.handle.as_mut().expect("handle was just stored"),
+        )
+        .await
+        {
+            Ok(join_result) => join_result,
+
+            Err(_elapsed) => {
+                guard.environment.launch_state = RuntimeLaunchState::ShutdownIncomplete(timeout);
+
+                // Returning drops the guard, which restores the JoinHandle.
+                return match stop_result {
+                    Ok(()) => Err(EnvironmentError::ShutdownTimeout(timeout)),
+                    Err(error) => Err(EnvironmentError::RuntimeError(Box::new(error))),
+                };
+            }
+        };
+
+        // The original managed run task has now finished. Only now is it safe to
+        // discard the handle and permit another run.
+        guard.handle = None;
+        guard.environment.launch_state = RuntimeLaunchState::Idle;
+
+        Self::resolve_shutdown_outcome(stop_result, Some(join_result))
     }
 
     /// Combine the runtime stop result with the run task join result, reporting
@@ -354,9 +381,13 @@ impl Environment {
     /// For [`run`](Self::run) this checks the managed join handle. For
     /// [`run_background`](Self::run_background) this returns `true` until
     /// [`shutdown`](Self::shutdown) clears the launch state.
+    ///
+    /// After a [`shutdown_with_timeout`](Self::shutdown_with_timeout) that missed
+    /// its deadline this stays `true`: the runtimes never confirmed they stopped,
+    /// so their lifecycle work must be assumed to still be running.
     pub fn is_running(&self) -> bool {
         match self.launch_state {
-            RuntimeLaunchState::Background => true,
+            RuntimeLaunchState::Background | RuntimeLaunchState::ShutdownIncomplete(_) => true,
             RuntimeLaunchState::Managed => self
                 .handle
                 .as_ref()
@@ -1063,8 +1094,15 @@ mod tests {
             other => panic!("expected a runtime shutdown timeout, got {other:?}"),
         }
         assert!(
-            !env.is_running(),
-            "a timed-out shutdown should still clear the launch state"
+            env.is_running(),
+            "a runtime that never confirmed it stopped must still count as running"
+        );
+        assert!(
+            matches!(
+                env.run(),
+                Err(EnvironmentError::ShutdownIncomplete(timeout)) if timeout == SHUTDOWN_TIMEOUT
+            ),
+            "relaunching must be refused while the previous stop is still detached"
         );
     }
 
@@ -1090,12 +1128,63 @@ mod tests {
             err,
             EnvironmentError::ShutdownTimeout(timeout) if timeout == SHUTDOWN_TIMEOUT
         ));
-        assert!(!env.is_running());
+        assert!(
+            env.is_running(),
+            "an unfinished run task must still count as running"
+        );
+        assert!(matches!(
+            env.run_background().await,
+            Err(EnvironmentError::ShutdownIncomplete(timeout)) if timeout == SHUTDOWN_TIMEOUT
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_environment_shutdown_timeout_preserves_run_handle() {
+        let mut env = Environment::new(None);
+
+        env.register_runtime(StallingRuntime::new(true))
+            .await
+            .unwrap();
+
+        env.run().expect("run should succeed");
+
+        let err = tokio::time::timeout(
+            SHUTDOWN_WATCHDOG,
+            env.shutdown_with_timeout(SHUTDOWN_TIMEOUT),
+        )
+        .await
+        .expect("shutdown must not hang")
+        .expect_err("unfinished run task should time out");
+
+        assert!(matches!(
+            err,
+            EnvironmentError::ShutdownTimeout(timeout)
+                if timeout == SHUTDOWN_TIMEOUT
+        ));
+
+        assert!(
+            env.handle.is_some(),
+            "the original managed run handle must remain tracked"
+        );
+
+        assert!(matches!(
+            env.run(),
+            Err(EnvironmentError::ShutdownIncomplete(timeout))
+                if timeout == SHUTDOWN_TIMEOUT
+        ));
     }
 
     #[test]
     fn test_environment_error_shutdown_timeout_display() {
         let error = EnvironmentError::ShutdownTimeout(SHUTDOWN_TIMEOUT);
         assert!(error.to_string().contains("did not finish within"));
+    }
+
+    #[test]
+    fn test_environment_error_shutdown_incomplete_display() {
+        let error = EnvironmentError::ShutdownIncomplete(SHUTDOWN_TIMEOUT);
+        let message = error.to_string();
+        assert!(message.contains("Previous shutdown did not complete"));
+        assert!(message.contains("may still be stopping"));
     }
 }

--- a/crates/autoagents-core/src/environment.rs
+++ b/crates/autoagents-core/src/environment.rs
@@ -6,7 +6,8 @@ use autoagents_protocol::{Event, RuntimeID};
 use futures_util::FutureExt;
 use std::path::PathBuf;
 use std::sync::Arc;
-use tokio::task::JoinHandle;
+use std::time::Duration;
+use tokio::task::{JoinError, JoinHandle};
 
 /// Errors emitted when managing runtimes and consuming event receivers
 #[derive(Debug, thiserror::Error)]
@@ -31,6 +32,12 @@ pub enum EnvironmentError {
 
     #[error("Finished run task result was not yet available")]
     RunResultNotReady,
+
+    /// The runtimes stopped within the deadline passed to
+    /// [`Environment::shutdown_with_timeout`], but the managed run task did not
+    /// finish in time.
+    #[error("Run task did not finish within {0:?}")]
+    ShutdownTimeout(Duration),
 }
 
 /// Configuration for the process environment that owns one or more runtimes.
@@ -258,6 +265,10 @@ impl Environment {
     }
 
     /// Request shutdown on all runtimes and await the run handle if present.
+    ///
+    /// This waits without a deadline. Use
+    /// [`shutdown_with_timeout`](Self::shutdown_with_timeout) when an
+    /// unresponsive runtime must not block shutdown indefinitely.
     pub async fn shutdown(&mut self) -> Result<(), EnvironmentError> {
         let stop_result = self.runtime_manager.stop().await;
 
@@ -269,6 +280,64 @@ impl Environment {
 
         self.launch_state = RuntimeLaunchState::Idle;
 
+        Self::resolve_shutdown_outcome(stop_result, join_result)
+    }
+
+    /// Request shutdown on all runtimes and await the run handle if present,
+    /// bounding both steps by `timeout`.
+    ///
+    /// The deadline applies to each runtime's [`Runtime::stop`] individually and
+    /// then, once the runtimes stopped in time, to joining the run task started
+    /// by [`run`](Self::run).
+    ///
+    /// The launch state returns to idle in every case, so the environment can be
+    /// started again even when shutdown timed out.
+    ///
+    /// # Errors
+    ///
+    /// - [`RuntimeError::ShutdownTimeout`] (wrapped in
+    ///   [`EnvironmentError::RuntimeError`]) when a runtime missed the deadline.
+    /// - [`EnvironmentError::ShutdownTimeout`] when the runtimes stopped in time
+    ///   but the run task did not finish within the deadline.
+    ///
+    /// # Cancellation
+    ///
+    /// A missed deadline only stops this call from waiting. Neither the runtime
+    /// `stop()` operations nor the run task are aborted; both keep running
+    /// detached, and the run task result is discarded once its join times out.
+    pub async fn shutdown_with_timeout(
+        &mut self,
+        timeout: Duration,
+    ) -> Result<(), EnvironmentError> {
+        let stop_result = self.runtime_manager.stop_with_timeout(timeout).await;
+
+        let mut join_timed_out = false;
+        let join_result = match self.handle.take() {
+            Some(handle) => match tokio::time::timeout(timeout, handle).await {
+                Ok(join_result) => Some(join_result),
+                Err(_elapsed) => {
+                    join_timed_out = true;
+                    None
+                }
+            },
+            None => None,
+        };
+
+        self.launch_state = RuntimeLaunchState::Idle;
+
+        if stop_result.is_ok() && join_timed_out {
+            return Err(EnvironmentError::ShutdownTimeout(timeout));
+        }
+
+        Self::resolve_shutdown_outcome(stop_result, join_result)
+    }
+
+    /// Combine the runtime stop result with the run task join result, reporting
+    /// a stop failure ahead of a run task failure.
+    fn resolve_shutdown_outcome(
+        stop_result: Result<(), RuntimeError>,
+        join_result: Option<Result<Result<(), RuntimeError>, JoinError>>,
+    ) -> Result<(), EnvironmentError> {
         if let Err(e) = stop_result {
             return Err(EnvironmentError::RuntimeError(Box::new(e)));
         }
@@ -860,5 +929,173 @@ mod tests {
             .await
             .expect("default runtime should resolve");
         assert_eq!(resolved.id(), runtime_id);
+    }
+
+    /// Runtime whose `run()` never returns, and whose `stop()` only returns when
+    /// `stop_completes` is set. Emulates a runtime that cannot be shut down.
+    struct StallingRuntime {
+        id: RuntimeID,
+        stop_completes: bool,
+        tx: mpsc::Sender<Event>,
+    }
+
+    impl StallingRuntime {
+        fn new(stop_completes: bool) -> Arc<Self> {
+            let (tx, _rx) = mpsc::channel(1);
+            Arc::new(Self {
+                id: RuntimeID::new_v4(),
+                stop_completes,
+                tx,
+            })
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl Runtime for StallingRuntime {
+        fn id(&self) -> RuntimeID {
+            self.id
+        }
+
+        async fn subscribe_any(
+            &self,
+            _topic_name: &str,
+            _topic_type: std::any::TypeId,
+            _actor: Arc<dyn crate::actor::AnyActor>,
+        ) -> Result<(), RuntimeError> {
+            Ok(())
+        }
+
+        async fn publish_any(
+            &self,
+            _topic_name: &str,
+            _topic_type: std::any::TypeId,
+            _message: Arc<dyn std::any::Any + Send + Sync>,
+        ) -> Result<(), RuntimeError> {
+            Ok(())
+        }
+
+        fn tx(&self) -> mpsc::Sender<Event> {
+            self.tx.clone()
+        }
+
+        async fn transport(&self) -> Arc<dyn crate::actor::Transport> {
+            Arc::new(crate::actor::LocalTransport)
+        }
+
+        async fn take_event_receiver(&self) -> Option<BoxEventStream<Event>> {
+            None
+        }
+
+        async fn subscribe_events(&self) -> BoxEventStream<Event> {
+            Box::pin(futures::stream::empty())
+        }
+
+        async fn run(&self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+            std::future::pending().await
+        }
+
+        async fn stop(&self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+            if self.stop_completes {
+                Ok(())
+            } else {
+                std::future::pending().await
+            }
+        }
+    }
+
+    /// Deadline handed to `shutdown_with_timeout` when the runtime is expected
+    /// to miss it. Short so the tests report the timeout quickly.
+    const SHUTDOWN_TIMEOUT: Duration = Duration::from_millis(50);
+    /// Deadline used when shutdown is expected to succeed. Comfortably above the
+    /// ~100ms `SingleThreadedRuntime::stop` takes to drain its event loop.
+    const GENEROUS_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(2);
+    /// Upper bound for the whole call, generously above either deadline.
+    const SHUTDOWN_WATCHDOG: Duration = Duration::from_secs(10);
+
+    #[tokio::test]
+    async fn test_environment_shutdown_with_timeout_succeeds() {
+        let mut env = Environment::new(None);
+        let runtime = SingleThreadedRuntime::new(None);
+        env.register_runtime(runtime).await.unwrap();
+
+        env.run().expect("run should succeed");
+        tokio::time::timeout(
+            SHUTDOWN_WATCHDOG,
+            env.shutdown_with_timeout(GENEROUS_SHUTDOWN_TIMEOUT),
+        )
+        .await
+        .expect("shutdown should not hang")
+        .expect("shutdown should succeed within the deadline");
+        assert!(!env.is_running());
+    }
+
+    #[tokio::test]
+    async fn test_environment_shutdown_with_timeout_succeeds_when_idle() {
+        let mut env = Environment::new(None);
+
+        env.shutdown_with_timeout(SHUTDOWN_TIMEOUT)
+            .await
+            .expect("shutdown should succeed when idle");
+    }
+
+    #[tokio::test]
+    async fn test_environment_shutdown_with_timeout_reports_unresponsive_runtime() {
+        let mut env = Environment::new(None);
+        let runtime = StallingRuntime::new(false);
+        let runtime_id = runtime.id;
+        env.register_runtime(runtime).await.unwrap();
+
+        env.run().expect("run should succeed");
+        let err = tokio::time::timeout(
+            SHUTDOWN_WATCHDOG,
+            env.shutdown_with_timeout(SHUTDOWN_TIMEOUT),
+        )
+        .await
+        .expect("shutdown must not wait indefinitely")
+        .expect_err("unresponsive runtime should be reported");
+
+        match err {
+            EnvironmentError::RuntimeError(runtime_error) => assert!(matches!(
+                runtime_error.as_ref(),
+                RuntimeError::ShutdownTimeout { runtime_ids, timeout }
+                if runtime_ids.as_slice() == [runtime_id] && *timeout == SHUTDOWN_TIMEOUT
+            )),
+            other => panic!("expected a runtime shutdown timeout, got {other:?}"),
+        }
+        assert!(
+            !env.is_running(),
+            "a timed-out shutdown should still clear the launch state"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_environment_shutdown_with_timeout_reports_unfinished_run_task() {
+        let mut env = Environment::new(None);
+        // The runtime stops promptly, but its run loop never returns, so the
+        // managed run task outlives the deadline.
+        env.register_runtime(StallingRuntime::new(true))
+            .await
+            .unwrap();
+
+        env.run().expect("run should succeed");
+        let err = tokio::time::timeout(
+            SHUTDOWN_WATCHDOG,
+            env.shutdown_with_timeout(SHUTDOWN_TIMEOUT),
+        )
+        .await
+        .expect("shutdown must not wait indefinitely")
+        .expect_err("unfinished run task should be reported");
+
+        assert!(matches!(
+            err,
+            EnvironmentError::ShutdownTimeout(timeout) if timeout == SHUTDOWN_TIMEOUT
+        ));
+        assert!(!env.is_running());
+    }
+
+    #[test]
+    fn test_environment_error_shutdown_timeout_display() {
+        let error = EnvironmentError::ShutdownTimeout(SHUTDOWN_TIMEOUT);
+        assert!(error.to_string().contains("did not finish within"));
     }
 }

--- a/crates/autoagents-core/src/environment.rs
+++ b/crates/autoagents-core/src/environment.rs
@@ -459,6 +459,7 @@ impl Drop for RestoreRunHandleOnDrop<'_> {
 mod tests {
     use super::*;
     use crate::runtime::SingleThreadedRuntime;
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use tempfile::tempdir;
     use tokio::sync::mpsc;
     use uuid::Uuid;
@@ -1034,6 +1035,85 @@ mod tests {
         }
     }
 
+    /// Runtime that runs to completion immediately, but whose first `stop()` is
+    /// slow. Later stops return promptly, so a test can tell whether a shutdown
+    /// waited for the detached first stop or merely for its own fresh one.
+    struct SlowStoppingRuntime {
+        id: RuntimeID,
+        stop_calls: Arc<AtomicUsize>,
+        stop_completions: Arc<AtomicUsize>,
+        tx: mpsc::Sender<Event>,
+    }
+
+    impl SlowStoppingRuntime {
+        fn new() -> Arc<Self> {
+            let (tx, _rx) = mpsc::channel(1);
+            Arc::new(Self {
+                id: RuntimeID::new_v4(),
+                stop_calls: Arc::new(AtomicUsize::new(0)),
+                stop_completions: Arc::new(AtomicUsize::new(0)),
+                tx,
+            })
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl Runtime for SlowStoppingRuntime {
+        fn id(&self) -> RuntimeID {
+            self.id
+        }
+
+        async fn subscribe_any(
+            &self,
+            _topic_name: &str,
+            _topic_type: std::any::TypeId,
+            _actor: Arc<dyn crate::actor::AnyActor>,
+        ) -> Result<(), RuntimeError> {
+            Ok(())
+        }
+
+        async fn publish_any(
+            &self,
+            _topic_name: &str,
+            _topic_type: std::any::TypeId,
+            _message: Arc<dyn std::any::Any + Send + Sync>,
+        ) -> Result<(), RuntimeError> {
+            Ok(())
+        }
+
+        fn tx(&self) -> mpsc::Sender<Event> {
+            self.tx.clone()
+        }
+
+        async fn transport(&self) -> Arc<dyn crate::actor::Transport> {
+            Arc::new(crate::actor::LocalTransport)
+        }
+
+        async fn take_event_receiver(&self) -> Option<BoxEventStream<Event>> {
+            None
+        }
+
+        async fn subscribe_events(&self) -> BoxEventStream<Event> {
+            Box::pin(futures::stream::empty())
+        }
+
+        async fn run(&self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+            Ok(())
+        }
+
+        async fn stop(&self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+            if self.stop_calls.fetch_add(1, Ordering::SeqCst) == 0 {
+                tokio::time::sleep(SLOW_STOP).await;
+            }
+            self.stop_completions.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+    }
+
+    /// Long enough that a stop which is not awaited would still be running when
+    /// the recovering shutdown returns.
+    const SLOW_STOP: Duration = Duration::from_millis(400);
+
     /// Deadline handed to `shutdown_with_timeout` when the runtime is expected
     /// to miss it. Short so the tests report the timeout quickly.
     const SHUTDOWN_TIMEOUT: Duration = Duration::from_millis(50);
@@ -1172,6 +1252,43 @@ mod tests {
             Err(EnvironmentError::ShutdownIncomplete(timeout))
                 if timeout == SHUTDOWN_TIMEOUT
         ));
+    }
+
+    #[tokio::test]
+    async fn test_environment_recovery_waits_for_the_detached_stop() {
+        let mut env = Environment::new(None);
+        let runtime = SlowStoppingRuntime::new();
+        let stop_completions = Arc::clone(&runtime.stop_completions);
+        env.register_runtime(runtime).await.unwrap();
+
+        env.run().expect("run should succeed");
+        tokio::time::timeout(
+            SHUTDOWN_WATCHDOG,
+            env.shutdown_with_timeout(SHUTDOWN_TIMEOUT),
+        )
+        .await
+        .expect("shutdown must not wait indefinitely")
+        .expect_err("the slow stop should miss the deadline");
+        assert_eq!(stop_completions.load(Ordering::SeqCst), 0);
+        assert!(matches!(
+            env.run(),
+            Err(EnvironmentError::ShutdownIncomplete(_))
+        ));
+
+        // Recovering must not merely start a second stop and declare success: the
+        // stop detached by the timed-out attempt has to be observed finishing
+        // before the environment may be launched again.
+        env.shutdown().await.expect("recovery shutdown should stop");
+        assert_eq!(
+            stop_completions.load(Ordering::SeqCst),
+            2,
+            "the guard must not clear while the first stop is still in flight"
+        );
+
+        assert!(!env.is_running());
+        env.run()
+            .expect("relaunch is allowed once every stop has been observed");
+        env.shutdown().await.expect("final shutdown should succeed");
     }
 
     #[test]

--- a/crates/autoagents-core/src/runtime/manager.rs
+++ b/crates/autoagents-core/src/runtime/manager.rs
@@ -12,17 +12,58 @@ use tokio::{
 type StopOutcome = Result<(), Box<dyn std::error::Error + Send + Sync>>;
 /// A spawned [`Runtime::stop`] call.
 type StopTask = JoinHandle<StopOutcome>;
+/// Result of joining a [`StopTask`]: the stop outcome, or the panic that
+/// replaced it.
+type StopJoinOutcome = Result<StopOutcome, JoinError>;
+
+/// A stop operation whose result no caller has reported yet.
+enum PendingStop {
+    /// Still in flight. Its handle has never been polled to completion, so it is
+    /// safe to await.
+    Running(StopTask),
+    /// Finished, with its outcome recorded but not yet reported: the call that
+    /// observed it was dropped before it could return.
+    Observed(StopJoinOutcome),
+}
+
+impl PendingStop {
+    /// Await the operation to completion, recording its outcome in place.
+    async fn observe(&mut self) {
+        if let PendingStop::Running(task) = self {
+            // The store follows the await with no suspension point in between,
+            // which is what makes callers cancellation safe: dropping them
+            // leaves either an untouched handle or a recorded outcome, never a
+            // completed handle that a later call would panic on re-polling.
+            *self = PendingStop::Observed(task.await);
+        }
+    }
+
+    /// Like [`observe`](Self::observe), but gives up after `timeout`, leaving an
+    /// unfinished operation running and observable by a later call.
+    async fn observe_with_timeout(&mut self, timeout: Duration) {
+        if let PendingStop::Running(task) = self
+            && let Ok(join_outcome) = tokio::time::timeout(timeout, task).await
+        {
+            *self = PendingStop::Observed(join_outcome);
+        }
+    }
+}
 
 pub struct RuntimeManager {
     runtimes: RwLock<HashMap<RuntimeID, Arc<dyn Runtime>>>,
-    /// Stop operations that outlived the deadline of an earlier
-    /// [`stop_with_timeout`](Self::stop_with_timeout).
+    /// Stop operations that no completed call has reported yet: those that
+    /// outlived the deadline of an earlier [`stop_with_timeout`](Self::stop_with_timeout),
+    /// and those left behind by a cancelled one.
     ///
     /// A timed-out stop keeps running detached. Holding its handle is what lets a
     /// later stop observe that it finished; dropping it would make the operation
     /// permanently unobservable, and any subsequent "shutdown completed" report
     /// would be unfounded.
-    pending_stops: Mutex<Vec<(RuntimeID, StopTask)>>,
+    ///
+    /// For the same reason an entry is removed only by the call that reports it,
+    /// never before awaiting it: a stop that is dropped mid-wait must leave the
+    /// work it was waiting on tracked here.
+    pending_stops: Mutex<Vec<(RuntimeID, PendingStop)>>,
 }
 
 impl RuntimeManager {
@@ -140,57 +181,61 @@ impl RuntimeManager {
     /// this method or to [`stop`](Self::stop) awaits it again. That is what makes
     /// a later successful stop meaningful: it reports success only once the
     /// earlier detached work has actually been observed to finish.
+    ///
+    /// Dropping this future keeps that guarantee: every stop operation it was
+    /// waiting on — retained and freshly spawned alike — stays tracked and is
+    /// awaited by the next call.
     pub async fn stop_with_timeout(&self, timeout: Duration) -> Result<(), RuntimeError> {
         let runtimes = self.runtimes.read().await;
         let mut pending_stops = self.pending_stops.lock().await;
 
-        // Re-await stop operations that outlived an earlier deadline alongside a
-        // fresh stop for every registered runtime, keeping each runtime id so
-        // unresponsive runtimes can be named in the error.
-        let mut tasks: Vec<(RuntimeID, StopTask)> = pending_stops.drain(..).collect();
-        tasks.extend(runtimes.values().map(|runtime| {
+        // Track a fresh stop for every registered runtime alongside the stop
+        // operations left unreported by an earlier call, keeping each runtime id
+        // so unresponsive runtimes can be named in the error. `pending_stops`
+        // owns every entry for the whole wait below, so dropping this future
+        // mid-wait leaves the unreported work tracked instead of detaching it.
+        pending_stops.extend(runtimes.values().map(|runtime| {
             let runtime = Arc::clone(runtime);
             let runtime_id = runtime.id();
             (
                 runtime_id,
-                tokio::spawn(async move { runtime.stop().await }),
+                PendingStop::Running(tokio::spawn(async move { runtime.stop().await })),
             )
         }));
 
-        let outcomes = join_all(tasks.into_iter().map(|(runtime_id, mut task)| async move {
-            // Await by reference so the handle survives the deadline and can be
-            // handed back for a later call to await.
-            match tokio::time::timeout(timeout, &mut task).await {
-                Ok(join_result) => (runtime_id, Ok(join_result)),
-                Err(_elapsed) => (runtime_id, Err(task)),
-            }
-        }))
+        join_all(
+            pending_stops
+                .iter_mut()
+                .map(|(_, pending)| pending.observe_with_timeout(timeout)),
+        )
         .await;
 
         let mut timed_out: Vec<RuntimeID> = Vec::new();
         let mut join_error: Option<JoinError> = None;
         let mut operation_error: Option<String> = None;
 
-        for (runtime_id, outcome) in outcomes {
-            match outcome {
-                Err(task) => {
+        // Reporting is free of await points, so every outcome taken out here is
+        // carried into this call's return value.
+        for (runtime_id, pending) in std::mem::take(&mut *pending_stops) {
+            match pending {
+                PendingStop::Running(task) => {
                     error!("Runtime {runtime_id} did not stop within {timeout:?}");
                     timed_out.push(runtime_id);
-                    pending_stops.push((runtime_id, task));
+                    pending_stops.push((runtime_id, PendingStop::Running(task)));
                 }
-                Ok(Err(err)) => {
+                PendingStop::Observed(Err(err)) => {
                     error!("Runtime {runtime_id} panicked while stopping: {err}");
                     if join_error.is_none() {
                         join_error = Some(err);
                     }
                 }
-                Ok(Ok(Err(err))) => {
+                PendingStop::Observed(Ok(Err(err))) => {
                     error!("Runtime {runtime_id} failed to stop: {err}");
                     if operation_error.is_none() {
                         operation_error = Some(err.to_string());
                     }
                 }
-                Ok(Ok(Ok(()))) => {}
+                PendingStop::Observed(Ok(Ok(()))) => {}
             }
         }
 
@@ -218,18 +263,34 @@ impl RuntimeManager {
         Ok(())
     }
 
-    /// Await every stop operation retained from a timed-out
-    /// [`stop_with_timeout`](Self::stop_with_timeout), without a deadline.
+    /// Await every stop operation left over by an earlier
+    /// [`stop_with_timeout`](Self::stop_with_timeout) that timed out or was
+    /// dropped, without a deadline.
     ///
     /// Outcomes are logged rather than returned; the call that hit the deadline
     /// already reported these runtimes as unresponsive.
+    ///
+    /// Dropping this future leaves every operation it has not yet observed
+    /// tracked in `pending_stops`, so a later call still awaits them.
     async fn drain_pending_stops(&self) {
         let mut pending_stops = self.pending_stops.lock().await;
-        for (runtime_id, task) in pending_stops.drain(..) {
-            match task.await {
-                Ok(Ok(())) => {}
-                Ok(Err(err)) => error!("Runtime {runtime_id} failed to stop: {err}"),
-                Err(err) => error!("Runtime {runtime_id} panicked while stopping: {err}"),
+        join_all(
+            pending_stops
+                .iter_mut()
+                .map(|(_, pending)| pending.observe()),
+        )
+        .await;
+
+        for (runtime_id, pending) in pending_stops.drain(..) {
+            match pending {
+                // `observe` leaves nothing running.
+                PendingStop::Running(_) | PendingStop::Observed(Ok(Ok(()))) => {}
+                PendingStop::Observed(Ok(Err(err))) => {
+                    error!("Runtime {runtime_id} failed to stop: {err}")
+                }
+                PendingStop::Observed(Err(err)) => {
+                    error!("Runtime {runtime_id} panicked while stopping: {err}")
+                }
             }
         }
     }
@@ -821,6 +882,69 @@ mod tests {
             stop_completions.load(Ordering::SeqCst),
             2,
             "stop() must not return while an earlier stop is still detached"
+        );
+    }
+
+    #[tokio::test]
+    async fn stop_with_timeout_keeps_retained_stops_when_cancelled() {
+        let manager = RuntimeManager::new();
+        let runtime =
+            TestRuntime::new(Behavior::Success, Behavior::Success).with_first_stop_delay(SLOW_STOP);
+        let stop_completions = runtime.stop_completions();
+
+        manager
+            .register_runtime(Arc::new(runtime))
+            .await
+            .expect("register runtime");
+
+        manager
+            .stop_with_timeout(STOP_TIMEOUT)
+            .await
+            .expect_err("the slow stop should miss the deadline");
+        assert_eq!(stop_completions.load(Ordering::SeqCst), 0);
+
+        // Drop a second call while it is still waiting on the retained stop.
+        timeout(STOP_TIMEOUT, manager.stop_with_timeout(WATCHDOG))
+            .await
+            .expect_err("the outer deadline should cancel the call mid-wait");
+
+        // The cancelled call must not have taken the still-running stop with it.
+        manager.stop().await.expect("unbounded stop should succeed");
+        assert_eq!(
+            stop_completions.load(Ordering::SeqCst),
+            3,
+            "a cancelled stop must leave every unobserved stop operation tracked"
+        );
+    }
+
+    #[tokio::test]
+    async fn stop_keeps_retained_stops_when_cancelled() {
+        let manager = RuntimeManager::new();
+        let runtime =
+            TestRuntime::new(Behavior::Success, Behavior::Success).with_first_stop_delay(SLOW_STOP);
+        let stop_completions = runtime.stop_completions();
+
+        manager
+            .register_runtime(Arc::new(runtime))
+            .await
+            .expect("register runtime");
+
+        manager
+            .stop_with_timeout(STOP_TIMEOUT)
+            .await
+            .expect_err("the slow stop should miss the deadline");
+        assert_eq!(stop_completions.load(Ordering::SeqCst), 0);
+
+        // Drop an unbounded stop while it is draining the retained stop.
+        timeout(STOP_TIMEOUT, manager.stop())
+            .await
+            .expect_err("the outer deadline should cancel the call mid-drain");
+
+        manager.stop().await.expect("unbounded stop should succeed");
+        assert_eq!(
+            stop_completions.load(Ordering::SeqCst),
+            2,
+            "a cancelled stop must leave the retained stop operation tracked"
         );
     }
 

--- a/crates/autoagents-core/src/runtime/manager.rs
+++ b/crates/autoagents-core/src/runtime/manager.rs
@@ -1,9 +1,9 @@
 use super::{Runtime, RuntimeError};
 use autoagents_protocol::RuntimeID;
-use futures::future::try_join_all;
+use futures::future::{join_all, try_join_all};
 use log::error;
-use std::{collections::HashMap, sync::Arc};
-use tokio::sync::RwLock;
+use std::{collections::HashMap, sync::Arc, time::Duration};
+use tokio::{sync::RwLock, task::JoinError};
 
 pub struct RuntimeManager {
     runtimes: RwLock<HashMap<RuntimeID, Arc<dyn Runtime>>>,
@@ -56,6 +56,11 @@ impl RuntimeManager {
         Ok(())
     }
 
+    /// Request shutdown of all registered runtimes and wait for every
+    /// [`Runtime::stop`] future to complete.
+    ///
+    /// This waits without a deadline. Use [`stop_with_timeout`](Self::stop_with_timeout)
+    /// when an unresponsive runtime must not block shutdown indefinitely.
     pub async fn stop(&self) -> Result<(), RuntimeError> {
         let runtimes = self.runtimes.read().await;
         // Call `stop()` on all runtimes
@@ -71,6 +76,103 @@ impl RuntimeManager {
         for result in results {
             result.map_err(|err| RuntimeError::OperationFailed(err.to_string()))?;
         }
+        Ok(())
+    }
+
+    /// Request shutdown of all registered runtimes, waiting at most `timeout`
+    /// for each [`Runtime::stop`] future to complete.
+    ///
+    /// Every runtime is stopped concurrently and the deadline applies to each
+    /// one individually, so the call returns after roughly `timeout` even when
+    /// several runtimes are unresponsive.
+    ///
+    /// Unlike [`stop`](Self::stop), this never short-circuits: every runtime is
+    /// awaited (up to the deadline) so a single unresponsive runtime cannot
+    /// prevent the others from being stopped.
+    ///
+    /// # Errors
+    ///
+    /// Outcomes are reported in a fixed precedence so the result is
+    /// deterministic when runtimes fail in different ways:
+    ///
+    /// 1. [`RuntimeError::ShutdownTimeout`] when any runtime missed the
+    ///    deadline, carrying the ids of all unresponsive runtimes.
+    /// 2. [`RuntimeError::JoinError`] when any `stop()` future panicked.
+    /// 3. [`RuntimeError::OperationFailed`] when any `stop()` future returned an
+    ///    error.
+    ///
+    /// # Cancellation
+    ///
+    /// Exceeding the deadline stops the manager from waiting; it does not abort
+    /// the underlying `stop()` future. A timed-out shutdown keeps running
+    /// detached until it completes on its own, so callers should treat
+    /// [`RuntimeError::ShutdownTimeout`] as "shutdown is still in progress"
+    /// rather than "shutdown was cancelled".
+    pub async fn stop_with_timeout(&self, timeout: Duration) -> Result<(), RuntimeError> {
+        let runtimes = self.runtimes.read().await;
+        // Call `stop()` on all runtimes, keeping each runtime id so unresponsive
+        // runtimes can be named in the error.
+        let tasks = runtimes
+            .values()
+            .map(|runtime| {
+                let runtime = Arc::clone(runtime);
+                let runtime_id = runtime.id();
+                (
+                    runtime_id,
+                    tokio::spawn(async move { runtime.stop().await }),
+                )
+            })
+            .collect::<Vec<_>>();
+
+        let outcomes = join_all(tasks.into_iter().map(|(runtime_id, task)| async move {
+            (runtime_id, tokio::time::timeout(timeout, task).await)
+        }))
+        .await;
+
+        let mut timed_out: Vec<RuntimeID> = Vec::new();
+        let mut join_error: Option<JoinError> = None;
+        let mut operation_error: Option<String> = None;
+
+        for (runtime_id, outcome) in outcomes {
+            match outcome {
+                Err(_elapsed) => {
+                    error!("Runtime {runtime_id} did not stop within {timeout:?}");
+                    timed_out.push(runtime_id);
+                }
+                Ok(Err(err)) => {
+                    error!("Runtime {runtime_id} panicked while stopping: {err}");
+                    if join_error.is_none() {
+                        join_error = Some(err);
+                    }
+                }
+                Ok(Ok(Err(err))) => {
+                    error!("Runtime {runtime_id} failed to stop: {err}");
+                    if operation_error.is_none() {
+                        operation_error = Some(err.to_string());
+                    }
+                }
+                Ok(Ok(Ok(()))) => {}
+            }
+        }
+
+        if !timed_out.is_empty() {
+            // Registration order is not observable through the `HashMap`, so sort
+            // to keep the reported ids stable across calls.
+            timed_out.sort_unstable();
+            return Err(RuntimeError::ShutdownTimeout {
+                runtime_ids: timed_out,
+                timeout,
+            });
+        }
+
+        if let Some(err) = join_error {
+            return Err(RuntimeError::JoinError(err));
+        }
+
+        if let Some(err) = operation_error {
+            return Err(RuntimeError::OperationFailed(err));
+        }
+
         Ok(())
     }
 }
@@ -93,6 +195,8 @@ mod tests {
         Success,
         Error,
         Panic,
+        /// Never resolves, emulating a runtime that cannot complete shutdown.
+        Hang,
     }
 
     struct TestRuntime {
@@ -101,7 +205,9 @@ mod tests {
         stop_behavior: Behavior,
         run_calls: Arc<AtomicUsize>,
         stop_calls: Arc<AtomicUsize>,
+        stop_completions: Arc<AtomicUsize>,
         run_started: Option<Arc<Notify>>,
+        stop_gate: Option<Arc<Notify>>,
         tx: mpsc::Sender<Event>,
     }
 
@@ -114,7 +220,9 @@ mod tests {
                 stop_behavior,
                 run_calls: Arc::new(AtomicUsize::new(0)),
                 stop_calls: Arc::new(AtomicUsize::new(0)),
+                stop_completions: Arc::new(AtomicUsize::new(0)),
                 run_started: None,
+                stop_gate: None,
                 tx,
             }
         }
@@ -124,12 +232,22 @@ mod tests {
             self
         }
 
+        /// Block `stop()` until the returned gate is notified.
+        fn with_stop_gate(mut self, stop_gate: Arc<Notify>) -> Self {
+            self.stop_gate = Some(stop_gate);
+            self
+        }
+
         fn run_calls(&self) -> Arc<AtomicUsize> {
             Arc::clone(&self.run_calls)
         }
 
         fn stop_calls(&self) -> Arc<AtomicUsize> {
             Arc::clone(&self.stop_calls)
+        }
+
+        fn stop_completions(&self) -> Arc<AtomicUsize> {
+            Arc::clone(&self.stop_completions)
         }
     }
 
@@ -183,17 +301,26 @@ mod tests {
                 Behavior::Success => Ok(()),
                 Behavior::Error => Err(std::io::Error::other("run failed").into()),
                 Behavior::Panic => panic!("runtime run panic"),
+                Behavior::Hang => std::future::pending().await,
             }
         }
 
         async fn stop(&self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
             self.stop_calls.fetch_add(1, Ordering::SeqCst);
-
-            match self.stop_behavior {
-                Behavior::Success => Ok(()),
-                Behavior::Error => Err(std::io::Error::other("stop failed").into()),
-                Behavior::Panic => panic!("runtime stop panic"),
+            if let Some(stop_gate) = &self.stop_gate {
+                stop_gate.notified().await;
             }
+
+            let result: Result<(), Box<dyn std::error::Error + Send + Sync>> =
+                match self.stop_behavior {
+                    Behavior::Success => Ok(()),
+                    Behavior::Error => Err(std::io::Error::other("stop failed").into()),
+                    Behavior::Panic => panic!("runtime stop panic"),
+                    Behavior::Hang => std::future::pending().await,
+                };
+
+            self.stop_completions.fetch_add(1, Ordering::SeqCst);
+            result
         }
     }
 
@@ -358,5 +485,223 @@ mod tests {
             .expect_err("runtime error should be surfaced");
         assert!(matches!(err, RuntimeError::OperationFailed(_)));
         assert!(err.to_string().contains("stop failed"));
+    }
+
+    /// Deadline handed to `stop_with_timeout`. Short so hanging runtimes are
+    /// reported quickly.
+    const STOP_TIMEOUT: Duration = Duration::from_millis(50);
+    /// Upper bound for the whole call; generously above `STOP_TIMEOUT` so a slow
+    /// machine cannot make the test flaky while still catching a hang.
+    const WATCHDOG: Duration = Duration::from_secs(5);
+
+    #[tokio::test]
+    async fn stop_with_timeout_stops_all_registered_runtimes() {
+        let manager = RuntimeManager::new();
+        let first = TestRuntime::new(Behavior::Success, Behavior::Success);
+        let second = TestRuntime::new(Behavior::Success, Behavior::Success);
+        let first_calls = first.stop_calls();
+        let second_calls = second.stop_calls();
+
+        manager
+            .register_runtime(Arc::new(first))
+            .await
+            .expect("register first runtime");
+        manager
+            .register_runtime(Arc::new(second))
+            .await
+            .expect("register second runtime");
+
+        manager
+            .stop_with_timeout(STOP_TIMEOUT)
+            .await
+            .expect("all runtimes stop within the deadline");
+
+        assert_eq!(first_calls.load(Ordering::SeqCst), 1);
+        assert_eq!(second_calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn stop_with_timeout_succeeds_without_registered_runtimes() {
+        let manager = RuntimeManager::new();
+
+        manager
+            .stop_with_timeout(STOP_TIMEOUT)
+            .await
+            .expect("stopping an empty manager succeeds");
+    }
+
+    #[tokio::test]
+    async fn stop_with_timeout_reports_unresponsive_runtime() {
+        let manager = RuntimeManager::new();
+        let unresponsive = TestRuntime::new(Behavior::Success, Behavior::Hang);
+        let unresponsive_id = unresponsive.id();
+        let responsive = TestRuntime::new(Behavior::Success, Behavior::Success);
+        let responsive_calls = responsive.stop_calls();
+
+        manager
+            .register_runtime(Arc::new(unresponsive))
+            .await
+            .expect("register unresponsive runtime");
+        manager
+            .register_runtime(Arc::new(responsive))
+            .await
+            .expect("register responsive runtime");
+
+        let err = timeout(WATCHDOG, manager.stop_with_timeout(STOP_TIMEOUT))
+            .await
+            .expect("stop_with_timeout must not wait indefinitely")
+            .expect_err("unresponsive runtime should be reported");
+
+        assert!(matches!(
+            &err,
+            RuntimeError::ShutdownTimeout { runtime_ids, timeout }
+            if runtime_ids.as_slice() == [unresponsive_id] && *timeout == STOP_TIMEOUT
+        ));
+        assert_eq!(
+            responsive_calls.load(Ordering::SeqCst),
+            1,
+            "an unresponsive runtime must not prevent the others from stopping"
+        );
+    }
+
+    #[tokio::test]
+    async fn stop_with_timeout_reports_every_unresponsive_runtime() {
+        let manager = RuntimeManager::new();
+        let first = TestRuntime::new(Behavior::Success, Behavior::Hang);
+        let second = TestRuntime::new(Behavior::Success, Behavior::Hang);
+        let mut expected_ids = vec![first.id(), second.id()];
+        expected_ids.sort_unstable();
+
+        manager
+            .register_runtime(Arc::new(first))
+            .await
+            .expect("register first runtime");
+        manager
+            .register_runtime(Arc::new(second))
+            .await
+            .expect("register second runtime");
+
+        let err = timeout(WATCHDOG, manager.stop_with_timeout(STOP_TIMEOUT))
+            .await
+            .expect("stop_with_timeout must not wait indefinitely")
+            .expect_err("unresponsive runtimes should be reported");
+
+        match err {
+            RuntimeError::ShutdownTimeout { runtime_ids, .. } => {
+                assert_eq!(runtime_ids, expected_ids);
+            }
+            other => panic!("expected a shutdown timeout, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn stop_with_timeout_prefers_timeout_over_stop_failure() {
+        let manager = RuntimeManager::new();
+        let unresponsive = TestRuntime::new(Behavior::Success, Behavior::Hang);
+        let unresponsive_id = unresponsive.id();
+
+        manager
+            .register_runtime(Arc::new(unresponsive))
+            .await
+            .expect("register unresponsive runtime");
+        manager
+            .register_runtime(Arc::new(TestRuntime::new(
+                Behavior::Success,
+                Behavior::Error,
+            )))
+            .await
+            .expect("register failing runtime");
+
+        let err = timeout(WATCHDOG, manager.stop_with_timeout(STOP_TIMEOUT))
+            .await
+            .expect("stop_with_timeout must not wait indefinitely")
+            .expect_err("shutdown should fail");
+
+        assert!(matches!(
+            &err,
+            RuntimeError::ShutdownTimeout { runtime_ids, .. }
+            if runtime_ids.as_slice() == [unresponsive_id]
+        ));
+    }
+
+    #[tokio::test]
+    async fn stop_with_timeout_surfaces_runtime_error() {
+        let manager = RuntimeManager::new();
+        manager
+            .register_runtime(Arc::new(TestRuntime::new(
+                Behavior::Success,
+                Behavior::Error,
+            )))
+            .await
+            .expect("register runtime");
+
+        let err = manager
+            .stop_with_timeout(STOP_TIMEOUT)
+            .await
+            .expect_err("runtime error should be surfaced");
+        assert!(matches!(err, RuntimeError::OperationFailed(_)));
+        assert!(err.to_string().contains("stop failed"));
+    }
+
+    #[tokio::test]
+    async fn stop_with_timeout_returns_join_error_when_runtime_panics() {
+        let manager = RuntimeManager::new();
+        manager
+            .register_runtime(Arc::new(TestRuntime::new(
+                Behavior::Success,
+                Behavior::Panic,
+            )))
+            .await
+            .expect("register runtime");
+
+        let err = manager
+            .stop_with_timeout(STOP_TIMEOUT)
+            .await
+            .expect_err("panic should surface as join error");
+        assert!(matches!(err, RuntimeError::JoinError(_)));
+    }
+
+    #[tokio::test]
+    async fn stop_with_timeout_does_not_abort_a_late_runtime() {
+        let manager = RuntimeManager::new();
+        let gate = Arc::new(Notify::new());
+        let runtime = TestRuntime::new(Behavior::Success, Behavior::Success)
+            .with_stop_gate(Arc::clone(&gate));
+        let stop_completions = runtime.stop_completions();
+
+        manager
+            .register_runtime(Arc::new(runtime))
+            .await
+            .expect("register runtime");
+
+        timeout(WATCHDOG, manager.stop_with_timeout(STOP_TIMEOUT))
+            .await
+            .expect("stop_with_timeout must not wait indefinitely")
+            .expect_err("gated runtime should miss the deadline");
+        assert_eq!(stop_completions.load(Ordering::SeqCst), 0);
+
+        // The deadline only stops the manager from waiting: the detached stop
+        // operation still runs to completion once it is unblocked.
+        gate.notify_one();
+        timeout(WATCHDOG, async {
+            while stop_completions.load(Ordering::SeqCst) == 0 {
+                tokio::time::sleep(Duration::from_millis(1)).await;
+            }
+        })
+        .await
+        .expect("the timed-out stop operation should still complete");
+    }
+
+    #[test]
+    fn shutdown_timeout_error_names_the_unresponsive_runtimes() {
+        let runtime_id = RuntimeID::new_v4();
+        let err = RuntimeError::ShutdownTimeout {
+            runtime_ids: vec![runtime_id],
+            timeout: STOP_TIMEOUT,
+        };
+
+        let message = err.to_string();
+        assert!(message.contains("did not complete"));
+        assert!(message.contains(&runtime_id.to_string()));
     }
 }

--- a/crates/autoagents-core/src/runtime/manager.rs
+++ b/crates/autoagents-core/src/runtime/manager.rs
@@ -3,16 +3,35 @@ use autoagents_protocol::RuntimeID;
 use futures::future::{join_all, try_join_all};
 use log::error;
 use std::{collections::HashMap, sync::Arc, time::Duration};
-use tokio::{sync::RwLock, task::JoinError};
+use tokio::{
+    sync::{Mutex, RwLock},
+    task::{JoinError, JoinHandle},
+};
+
+/// Result produced by a [`Runtime::stop`] call.
+type StopOutcome = Result<(), Box<dyn std::error::Error + Send + Sync>>;
+/// A spawned [`Runtime::stop`] call.
+type StopTask = JoinHandle<StopOutcome>;
 
 pub struct RuntimeManager {
     runtimes: RwLock<HashMap<RuntimeID, Arc<dyn Runtime>>>,
+    /// Stop operations that outlived the deadline of an earlier
+    /// [`stop_with_timeout`](Self::stop_with_timeout).
+    ///
+    /// A timed-out stop keeps running detached. Holding its handle is what lets a
+    /// later stop observe that it finished; dropping it would make the operation
+    /// permanently unobservable, and any subsequent "shutdown completed" report
+    /// would be unfounded.
+    pending_stops: Mutex<Vec<(RuntimeID, StopTask)>>,
 }
 
 impl RuntimeManager {
     pub fn new() -> Self {
         let runtimes = RwLock::new(HashMap::new());
-        RuntimeManager { runtimes }
+        RuntimeManager {
+            runtimes,
+            pending_stops: Mutex::new(Vec::new()),
+        }
     }
 
     pub async fn register_runtime(&self, runtime: Arc<dyn Runtime>) -> Result<(), RuntimeError> {
@@ -61,8 +80,16 @@ impl RuntimeManager {
     ///
     /// This waits without a deadline. Use [`stop_with_timeout`](Self::stop_with_timeout)
     /// when an unresponsive runtime must not block shutdown indefinitely.
+    ///
+    /// Stop operations left detached by an earlier timed-out
+    /// [`stop_with_timeout`](Self::stop_with_timeout) are awaited first, so
+    /// returning from this method means no stop work is still in flight. Their
+    /// outcomes are logged rather than returned: the earlier call already
+    /// reported them as [`RuntimeError::ShutdownTimeout`].
     pub async fn stop(&self) -> Result<(), RuntimeError> {
         let runtimes = self.runtimes.read().await;
+        self.drain_pending_stops().await;
+
         // Call `stop()` on all runtimes
         let tasks = runtimes
             .values()
@@ -108,24 +135,35 @@ impl RuntimeManager {
     /// detached until it completes on its own, so callers should treat
     /// [`RuntimeError::ShutdownTimeout`] as "shutdown is still in progress"
     /// rather than "shutdown was cancelled".
+    ///
+    /// The handle of a timed-out operation is retained, and the next call to
+    /// this method or to [`stop`](Self::stop) awaits it again. That is what makes
+    /// a later successful stop meaningful: it reports success only once the
+    /// earlier detached work has actually been observed to finish.
     pub async fn stop_with_timeout(&self, timeout: Duration) -> Result<(), RuntimeError> {
         let runtimes = self.runtimes.read().await;
-        // Call `stop()` on all runtimes, keeping each runtime id so unresponsive
-        // runtimes can be named in the error.
-        let tasks = runtimes
-            .values()
-            .map(|runtime| {
-                let runtime = Arc::clone(runtime);
-                let runtime_id = runtime.id();
-                (
-                    runtime_id,
-                    tokio::spawn(async move { runtime.stop().await }),
-                )
-            })
-            .collect::<Vec<_>>();
+        let mut pending_stops = self.pending_stops.lock().await;
 
-        let outcomes = join_all(tasks.into_iter().map(|(runtime_id, task)| async move {
-            (runtime_id, tokio::time::timeout(timeout, task).await)
+        // Re-await stop operations that outlived an earlier deadline alongside a
+        // fresh stop for every registered runtime, keeping each runtime id so
+        // unresponsive runtimes can be named in the error.
+        let mut tasks: Vec<(RuntimeID, StopTask)> = pending_stops.drain(..).collect();
+        tasks.extend(runtimes.values().map(|runtime| {
+            let runtime = Arc::clone(runtime);
+            let runtime_id = runtime.id();
+            (
+                runtime_id,
+                tokio::spawn(async move { runtime.stop().await }),
+            )
+        }));
+
+        let outcomes = join_all(tasks.into_iter().map(|(runtime_id, mut task)| async move {
+            // Await by reference so the handle survives the deadline and can be
+            // handed back for a later call to await.
+            match tokio::time::timeout(timeout, &mut task).await {
+                Ok(join_result) => (runtime_id, Ok(join_result)),
+                Err(_elapsed) => (runtime_id, Err(task)),
+            }
         }))
         .await;
 
@@ -135,9 +173,10 @@ impl RuntimeManager {
 
         for (runtime_id, outcome) in outcomes {
             match outcome {
-                Err(_elapsed) => {
+                Err(task) => {
                     error!("Runtime {runtime_id} did not stop within {timeout:?}");
                     timed_out.push(runtime_id);
+                    pending_stops.push((runtime_id, task));
                 }
                 Ok(Err(err)) => {
                     error!("Runtime {runtime_id} panicked while stopping: {err}");
@@ -157,8 +196,11 @@ impl RuntimeManager {
 
         if !timed_out.is_empty() {
             // Registration order is not observable through the `HashMap`, so sort
-            // to keep the reported ids stable across calls.
+            // to keep the reported ids stable across calls. A runtime can appear
+            // twice when its retained stop misses the deadline again alongside the
+            // fresh one, so report each runtime once.
             timed_out.sort_unstable();
+            timed_out.dedup();
             return Err(RuntimeError::ShutdownTimeout {
                 runtime_ids: timed_out,
                 timeout,
@@ -174,6 +216,22 @@ impl RuntimeManager {
         }
 
         Ok(())
+    }
+
+    /// Await every stop operation retained from a timed-out
+    /// [`stop_with_timeout`](Self::stop_with_timeout), without a deadline.
+    ///
+    /// Outcomes are logged rather than returned; the call that hit the deadline
+    /// already reported these runtimes as unresponsive.
+    async fn drain_pending_stops(&self) {
+        let mut pending_stops = self.pending_stops.lock().await;
+        for (runtime_id, task) in pending_stops.drain(..) {
+            match task.await {
+                Ok(Ok(())) => {}
+                Ok(Err(err)) => error!("Runtime {runtime_id} failed to stop: {err}"),
+                Err(err) => error!("Runtime {runtime_id} panicked while stopping: {err}"),
+            }
+        }
     }
 }
 
@@ -208,6 +266,7 @@ mod tests {
         stop_completions: Arc<AtomicUsize>,
         run_started: Option<Arc<Notify>>,
         stop_gate: Option<Arc<Notify>>,
+        first_stop_delay: Option<Duration>,
         tx: mpsc::Sender<Event>,
     }
 
@@ -223,6 +282,7 @@ mod tests {
                 stop_completions: Arc::new(AtomicUsize::new(0)),
                 run_started: None,
                 stop_gate: None,
+                first_stop_delay: None,
                 tx,
             }
         }
@@ -235,6 +295,13 @@ mod tests {
         /// Block `stop()` until the returned gate is notified.
         fn with_stop_gate(mut self, stop_gate: Arc<Notify>) -> Self {
             self.stop_gate = Some(stop_gate);
+            self
+        }
+
+        /// Delay only the first `stop()` call. Later calls return promptly, so a
+        /// test can tell whether a stop waited for the slow first operation.
+        fn with_first_stop_delay(mut self, delay: Duration) -> Self {
+            self.first_stop_delay = Some(delay);
             self
         }
 
@@ -306,9 +373,12 @@ mod tests {
         }
 
         async fn stop(&self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-            self.stop_calls.fetch_add(1, Ordering::SeqCst);
+            let call_index = self.stop_calls.fetch_add(1, Ordering::SeqCst);
             if let Some(stop_gate) = &self.stop_gate {
                 stop_gate.notified().await;
+            }
+            if let (0, Some(delay)) = (call_index, self.first_stop_delay) {
+                tokio::time::sleep(delay).await;
             }
 
             let result: Result<(), Box<dyn std::error::Error + Send + Sync>> =
@@ -690,6 +760,95 @@ mod tests {
         })
         .await
         .expect("the timed-out stop operation should still complete");
+    }
+
+    /// Long enough that a stop which is *not* awaited would still be running when
+    /// the second call returns, so the assertions below actually discriminate.
+    const SLOW_STOP: Duration = Duration::from_millis(400);
+
+    #[tokio::test]
+    async fn stop_with_timeout_awaits_a_previously_timed_out_stop() {
+        let manager = RuntimeManager::new();
+        // Only the first stop is slow, so the second call's own stop finishes
+        // immediately and the wait observed below can only come from the retained
+        // first operation.
+        let runtime =
+            TestRuntime::new(Behavior::Success, Behavior::Success).with_first_stop_delay(SLOW_STOP);
+        let stop_completions = runtime.stop_completions();
+
+        manager
+            .register_runtime(Arc::new(runtime))
+            .await
+            .expect("register runtime");
+
+        manager
+            .stop_with_timeout(STOP_TIMEOUT)
+            .await
+            .expect_err("the slow stop should miss the deadline");
+        assert_eq!(stop_completions.load(Ordering::SeqCst), 0);
+
+        manager
+            .stop_with_timeout(WATCHDOG)
+            .await
+            .expect("the retained stop and the new one should both complete");
+        assert_eq!(
+            stop_completions.load(Ordering::SeqCst),
+            2,
+            "a successful stop must mean the earlier detached stop finished too"
+        );
+    }
+
+    #[tokio::test]
+    async fn stop_awaits_a_previously_timed_out_stop() {
+        let manager = RuntimeManager::new();
+        let runtime =
+            TestRuntime::new(Behavior::Success, Behavior::Success).with_first_stop_delay(SLOW_STOP);
+        let stop_completions = runtime.stop_completions();
+
+        manager
+            .register_runtime(Arc::new(runtime))
+            .await
+            .expect("register runtime");
+
+        manager
+            .stop_with_timeout(STOP_TIMEOUT)
+            .await
+            .expect_err("the slow stop should miss the deadline");
+        assert_eq!(stop_completions.load(Ordering::SeqCst), 0);
+
+        manager.stop().await.expect("unbounded stop should succeed");
+        assert_eq!(
+            stop_completions.load(Ordering::SeqCst),
+            2,
+            "stop() must not return while an earlier stop is still detached"
+        );
+    }
+
+    #[tokio::test]
+    async fn stop_with_timeout_reports_a_still_unresponsive_retained_stop_once() {
+        let manager = RuntimeManager::new();
+        let runtime = TestRuntime::new(Behavior::Success, Behavior::Hang);
+        let runtime_id = runtime.id();
+
+        manager
+            .register_runtime(Arc::new(runtime))
+            .await
+            .expect("register runtime");
+
+        for _ in 0..2 {
+            let err = timeout(WATCHDOG, manager.stop_with_timeout(STOP_TIMEOUT))
+                .await
+                .expect("stop_with_timeout must not wait indefinitely")
+                .expect_err("the hanging runtime should be reported every time");
+
+            // The retained stop and the fresh one both belong to this runtime, so
+            // it must still be named exactly once.
+            assert!(matches!(
+                &err,
+                RuntimeError::ShutdownTimeout { runtime_ids, .. }
+                if runtime_ids.as_slice() == [runtime_id]
+            ));
+        }
     }
 
     #[test]

--- a/crates/autoagents-core/src/runtime/mod.rs
+++ b/crates/autoagents-core/src/runtime/mod.rs
@@ -5,6 +5,7 @@ use ractor::ActorRef;
 use std::any::{Any, TypeId};
 use std::fmt::Debug;
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::error::SendError;
 use tokio::task::JoinError;
@@ -43,6 +44,17 @@ pub enum RuntimeError {
 
     #[error("Runtime operation failed: {0}")]
     OperationFailed(String),
+
+    /// One or more runtimes did not complete [`Runtime::stop`] within the
+    /// deadline passed to `RuntimeManager::stop_with_timeout`.
+    ///
+    /// `runtime_ids` lists the unresponsive runtimes, sorted so the reported
+    /// order does not depend on registration order.
+    #[error("Runtime shutdown did not complete within {timeout:?}: {runtime_ids:?}")]
+    ShutdownTimeout {
+        runtime_ids: Vec<RuntimeID>,
+        timeout: Duration,
+    },
 
     #[error("Event error: {0}")]
     EventError(#[from] Box<SendError<Event>>),


### PR DESCRIPTION
## Summary

Add an optional timeout-aware shutdown API for AutoAgents runtimes.

`RuntimeManager::stop()` currently waits for every registered runtime to finish
its `stop()` operation without a deadline. If one runtime never completes,
shutdown can wait indefinitely.

This PR adds an opt-in bounded shutdown path while preserving the existing
`RuntimeManager::stop()` and `Environment::shutdown()` behaviour.

Related #295

## Changes

### Add `RuntimeError::ShutdownTimeout`

```rust
RuntimeError::ShutdownTimeout {
    runtime_ids: Vec<RuntimeID>,
    timeout: Duration,
}
```

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds an opt-in timeout-aware runtime shutdown API while preserving the existing unbounded shutdown behavior.
- Adds timeout and incomplete-shutdown errors with runtime IDs and timeout details.
- Retains timed-out or cancellation-interrupted stop tasks so later shutdown attempts can observe them.
- Prevents environment relaunch until detached stop work and the managed run task have completed.
- Adds lifecycle, timeout, recovery, error-precedence, and cancellation tests.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

The previously reported relaunch-state and cancellation-tracking failures are addressed: timed-out stop handles remain tracked, later shutdowns drain them, managed run handles are preserved, and relaunch remains blocked until recovery completes.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/autoagents-core/src/environment.rs | Adds timeout-aware shutdown state handling, preserves managed run handles across cancellation and timeout, and blocks unsafe relaunch until recovery completes. |
| crates/autoagents-core/src/runtime/manager.rs | Tracks stop tasks and observed outcomes in place so timed-out or cancelled shutdown calls leave pending lifecycle work recoverable. |
| crates/autoagents-core/src/runtime/mod.rs | Adds the structured `ShutdownTimeout` runtime error carrying stable runtime IDs and the requested timeout. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Environment running] --> B[shutdown_with_timeout]
  B --> C[RuntimeManager stop_with_timeout]
  C -->|All stops finish| D[Await managed run task]
  C -->|Deadline missed| E[ShutdownIncomplete]
  D -->|Run task finishes| F[Idle]
  D -->|Deadline missed| E
  E -->|run or run_background| G[Reject relaunch]
  E -->|Later shutdown drains retained stops and joins run task| F
```
</details>

<sub>Reviews (6): Last reviewed commit: ["fix(core): retain pending shutdown tasks..."](https://github.com/liquidos-ai/autoagents/commit/572b2998aaa183ba5664e04cbfd0a3f025652eef) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49651817)</sub>

**Context used:**

- Knowledge Base — [Core Agent Runtime](https://app.greptile.com/liquidos/-/custom-context/knowledge-base/liquidos-ai/autoagents/-/docs/core-agent-runtime.md)

<!-- /greptile_comment -->