### PR TITLE
refactor(core): acknowledge single-threaded runtime shutdown

### DIFF
--- a/crates/autoagents-core/src/runtime/single_threaded.rs
+++ b/crates/autoagents-core/src/runtime/single_threaded.rs
@@ -38,11 +38,13 @@ mod lifecycle {
 }
 
 /// Publishes shutdown completion when dropped, so a `stop()` caller waiting on
-/// the completion channel is released however the event loop stops running:
+/// the completion channel is released however the runtime task stops running:
 /// normal exit, an early `?` error, a panic unwind, or task cancellation (the
-/// future being dropped). Without this, an aborted or panicking runtime task
-/// would skip the completion signal, and because the `watch::Sender` lives on
-/// in the shared runtime, `stop()` could neither observe completion nor see the
+/// future being dropped). It is created by `run()` in the same synchronous step
+/// that publishes `RUNNING`, so it covers cancellation even before the event
+/// loop starts. Without this, an aborted or panicking runtime task would skip
+/// the completion signal, and because the `watch::Sender` lives on in the
+/// shared runtime, `stop()` could neither observe completion nor see the
 /// channel close — it would wait forever.
 struct CompletionGuard<'a> {
     tx: &'a watch::Sender<bool>,
@@ -247,15 +249,6 @@ impl SingleThreadedRuntime {
             .take()
             .ok_or("Internal receiver already taken")?;
 
-        // From here on this task owns the event loop, so it is responsible for
-        // acknowledging completion. The guard publishes it on every exit path,
-        // including a panic or the task being cancelled mid-loop. Taking the
-        // receiver first ensures a second `run()` (which fails above) never
-        // falsely signals completion for the loop this task owns.
-        let _completion = CompletionGuard {
-            tx: &self.shutdown_complete_tx,
-        };
-
         info!("Runtime event loop starting");
 
         loop {
@@ -299,8 +292,8 @@ impl SingleThreadedRuntime {
             }
         }
 
-        // Completion is published by `_completion` when it drops at the end of
-        // this scope, i.e. after the drain above has finished.
+        // Completion is published by the `run()` completion guard once this
+        // returns, i.e. after the drain above has finished.
         info!("Runtime event loop stopped");
         Ok(())
     }
