### PR TITLE
fix(core): propagate single-threaded runtime processing errors

### DIFF
--- a/crates/autoagents-core/src/runtime/single_threaded.rs
+++ b/crates/autoagents-core/src/runtime/single_threaded.rs
@@ -251,6 +251,12 @@ impl SingleThreadedRuntime {
 
         info!("Runtime event loop starting");
 
+        // Records the first error that terminates normal event processing. It is
+        // preserved across the drain/cleanup below and returned once the loop
+        // has finished, so a real processing failure is never masked by the
+        // `Ok(())` epilogue. A graceful `Shutdown` leaves this `None`.
+        let mut terminal_error: Option<Error> = None;
+
         loop {
             tokio::select! {
                 // Process internal events
@@ -266,6 +272,7 @@ impl SingleThreadedRuntime {
 
                     if let Err(e) = self.process_internal_event(event).await {
                         error!("Error processing internal event: {e}");
+                        terminal_error = Some(e);
                         break;
                     }
                 }
@@ -284,7 +291,10 @@ impl SingleThreadedRuntime {
             }
         }
 
-        // Drain remaining events
+        // Drain remaining events regardless of why the loop exited. A drain
+        // failure is only logged, never returned: the first terminal error above
+        // must win, and a graceful shutdown must not be turned into an error by a
+        // late drain failure.
         info!("Draining remaining events before shutdown");
         while let Ok(event) = internal_rx.try_recv() {
             if let Err(e) = self.process_internal_event(event).await {
@@ -295,6 +305,9 @@ impl SingleThreadedRuntime {
         // Completion is published by the `run()` completion guard once this
         // returns, i.e. after the drain above has finished.
         info!("Runtime event loop stopped");
+        if let Some(error) = terminal_error {
+            return Err(error.into());
+        }
         Ok(())
     }
 }
@@ -1044,6 +1057,121 @@ mod tests {
         assert!(
             *runtime.shutdown_complete_tx.borrow(),
             "completion must be published once draining has finished"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_processing_error_propagates_from_run() {
+        // Regression test for the bug where a terminal event-processing failure
+        // was swallowed and `run()` returned `Ok(())`. Dropping the external
+        // receiver closes the external channel, so forwarding a non-publish
+        // protocol event fails inside `process_protocol_event`, which is the
+        // real production path that terminates the event loop.
+        let runtime = SingleThreadedRuntime::new(None);
+        drop(runtime.take_event_receiver().await);
+
+        runtime
+            .internal_tx
+            .send(InternalEvent::ProtocolEvent(Box::new(Event::SendMessage {
+                message: "boom".to_string(),
+                actor_id: Uuid::new_v4(),
+            })))
+            .await
+            .unwrap();
+
+        let result = runtime.run().await;
+        assert!(
+            result.is_err(),
+            "run() must surface a terminal event-processing failure"
+        );
+        let message = result.unwrap_err().to_string();
+        assert!(
+            message.contains("Event error"),
+            "expected the forwarding failure to be preserved, got: {message}"
+        );
+
+        // The completion guard must still publish terminal state on the error
+        // path so a waiting `stop()` is released.
+        assert!(
+            *runtime.shutdown_complete_tx.borrow(),
+            "completion must be published even when run() returns an error"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_graceful_shutdown_returns_ok() {
+        // A normal shutdown must remain a success: it must not be turned into an
+        // error by the new terminal-error propagation.
+        let runtime = SingleThreadedRuntime::new(None);
+        let runtime_handle = runtime.clone();
+        let runtime_task = tokio::spawn(async move { runtime_handle.run().await });
+
+        while runtime.lifecycle.load(Ordering::SeqCst) != lifecycle::RUNNING {
+            tokio::task::yield_now().await;
+        }
+
+        runtime.stop().await.expect("graceful stop should succeed");
+        runtime_task
+            .await
+            .expect("runtime task should not panic")
+            .expect("graceful shutdown must return Ok(())");
+    }
+
+    #[tokio::test]
+    async fn test_drain_failure_does_not_replace_original_error() {
+        // First terminal error wins: a failure while draining must not overwrite
+        // the error that originally terminated normal processing.
+        let runtime = SingleThreadedRuntime::new(None);
+
+        // Register a subscription so a type-mismatched publish yields a
+        // deterministic TopicTypeMismatch as the first terminal error.
+        let received = Arc::new(Mutex::new(Vec::new()));
+        let (actor_ref, _handle) = Actor::spawn(
+            None,
+            TestActor {
+                received: received.clone(),
+            },
+            received.clone(),
+        )
+        .await
+        .unwrap();
+        let topic = Topic::<TestMessage>::new("drain_precedence");
+        runtime.subscribe(&topic, actor_ref).await.unwrap();
+
+        // Close the external channel so the drained event fails too.
+        drop(runtime.take_event_receiver().await);
+
+        // First event: type-mismatched publish -> TopicTypeMismatch (terminal).
+        runtime
+            .internal_tx
+            .send(InternalEvent::ProtocolEvent(Box::new(
+                Event::PublishMessage {
+                    topic_name: "drain_precedence".to_string(),
+                    topic_type: TypeId::of::<u8>(),
+                    message: Arc::new(0u8) as Arc<dyn Any + Send + Sync>,
+                },
+            )))
+            .await
+            .unwrap();
+        // Second event: routed to the closed external channel -> EventError,
+        // encountered only during the post-break drain.
+        runtime
+            .internal_tx
+            .send(InternalEvent::ProtocolEvent(Box::new(Event::SendMessage {
+                message: "drain".to_string(),
+                actor_id: Uuid::new_v4(),
+            })))
+            .await
+            .unwrap();
+
+        let err = runtime
+            .run()
+            .await
+            .expect_err("the terminal processing failure must propagate");
+        let message = err.to_string();
+        assert!(
+            message.contains("TopicTypeMismatch"),
+            "the first terminal error must win over a later drain failure, got: {message}"
         );
     }
 

--- a/crates/autoagents-core/src/runtime/single_threaded.rs
+++ b/crates/autoagents-core/src/runtime/single_threaded.rs
@@ -1077,7 +1077,7 @@ mod tests {
                 actor_id: Uuid::new_v4(),
             })))
             .await
-            .unwrap();
+            .expect("queuing the terminal event should succeed");
 
         let result = runtime.run().await;
         assert!(
@@ -1134,9 +1134,12 @@ mod tests {
             received.clone(),
         )
         .await
-        .unwrap();
+        .expect("spawning the test actor should succeed");
         let topic = Topic::<TestMessage>::new("drain_precedence");
-        runtime.subscribe(&topic, actor_ref).await.unwrap();
+        runtime
+            .subscribe(&topic, actor_ref)
+            .await
+            .expect("subscribing the test actor should succeed");
 
         // Close the external channel so the drained event fails too.
         drop(runtime.take_event_receiver().await);
@@ -1152,7 +1155,7 @@ mod tests {
                 },
             )))
             .await
-            .unwrap();
+            .expect("queuing the type-mismatched event should succeed");
         // Second event: routed to the closed external channel -> EventError,
         // encountered only during the post-break drain.
         runtime
@@ -1162,7 +1165,7 @@ mod tests {
                 actor_id: Uuid::new_v4(),
             })))
             .await
