### PR TITLE
[MAINT]: Fix broken star history chart

### DIFF
--- a/README.de.md
+++ b/README.de.md
@@ -460,4 +460,4 @@ Besonderer Dank an:
 
 ## Star-Verlauf
 
-[![Star History Chart](https://api.star-history.com/svg?repos=liquidos-ai/AutoAgents&type=Date)](https://www.star-history.com/#liquidos-ai/AutoAgents&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=liquidos-ai/AutoAgents&type=Date)](https://star-history.dera.page/#liquidos-ai/AutoAgents&Date)

--- a/README.es.md
+++ b/README.es.md
@@ -460,4 +460,4 @@ Agradecimientos especiales:
 
 ## Historial de estrellas
 
-[![Star History Chart](https://api.star-history.com/svg?repos=liquidos-ai/AutoAgents&type=Date)](https://www.star-history.com/#liquidos-ai/AutoAgents&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=liquidos-ai/AutoAgents&type=Date)](https://star-history.dera.page/#liquidos-ai/AutoAgents&Date)

--- a/README.fr.md
+++ b/README.fr.md
@@ -460,4 +460,4 @@ Remerciements particuliers :
 
 ## Historique des étoiles
 
-[![Star History Chart](https://api.star-history.com/svg?repos=liquidos-ai/AutoAgents&type=Date)](https://www.star-history.com/#liquidos-ai/AutoAgents&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=liquidos-ai/AutoAgents&type=Date)](https://star-history.dera.page/#liquidos-ai/AutoAgents&Date)

--- a/README.ja.md
+++ b/README.ja.md
@@ -459,4 +459,4 @@ AutoAgents はデュアルライセンスです：
 
 ## スター履歴
 
-[![Star History Chart](https://api.star-history.com/svg?repos=liquidos-ai/AutoAgents&type=Date)](https://www.star-history.com/#liquidos-ai/AutoAgents&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=liquidos-ai/AutoAgents&type=Date)](https://star-history.dera.page/#liquidos-ai/AutoAgents&Date)

--- a/README.ko.md
+++ b/README.ko.md
@@ -459,4 +459,4 @@ AutoAgents는 이중 라이선스를 사용합니다:
 
 ## 스타 기록
 
-[![Star History Chart](https://api.star-history.com/svg?repos=liquidos-ai/AutoAgents&type=Date)](https://www.star-history.com/#liquidos-ai/AutoAgents&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=liquidos-ai/AutoAgents&type=Date)](https://star-history.dera.page/#liquidos-ai/AutoAgents&Date)

--- a/README.md
+++ b/README.md
@@ -485,4 +485,4 @@ Special thanks to:
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=liquidos-ai/AutoAgents&type=Date)](https://www.star-history.com/#liquidos-ai/AutoAgents&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=liquidos-ai/AutoAgents&type=Date)](https://star-history.dera.page/#liquidos-ai/AutoAgents&Date)

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -460,4 +460,4 @@ Agradecimentos especiais:
 
 ## Histórico de estrelas
 
-[![Star History Chart](https://api.star-history.com/svg?repos=liquidos-ai/AutoAgents&type=Date)](https://www.star-history.com/#liquidos-ai/AutoAgents&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=liquidos-ai/AutoAgents&type=Date)](https://star-history.dera.page/#liquidos-ai/AutoAgents&Date)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -459,4 +459,4 @@ AutoAgents 采用双许可证：
 
 ## Star 历史
 
-[![Star History Chart](https://api.star-history.com/svg?repos=liquidos-ai/AutoAgents&type=Date)](https://www.star-history.com/#liquidos-ai/AutoAgents&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=liquidos-ai/AutoAgents&type=Date)](https://star-history.dera.page/#liquidos-ai/AutoAgents&Date)


### PR DESCRIPTION
The star history chart at the bottom of the README was broken and no longer rendered correctly. This change updates the chart links in README.md and all localized README files so the visualization works again, keeping the project's stargazer history visible to visitors.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the broken Star History image and destination URLs with the revived `star-history.dera.page` service.
- Updates the primary English README.
- Applies the same chart URL consistently across all seven localized READMEs.

<h3>Confidence Score: 5/5</h3>

The documentation-only PR appears safe to merge.

The replacement chart and destination URLs are applied consistently across every README variant, with no code, build, security, or repository-contract regressions identified.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| README.md | Replaces both Star History URLs consistently; no actionable issue identified. |
| README.de.md | Applies the same working chart-link replacement to the German README. |
| README.es.md | Applies the same working chart-link replacement to the Spanish README. |
| README.fr.md | Applies the same working chart-link replacement to the French README. |
| README.ja.md | Applies the same working chart-link replacement to the Japanese README. |
| README.ko.md | Applies the same working chart-link replacement to the Korean README. |
| README.pt-BR.md | Applies the same working chart-link replacement to the Brazilian Portuguese README. |
| README.zh-CN.md | Applies the same working chart-link replacement to the Simplified Chinese README. |

</details>

<sub>Reviews (1): Last reviewed commit: ["\[MAINT\]: Fix broken star history chart"](https://github.com/liquidos-ai/autoagents/commit/3e5afa7c06c8d84dea0a899bc307c48fadbb9d3d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53753702)</sub>

<!-- /greptile_comment -->