@@ -368,11 +361,24 @@ impl Runtime for SingleThreadedRuntime {
     }
 
     async fn run(&self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-        // Claim the running state. If a `stop()` already queued a Shutdown before
-        // the event loop existed (`STOP_BEFORE_RUN`), that request is still
-        // buffered on the internal channel; the loop below will consume it and
-        // exit immediately.
-        self.lifecycle.store(lifecycle::RUNNING, Ordering::SeqCst);
+        // Publish `RUNNING` and install the completion guard as one synchronous
+        // step: there is no `.await` between the swap and the guard binding, so
+        // this task cannot be cancelled in between. That guarantees any `stop()`
+        // which observes `RUNNING` is matched by a guard that will publish
+        // completion on every exit path — including cancellation before the
+        // event loop starts. `swap` also gates re-entry: a second `run()` finds
+        // the state already `RUNNING`, claims nothing, and returns without a
+        // guard, so it can never falsely signal completion for the live loop.
+        //
+        // If a `stop()` already queued a Shutdown before the loop existed
+        // (`STOP_BEFORE_RUN`), that request stays buffered on the internal
+        // channel and the loop below consumes it and exits immediately.
+        if self.lifecycle.swap(lifecycle::RUNNING, Ordering::SeqCst) == lifecycle::RUNNING {
+            return Err("Runtime event loop is already running".into());
+        }
+        let _completion = CompletionGuard {
+            tx: &self.shutdown_complete_tx,
+        };
 
         info!("Starting SingleThreadedRuntime {}", self.id);
         self.event_loop().await

--- a/crates/autoagents-core/src/runtime/single_threaded.rs
+++ b/crates/autoagents-core/src/runtime/single_threaded.rs
@@ -37,6 +37,25 @@ mod lifecycle {
     pub(super) const STOP_BEFORE_RUN: u8 = 2;
 }
 
+/// Publishes shutdown completion when dropped, so a `stop()` caller waiting on
+/// the completion channel is released however the event loop stops running:
+/// normal exit, an early `?` error, a panic unwind, or task cancellation (the
+/// future being dropped). Without this, an aborted or panicking runtime task
+/// would skip the completion signal, and because the `watch::Sender` lives on
+/// in the shared runtime, `stop()` could neither observe completion nor see the
+/// channel close — it would wait forever.
+struct CompletionGuard<'a> {
+    tx: &'a watch::Sender<bool>,
+}
+
+impl Drop for CompletionGuard<'_> {
+    fn drop(&mut self) {
+        // `send_replace` never fails and works even with no receivers, so it is
+        // safe to run while unwinding or during cancellation.
+        self.tx.send_replace(true);
+    }
+}
+
 /// Topic subscription entry storing type information and actor references
 #[derive(Debug)]
 struct Subscription {
@@ -228,6 +247,15 @@ impl SingleThreadedRuntime {
             .take()
             .ok_or("Internal receiver already taken")?;
 
+        // From here on this task owns the event loop, so it is responsible for
+        // acknowledging completion. The guard publishes it on every exit path,
+        // including a panic or the task being cancelled mid-loop. Taking the
+        // receiver first ensures a second `run()` (which fails above) never
+        // falsely signals completion for the loop this task owns.
+        let _completion = CompletionGuard {
+            tx: &self.shutdown_complete_tx,
+        };
+
         info!("Runtime event loop starting");
 
         loop {
@@ -271,10 +299,8 @@ impl SingleThreadedRuntime {
             }
         }
 
-        // Persist the completed state so current and future stop() callers
-        // can observe that shutdown processing has finished.
-        self.shutdown_complete_tx.send_replace(true);
-
+        // Completion is published by `_completion` when it drops at the end of
+        // this scope, i.e. after the drain above has finished.
         info!("Runtime event loop stopped");
         Ok(())
     }
@@ -453,6 +479,37 @@ mod tests {
             received.push(message.content);
             Ok(())
         }
+    }
+
+    /// Transport that only counts dispatches, so lifecycle tests can observe
+    /// that the event loop processed an event without depending on asynchronous
+    /// actor delivery.
+    #[derive(Debug)]
+    struct CountingTransport {
+        delivered: Arc<std::sync::atomic::AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl Transport for CountingTransport {
+        async fn send(
+            &self,
+            _actor: &dyn AnyActor,
+            _msg: Arc<dyn Any + Send + Sync>,
+        ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+            self.delivered.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }
+    }
+
+    /// Build a queued publish event for `topic_name` carrying `content`.
+    fn publish_event(topic_name: &str, content: &str) -> InternalEvent {
+        InternalEvent::ProtocolEvent(Box::new(Event::PublishMessage {
+            topic_name: topic_name.to_string(),
+            topic_type: TypeId::of::<TestMessage>(),
+            message: Arc::new(TestMessage {
+                content: content.to_string(),
+            }) as Arc<dyn Any + Send + Sync>,
+        }))
     }
 
     #[tokio::test]
@@ -922,25 +979,6 @@ mod tests {
 
     #[tokio::test]
     async fn test_completion_published_after_drain() {
-        // A transport that only counts dispatches, so the assertion below depends
-        // on runtime lifecycle state rather than on asynchronous actor delivery.
-        #[derive(Debug)]
-        struct CountingTransport {
-            delivered: Arc<std::sync::atomic::AtomicUsize>,
-        }
-
-        #[async_trait]
-        impl Transport for CountingTransport {
-            async fn send(
-                &self,
-                _actor: &dyn AnyActor,
-                _msg: Arc<dyn Any + Send + Sync>,
-            ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-                self.delivered.fetch_add(1, Ordering::SeqCst);
-                Ok(())
-            }
-        }
-
         let delivered = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let runtime = SingleThreadedRuntime::with_transport(
             None,
@@ -963,22 +1001,12 @@ mod tests {
         let topic = Topic::<TestMessage>::new("drain_topic");
         runtime.subscribe(&topic, actor_ref).await.unwrap();
 
-        let publish_event = |content: &str| {
-            InternalEvent::ProtocolEvent(Box::new(Event::PublishMessage {
-                topic_name: "drain_topic".to_string(),
-                topic_type: TypeId::of::<TestMessage>(),
-                message: Arc::new(TestMessage {
-                    content: content.to_string(),
-                }) as Arc<dyn Any + Send + Sync>,
-            }))
-        };
-
         // Queue an event, then Shutdown, then two more events. The loop processes
         // the first event and breaks on Shutdown; the trailing two can only be
         // handled by the post-shutdown drain path.
         runtime
             .internal_tx
-            .send(publish_event("first"))
+            .send(publish_event("drain_topic", "first"))
             .await
             .unwrap();
         runtime
@@ -988,12 +1016,12 @@ mod tests {
             .unwrap();
         runtime
             .internal_tx
-            .send(publish_event("second"))
+            .send(publish_event("drain_topic", "second"))
             .await
             .unwrap();
         runtime
             .internal_tx
-            .send(publish_event("third"))
+            .send(publish_event("drain_topic", "third"))
             .await
             .unwrap();
 
@@ -1010,6 +1038,73 @@ mod tests {
         assert!(
             *runtime.shutdown_complete_tx.borrow(),
             "completion must be published once draining has finished"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_completion_published_when_run_task_cancelled() {
+        // Regression test: once run() records RUNNING, a stop() caller waits on
+        // the completion channel. If the runtime task is cancelled (or panics)
+        // the event loop's normal epilogue never runs, yet the completion guard
+        // must still fire on drop so the waiter is released instead of hanging
+        // forever on a `watch::Sender` that the shared runtime keeps alive.
+        let delivered = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let runtime = SingleThreadedRuntime::with_transport(
+            None,
+            Arc::new(CountingTransport {
+                delivered: delivered.clone(),
+            }),
+        );
+
+        let received = Arc::new(Mutex::new(Vec::new()));
+        let (actor_ref, _handle) = Actor::spawn(
+            None,
+            TestActor {
+                received: received.clone(),
+            },
+            received.clone(),
+        )
+        .await
+        .unwrap();
+        let topic = Topic::<TestMessage>::new("cancel_topic");
+        runtime.subscribe(&topic, actor_ref).await.unwrap();
+
+        let run_handle = runtime.clone();
+        let runtime_task = tokio::spawn(async move { run_handle.run().await });
+
+        // Drive one event through so the event loop is provably running with its
+        // completion guard installed (the counter only advances inside the loop).
+        runtime
+            .internal_tx
+            .send(publish_event("cancel_topic", "warmup"))
+            .await
+            .unwrap();
+        tokio::time::timeout(Duration::from_secs(5), async {
+            while delivered.load(Ordering::SeqCst) == 0 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("the event loop should process the warmup event");
+
+        // Cancel the task without requesting shutdown: only the completion guard
+        // (run on drop) can release a waiter now.
+        runtime_task.abort();
+        let join = runtime_task.await;
+        assert!(
+            join.is_err(),
+            "the aborted run task should report cancellation"
+        );
+
+        // Completion was published on drop, so stop() returns promptly instead of
+        // waiting forever.
+        tokio::time::timeout(Duration::from_secs(5), runtime.stop())
+            .await
+            .expect("stop() must not hang after the run task was cancelled")
+            .expect("stop() should succeed");
+        assert!(
+            *runtime.shutdown_complete_tx.borrow(),
+            "completion must be published even when the run task is cancelled"
         );
     }
 }

--- a/crates/autoagents-core/src/runtime/single_threaded.rs
+++ b/crates/autoagents-core/src/runtime/single_threaded.rs
@@ -14,14 +14,28 @@ use std::{
     collections::HashMap,
     sync::{
         Arc,
-        atomic::{AtomicBool, Ordering},
+        atomic::{AtomicBool, AtomicU8, Ordering},
     },
 };
-use tokio::sync::{Mutex, Notify, RwLock, broadcast, mpsc};
+use tokio::sync::{Mutex, Notify, RwLock, broadcast, mpsc, watch};
 use tokio_stream::wrappers::{BroadcastStream, errors::BroadcastStreamRecvError};
 use uuid::Uuid;
 
 const DEFAULT_INTERNAL_BUFFER: usize = 1000;
+
+/// Lifecycle states used to make the `run()`/`stop()` startup decision with a
+/// single atomic operation, so "who happened first" is never resolved by a
+/// racy check-then-act. Shutdown *completion* is tracked separately by
+/// `shutdown_complete_tx`; these states only describe the startup transition.
+mod lifecycle {
+    /// `run()` has not started and no `stop()` has claimed the runtime yet.
+    pub(super) const NOT_STARTED: u8 = 0;
+    /// `run()` has started; an event loop exists to acknowledge shutdown.
+    pub(super) const RUNNING: u8 = 1;
+    /// `stop()` won the startup race before `run()`: the Shutdown request is
+    /// queued for a future `run()`, and there is no loop to wait on.
+    pub(super) const STOP_BEFORE_RUN: u8 = 2;
+}
 
 /// Topic subscription entry storing type information and actor references
 #[derive(Debug)]
@@ -47,8 +61,14 @@ pub struct SingleThreadedRuntime {
     // Transport layer for message delivery
     transport: Arc<dyn Transport>,
     // Runtime state
+    // Startup lifecycle state (see `lifecycle`); drives the race-free
+    // decision between `run()` and `stop()`.
+    lifecycle: Arc<AtomicU8>,
     shutdown_flag: Arc<AtomicBool>,
     shutdown_notify: Arc<Notify>,
+    // Published once, after the event loop has drained and exited, so that
+    // `stop()` can await *actual* completion instead of an arbitrary sleep.
+    shutdown_complete_tx: watch::Sender<bool>,
 }
 
 impl SingleThreadedRuntime {
@@ -67,6 +87,7 @@ impl SingleThreadedRuntime {
         let (external_tx, external_rx) = mpsc::channel(buffer_size);
         let (internal_tx, internal_rx) = mpsc::channel(DEFAULT_INTERNAL_BUFFER);
         let (broadcast_tx, _) = broadcast::channel(buffer_size);
+        let (shutdown_complete_tx, _) = watch::channel(false);
 
         Arc::new(Self {
             id,
@@ -77,8 +98,10 @@ impl SingleThreadedRuntime {
             internal_rx: Mutex::new(Some(internal_rx)),
             subscriptions: Arc::new(RwLock::new(HashMap::new())),
             transport,
+            lifecycle: Arc::new(AtomicU8::new(lifecycle::NOT_STARTED)),
             shutdown_flag: Arc::new(AtomicBool::new(false)),
             shutdown_notify: Arc::new(Notify::new()),
+            shutdown_complete_tx,
         })
     }
 
@@ -248,6 +271,10 @@ impl SingleThreadedRuntime {
             }
         }
 
+        // Persist the completed state so current and future stop() callers
+        // can observe that shutdown processing has finished.
+        self.shutdown_complete_tx.send_replace(true);
+
         info!("Runtime event loop stopped");
         Ok(())
     }
@@ -315,29 +342,68 @@ impl Runtime for SingleThreadedRuntime {
     }
 
     async fn run(&self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        // Claim the running state. If a `stop()` already queued a Shutdown before
+        // the event loop existed (`STOP_BEFORE_RUN`), that request is still
+        // buffered on the internal channel; the loop below will consume it and
+        // exit immediately.
+        self.lifecycle.store(lifecycle::RUNNING, Ordering::SeqCst);
+
         info!("Starting SingleThreadedRuntime {}", self.id);
         self.event_loop().await
     }
 
     async fn stop(&self) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-        if self.shutdown_flag.load(Ordering::SeqCst) {
+        let mut shutdown_complete_rx = self.shutdown_complete_tx.subscribe();
+
+        // Shutdown has already completed.
+        if *shutdown_complete_rx.borrow() {
             return Ok(());
         }
 
         info!("Initiating runtime shutdown for {}", self.id);
 
-        // Send shutdown signal
+        // Send the shutdown request.
         if let Err(e) = self.internal_tx.send(InternalEvent::Shutdown).await {
-            if self.shutdown_flag.load(Ordering::SeqCst) {
+            // The runtime may have completed between the initial check
+            // and sending the shutdown request.
+            if *shutdown_complete_rx.borrow() {
                 return Ok(());
             }
+
             return Err(format!("Failed to send shutdown signal: {e}").into());
         }
 
-        // Wait a brief moment for shutdown to complete
-        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+        // Decide atomically whether an event loop exists to acknowledge
+        // completion. Winning this compare-exchange means `run()` has not
+        // started, so there is no loop to wait on: the queued Shutdown stays
+        // buffered for a future `run()`. Losing it means `run()` is live and
+        // will publish completion, so fall through and wait for it. Making this
+        // a single atomic operation removes the check-then-act race where
+        // `run()` could store its state between a plain load and this branch.
+        match self.lifecycle.compare_exchange(
+            lifecycle::NOT_STARTED,
+            lifecycle::STOP_BEFORE_RUN,
+            Ordering::SeqCst,
+            Ordering::SeqCst,
+        ) {
+            // We won before `run()` started, or another `stop()` already claimed
+            // the pre-run state: either way there is no event loop to wait on.
+            Ok(_) | Err(lifecycle::STOP_BEFORE_RUN) => return Ok(()),
+            // `RUNNING`: the event loop is live and will publish completion.
+            Err(_) => {}
+        }
 
-        Ok(())
+        // Wait until the event loop reports actual shutdown completion.
+        loop {
+            if *shutdown_complete_rx.borrow_and_update() {
+                return Ok(());
+            }
+
+            shutdown_complete_rx
+                .changed()
+                .await
+                .map_err(|e| format!("Shutdown completion channel closed: {e}"))?;
+        }
     }
 }
 
@@ -451,7 +517,7 @@ mod tests {
 
         // Shutdown
         runtime.stop().await.unwrap();
-        runtime_task.abort();
+        runtime_task.await.unwrap().unwrap();
     }
 
     #[tokio::test]
@@ -532,7 +598,7 @@ mod tests {
 
         // Shutdown
         runtime.stop().await.unwrap();
-        runtime_task.abort();
+        runtime_task.await.unwrap().unwrap();
     }
 
     #[tokio::test]
@@ -585,7 +651,7 @@ mod tests {
 
         // Shutdown
         runtime.stop().await.unwrap();
-        runtime_task.abort();
+        runtime_task.await.unwrap().unwrap();
     }
 
     #[tokio::test]
@@ -654,7 +720,7 @@ mod tests {
 
         // Shutdown
         runtime.stop().await.unwrap();
-        runtime_task.abort();
+        runtime_task.await.unwrap().unwrap();
     }
 
     #[tokio::test]
@@ -714,7 +780,7 @@ mod tests {
 
         // Shutdown
         runtime.stop().await.unwrap();
-        runtime_task.abort();
+        runtime_task.await.unwrap().unwrap();
     }
 
     #[test]
@@ -731,5 +797,219 @@ mod tests {
         let runtime2 = SingleThreadedRuntime::new(None);
 
         assert_ne!(runtime1.id(), runtime2.id());
+    }
+
+    #[tokio::test]
+    async fn test_stop_waits_for_shutdown_completion() {
+        let runtime = SingleThreadedRuntime::new(None);
+        let runtime_handle = runtime.clone();
+
+        let runtime_task = tokio::spawn(async move { runtime_handle.run().await });
+
+        // Ensure run() has started before requesting shutdown.
+        while runtime.lifecycle.load(Ordering::SeqCst) != lifecycle::RUNNING {
+            tokio::task::yield_now().await;
+        }
+
+        runtime.stop().await.unwrap();
+
+        assert!(
+            *runtime.shutdown_complete_tx.borrow(),
+            "stop() should only return after shutdown completion is acknowledged"
+        );
+
+        runtime_task.await.unwrap().unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_stop_before_run_does_not_hang() {
+        let runtime = SingleThreadedRuntime::new(None);
+
+        tokio::time::timeout(Duration::from_secs(1), runtime.stop())
+            .await
+            .expect("stop() should not hang before run()")
+            .expect("stop() should succeed");
+
+        let runtime_handle = runtime.clone();
+
+        let runtime_task = tokio::spawn(async move { runtime_handle.run().await });
+
+        tokio::time::timeout(Duration::from_secs(1), runtime_task)
+            .await
+            .expect("runtime should process the queued shutdown request")
+            .expect("runtime task should not panic")
+            .expect("runtime should shut down successfully");
+
+        assert!(
+            *runtime.shutdown_complete_tx.borrow(),
+            "shutdown should be completed after the runtime processes the queued request"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_repeated_stop_is_safe() {
+        let runtime = SingleThreadedRuntime::new(None);
+        let runtime_handle = runtime.clone();
+
+        let runtime_task = tokio::spawn(async move { runtime_handle.run().await });
+
+        while runtime.lifecycle.load(Ordering::SeqCst) != lifecycle::RUNNING {
+            tokio::task::yield_now().await;
+        }
+
+        runtime.stop().await.unwrap();
+        runtime.stop().await.unwrap();
+
+        runtime_task.await.unwrap().unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_concurrent_stop_is_safe() {
+        let runtime = SingleThreadedRuntime::new(None);
+        let runtime_handle = runtime.clone();
+
+        let runtime_task = tokio::spawn(async move { runtime_handle.run().await });
+
+        while runtime.lifecycle.load(Ordering::SeqCst) != lifecycle::RUNNING {
+            tokio::task::yield_now().await;
+        }
+
+        let (first, second, third) = tokio::join!(runtime.stop(), runtime.stop(), runtime.stop(),);
+
+        first.unwrap();
+        second.unwrap();
+        third.unwrap();
+
+        runtime_task.await.unwrap().unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_run_stop_startup_race() {
+        // Regression test for the run()/stop() startup race. `run()` and `stop()`
+        // are started concurrently and neither waits for the other, so the
+        // atomic "who happened first" decision is exercised under real
+        // contention. Repeat to widen scheduling coverage while staying
+        // deterministic; an outer timeout turns any lost shutdown or deadlock
+        // into a failure instead of a hung suite.
+        for _ in 0..100 {
+            let runtime = SingleThreadedRuntime::new(None);
+            let run_handle = runtime.clone();
+            let stop_handle = runtime.clone();
+
+            let run_task = tokio::spawn(async move { run_handle.run().await });
+            let stop_task = tokio::spawn(async move { stop_handle.stop().await });
+
+            tokio::time::timeout(Duration::from_secs(5), stop_task)
+                .await
+                .expect("stop() must not hang during the startup race")
+                .expect("stop() task must not panic")
+                .expect("stop() should succeed");
+
+            // Whoever won the race, the shutdown request is never lost: run()
+            // consumes it and exits on its own rather than being left running.
+            tokio::time::timeout(Duration::from_secs(5), run_task)
+                .await
+                .expect("run() must not be left running after stop()")
+                .expect("run() task must not panic")
+                .expect("run() should exit cleanly");
+
+            assert!(
+                *runtime.shutdown_complete_tx.borrow(),
+                "shutdown completion must be published once the race resolves"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_completion_published_after_drain() {
+        // A transport that only counts dispatches, so the assertion below depends
+        // on runtime lifecycle state rather than on asynchronous actor delivery.
+        #[derive(Debug)]
+        struct CountingTransport {
+            delivered: Arc<std::sync::atomic::AtomicUsize>,
+        }
+
+        #[async_trait]
+        impl Transport for CountingTransport {
+            async fn send(
+                &self,
+                _actor: &dyn AnyActor,
+                _msg: Arc<dyn Any + Send + Sync>,
+            ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+                self.delivered.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            }
+        }
+
+        let delivered = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let runtime = SingleThreadedRuntime::with_transport(
+            None,
+            Arc::new(CountingTransport {
+                delivered: delivered.clone(),
+            }),
+        );
+
+        // Subscribe an actor so the topic has a delivery target.
+        let received = Arc::new(Mutex::new(Vec::new()));
+        let (actor_ref, _handle) = Actor::spawn(
+            None,
+            TestActor {
+                received: received.clone(),
+            },
+            received.clone(),
+        )
+        .await
+        .unwrap();
+        let topic = Topic::<TestMessage>::new("drain_topic");
+        runtime.subscribe(&topic, actor_ref).await.unwrap();
+
+        let publish_event = |content: &str| {
+            InternalEvent::ProtocolEvent(Box::new(Event::PublishMessage {
+                topic_name: "drain_topic".to_string(),
+                topic_type: TypeId::of::<TestMessage>(),
+                message: Arc::new(TestMessage {
+                    content: content.to_string(),
+                }) as Arc<dyn Any + Send + Sync>,
+            }))
+        };
+
+        // Queue an event, then Shutdown, then two more events. The loop processes
+        // the first event and breaks on Shutdown; the trailing two can only be
+        // handled by the post-shutdown drain path.
+        runtime
+            .internal_tx
+            .send(publish_event("first"))
+            .await
+            .unwrap();
+        runtime
+            .internal_tx
+            .send(InternalEvent::Shutdown)
+            .await
+            .unwrap();
+        runtime
+            .internal_tx
+            .send(publish_event("second"))
+            .await
+            .unwrap();
+        runtime
+            .internal_tx
+            .send(publish_event("third"))
+            .await
+            .unwrap();
+
+        runtime.run().await.unwrap();
+
+        // run() only returns after the drain loop, and completion is published
+        // last, so both facts must hold together: every queued event was
+        // dispatched, and only then was completion signalled.
+        assert_eq!(
+            delivered.load(Ordering::SeqCst),
+            3,
+            "all queued events, including those drained after shutdown, must be processed"
+        );
+        assert!(
+            *runtime.shutdown_complete_tx.borrow(),
+            "completion must be published once draining has finished"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Replaces the fixed 100ms delay in `SingleThreadedRuntime::stop()` with explicit
shutdown-completion acknowledgement from the runtime event loop.

`stop()` now relies on actual runtime lifecycle completion instead of an
arbitrary sleep.

Closes #<ISSUE_NUMBER>

## Problem

Previously, `SingleThreadedRuntime::stop()` sent
`InternalEvent::Shutdown` and then waited for a fixed 100ms:

```rust
self.internal_tx
    .send(InternalEvent::Shutdown)
    .await?;

tokio::time::sleep(
    tokio::time::Duration::from_millis(100)
).await;
```

This did not guarantee that the runtime event loop had actually completed.

The event loop could:

- finish earlier than 100ms;
- still be draining events after 100ms;
- allow `stop()` to return without confirming lifecycle completion.

There was also a lifecycle edge case around `run()` and `stop()` starting
concurrently that needed deterministic synchronization.

## Changes

- Removed the fixed 100ms delay from `SingleThreadedRuntime::stop()`.
- Added explicit shutdown-completion signalling.
- Publish completion only after the event loop finishes its shutdown/drain path.
- Allow later `stop()` callers to observe already-completed shutdown state.
- Preserve safe repeated `stop()` calls.
- Preserve safe concurrent `stop()` calls.
- Handle `stop()` before `run()` without waiting indefinitely.
- Handle the `run()` / `stop()` startup race deterministically.
- Updated existing tests to join the runtime normally instead of aborting it
  after `stop()`.

## Shutdown Flow

Before:

```text
stop()
  │
  ├── send Shutdown
  ├── sleep 100ms
  └── return
```

Now:

```text
stop()
  │
  ├── request shutdown
  │
  └── wait for completion
             ▲
             │
       drain pending events
             │
       event loop exits
             │
       publish completion
```

## Tests

Added/updated coverage for:

- shutdown completion acknowledgement;
- repeated `stop()` calls;
- concurrent `stop()` calls;
- `stop()` before `run()`;
- `run()` / `stop()` startup race;
- normal runtime task completion after shutdown.

## Compatibility

- No changes to the public `Runtime` trait.
- No new external dependencies.
- No changes to higher-level orchestration APIs.
- Existing shutdown behaviour remains compatible while becoming deterministic.

Related - #300

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaces the runtime’s fixed shutdown delay with lifecycle-state synchronization and explicit completion acknowledgement.
- Atomically resolves the `run()`/`stop()` startup race.
- Uses a completion guard to release shutdown waiters on normal exit, errors, panic, or cancellation.
- Adds coverage for repeated and concurrent stops, pre-run shutdown, startup races, draining, and task cancellation.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/autoagents-core/src/runtime/single_threaded.rs | Introduces atomic startup lifecycle coordination, watch-based shutdown acknowledgement, cancellation-safe completion signaling, and comprehensive lifecycle tests. |

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(core): guard shutdown completion dur..."](https://github.com/liquidos-ai/autoagents/commit/558be8771db20b6b7e72d0d2ee6e829f1fd0b95e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51570921)</sub>

**Context used:**

- Knowledge Base — [Core Agent Runtime](https://app.greptile.com/liquidos/-/custom-context/knowledge-base/liquidos-ai/autoagents/-/docs/core-agent-runtime.md)

<!-- /greptile_comment -->