-            .unwrap();
+            .expect("queuing the drain event should succeed");
 
         let err = runtime
             .run()


### PR DESCRIPTION
## Summary

Fixes `SingleThreadedRuntime` reporting a successful runtime exit when normal internal event processing terminates with an error.

Previously, `event_loop()` logged an error from `process_internal_event()`, broke out of the main loop, drained the remaining queued events, and eventually returned `Ok(())`.

This could make an abnormal runtime termination appear as a successful shutdown.

## Problem

The previous flow was effectively:

```text
process_internal_event()
        |
        v
       Err
        |
        v
log error
        |
        v
break event loop
        |
        v
drain queued events
        |
        v
Ok(())
```

As a result, callers of `Runtime::run()` could not reliably distinguish an internal processing failure from a normal runtime exit.

## Changes

- Preserve the terminal error that causes normal event processing to stop.
- Continue running the existing drain/cleanup path.
- Return the original processing error after cleanup.
- Keep graceful shutdown returning `Ok(())`.
- Preserve the first terminal error if additional errors occur while draining.
- Add regression coverage for the failure-propagation behavior.

## Expected behavior

```text
graceful shutdown
        |
        v
Ok(())

event processing failure
        |
        v
cleanup / drain
        |
        v
Err(original_error)
```

Closes #302

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR preserves the first error that terminates normal event processing, drains queued events, and then returns that error instead of reporting successful completion.
- Keeps graceful shutdown successful.
- Preserves the original terminal error when later drain operations fail.
- Adds regression tests for propagation, graceful shutdown, completion signaling, and error precedence.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/autoagents-core/src/runtime/single_threaded.rs | Preserves and returns the first main-loop processing error after the existing drain path, with focused lifecycle and precedence regression coverage. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Process internal event] --> B{Processing result}
  B -->|Success| A
  B -->|Graceful shutdown| C[Drain queued events]
  B -->|Error| D[Store first terminal error]
  D --> C
  C --> E{Stored terminal error?}
  E -->|Yes| F[Return original error]
  E -->|No| G[Return success]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["error handling"](https://github.com/liquidos-ai/autoagents/commit/e77d21f8c4c26ea36fd4a99537d7628c2d84be42) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53762180)</sub>

**Context used:**

- Knowledge Base — [Core Agent Runtime](https://app.greptile.com/liquidos/-/custom-context/knowledge-base/liquidos-ai/autoagents/-/docs/core-agent-runtime.md)

<!-- /greptile_comment -->