### PR TITLE
[BUG]: Preserve reasoning content in tool-call history

### DIFF
--- a/bindings/python/autoagents/src/agent/py_agent.rs
+++ b/bindings/python/autoagents/src/agent/py_agent.rs
@@ -807,6 +807,7 @@ fn parse_tool_calls_from_value(value: Option<&Value>) -> Result<Vec<ToolCall>, S
 fn parse_chat_message_from_any(value: &Bound<'_, PyAny>) -> PyResult<ChatMessage> {
     if let Ok(content) = value.extract::<String>() {
         return Ok(ChatMessage {
+            reasoning_content: None,
             role: ChatRole::User,
             message_type: MessageType::Text,
             content,
@@ -851,11 +852,16 @@ fn parse_chat_message_from_any(value: &Bound<'_, PyAny>) -> PyResult<ChatMessage
         .or_else(|| object.get("text"))
         .and_then(Value::as_str)
         .unwrap_or_default();
+    let reasoning_content = object
+        .get("reasoning_content")
+        .and_then(Value::as_str)
+        .map(str::to_owned);
 
     Ok(ChatMessage {
         role,
         message_type,
         content: content.to_string(),
+        reasoning_content,
     })
 }
 
@@ -1507,6 +1513,7 @@ mod tests {
                     "role": "assistant",
                     "message_type": "tool_use",
                     "content": "tool request",
+                    "reasoning_content": "inspect the workspace",
                     "tool_calls": tool_call,
                 }),
             )
@@ -1515,6 +1522,10 @@ mod tests {
                 .expect("tool message should parse");
             assert_eq!(parsed.role, ChatRole::Assistant);
             assert!(matches!(parsed.message_type, MessageType::ToolUse(_)));
+            assert_eq!(
+                parsed.reasoning_content.as_deref(),
+                Some("inspect the workspace")
+            );
 
             let list = json_value_to_py(
                 py,

--- a/bindings/python/autoagents/src/llm/pipeline.rs
+++ b/bindings/python/autoagents/src/llm/pipeline.rs
@@ -635,6 +635,7 @@ mod tests {
 
     fn sample_message() -> ChatMessage {
         ChatMessage {
+            reasoning_content: None,
             role: ChatRole::User,
             message_type: MessageType::Text,
             content: "hello".to_string(),

--- a/bindings/python/autoagents/src/memory/mod.rs
+++ b/bindings/python/autoagents/src/memory/mod.rs
@@ -80,11 +80,16 @@ fn parse_chat_message_value(value: serde_json::Value) -> Result<ChatMessage, LLM
         .and_then(serde_json::Value::as_str)
         .unwrap_or_default()
         .to_string();
+    let reasoning_content = object
+        .get("reasoning_content")
+        .and_then(serde_json::Value::as_str)
+        .map(str::to_owned);
 
     Ok(ChatMessage {
         role,
         message_type: MessageType::Text,
         content,
+        reasoning_content,
     })
 }
 
@@ -321,6 +326,7 @@ mod tests {
             );
 
             let typed = serde_json::to_value(ChatMessage {
+                reasoning_content: None,
                 role: ChatRole::User,
                 message_type: MessageType::Text,
                 content: "hello".to_string(),
@@ -331,11 +337,19 @@ mod tests {
             assert_eq!(typed_message.role, ChatRole::User);
             assert_eq!(typed_message.content, "hello");
 
-            let dict = json!({"role": "assistant", "content": "world"});
+            let dict = json!({
+                "role": "assistant",
+                "content": "world",
+                "reasoning_content": "inspect the workspace"
+            });
             let dict_message =
                 parse_chat_message_value(dict).expect("dict message should fall back");
             assert_eq!(dict_message.role, ChatRole::Assistant);
             assert_eq!(dict_message.content, "world");
+            assert_eq!(
+                dict_message.reasoning_content.as_deref(),
+                Some("inspect the workspace")
+            );
 
             let py_messages = json_value_to_py(
                 py,
@@ -373,6 +387,7 @@ mod tests {
 
             runtime
                 .block_on(memory.remember(&ChatMessage {
+                    reasoning_content: None,
                     role: ChatRole::User,
                     message_type: MessageType::Text,
                     content: "hello".to_string(),

--- a/crates/autoagents-core/benches/agent_runtime.rs
+++ b/crates/autoagents-core/benches/agent_runtime.rs
@@ -86,6 +86,7 @@ fn bench_tool_defs() -> Vec<Tool> {
 
 fn bench_tool_result_message() -> ChatMessage {
     ChatMessage {
+        reasoning_content: None,
         role: ChatRole::Tool,
         message_type: MessageType::ToolResult(vec![default_tool_call()]),
         content: String::default(),

--- a/crates/autoagents-core/src/agent/executor/memory_helper.rs
+++ b/crates/autoagents-core/src/agent/executor/memory_helper.rs
@@ -37,6 +37,24 @@ impl MemoryHelper {
         tool_results: &[ToolCallResult],
         response_text: &str,
     ) -> Result<(), LLMError> {
+        Self::store_tool_interaction_with_reasoning(
+            memory,
+            tool_calls,
+            tool_results,
+            response_text,
+            None,
+        )
+        .await
+    }
+
+    /// Store tool calls, results, and assistant reasoning in memory
+    pub async fn store_tool_interaction_with_reasoning(
+        memory: &Option<Arc<Mutex<Box<dyn MemoryProvider>>>>,
+        tool_calls: &[ToolCall],
+        tool_results: &[ToolCallResult],
+        response_text: &str,
+        reasoning_content: Option<&str>,
+    ) -> Result<(), LLMError> {
         if let Some(mem) = memory {
             let result_tool_calls =
                 ToolProcessor::create_result_tool_calls(tool_calls, tool_results);
@@ -45,11 +63,15 @@ impl MemoryHelper {
                     role: ChatRole::Assistant,
                     message_type: MessageType::ToolUse(tool_calls.to_vec()),
                     content: response_text.to_string(),
+                    reasoning_content: reasoning_content
+                        .filter(|content| !content.is_empty())
+                        .map(str::to_owned),
                 },
                 ChatMessage {
                     role: ChatRole::Tool,
                     message_type: MessageType::ToolResult(result_tool_calls),
                     content: String::default(),
+                    reasoning_content: None,
                 },
             ];
 
@@ -68,12 +90,14 @@ impl MemoryHelper {
             let mut mem = mem.lock().await;
             let message = if let Some((mime, data)) = image {
                 ChatMessage {
+                    reasoning_content: None,
                     role: ChatRole::User,
                     message_type: MessageType::Image((mime.into(), data)),
                     content,
                 }
             } else {
                 ChatMessage {
+                    reasoning_content: None,
                     role: ChatRole::User,
                     message_type: MessageType::Text,
                     content,
@@ -92,6 +116,7 @@ impl MemoryHelper {
         Self::store_message(
             memory,
             ChatMessage {
+                reasoning_content: None,
                 role: ChatRole::Assistant,
                 message_type: MessageType::Text,
                 content: response,
@@ -173,6 +198,7 @@ mod tests {
         MemoryHelper::store_message(
             &None,
             ChatMessage {
+                reasoning_content: None,
                 role: ChatRole::User,
                 message_type: MessageType::Text,
                 content: "test".to_string(),
@@ -188,6 +214,7 @@ mod tests {
         MemoryHelper::store_message(
             &Some(mem.clone()),
             ChatMessage {
+                reasoning_content: None,
                 role: ChatRole::User,
                 message_type: MessageType::Text,
                 content: "hello".to_string(),
@@ -270,11 +297,22 @@ mod tests {
             arguments: serde_json::json!({}),
             result: serde_json::json!("ok"),
         }];
-        MemoryHelper::store_tool_interaction(&Some(mem.clone()), &calls, &results, "text")
-            .await
-            .unwrap();
+        MemoryHelper::store_tool_interaction_with_reasoning(
+            &Some(mem.clone()),
+            &calls,
+            &results,
+            "text",
+            Some("inspect the workspace"),
+        )
+        .await
+        .unwrap();
         let stored = mem.lock().await.recall("", None).await.unwrap();
         assert_eq!(stored.len(), 2);
+        assert_eq!(
+            stored[0].reasoning_content.as_deref(),
+            Some("inspect the workspace")
+        );
+        assert!(stored[1].reasoning_content.is_none());
     }
 
     #[tokio::test]
@@ -288,6 +326,7 @@ mod tests {
     async fn test_store_message_returns_memory_write_failure() {
         let mem = make_failing_memory();
         let message = ChatMessage {
+            reasoning_content: None,
             role: ChatRole::User,
             message_type: MessageType::Text,
             content: "test".to_string(),
@@ -343,6 +382,7 @@ mod tests {
         for content in ["Message 1", "Message 2"] {
             memory
                 .remember(&ChatMessage {
+                    reasoning_content: None,
                     role: ChatRole::User,
                     message_type: MessageType::Text,
                     content: content.to_string(),
@@ -390,6 +430,7 @@ mod tests {
         MemoryHelper::store_message(
             &Some(mem.clone()),
             ChatMessage {
+                reasoning_content: None,
                 role: ChatRole::User,
                 message_type: MessageType::Text,
                 content: "msg1".to_string(),
@@ -400,6 +441,7 @@ mod tests {
         MemoryHelper::store_message(
             &Some(mem.clone()),
             ChatMessage {
+                reasoning_content: None,
                 role: ChatRole::Assistant,
                 message_type: MessageType::Text,
                 content: "msg2".to_string(),

--- a/crates/autoagents-core/src/agent/executor/memory_policy.rs
+++ b/crates/autoagents-core/src/agent/executor/memory_policy.rs
@@ -280,12 +280,22 @@ mod tests {
             result: serde_json::json!("ok"),
         }];
         adapter
-            .store_tool_interaction(&tool_calls, &results, "text")
+            .store_tool_interaction_with_reasoning(
+                &tool_calls,
+                &results,
+                "text",
+                Some("inspect the workspace"),
+            )
             .await
             .unwrap();
         let stored = mem_arc.lock().await.recall("", None).await.unwrap();
         // Stores 2 messages: assistant ToolUse + Tool ToolResult
         assert_eq!(stored.len(), 2);
+        assert_eq!(
+            stored[0].reasoning_content.as_deref(),
+            Some("inspect the workspace")
+        );
+        assert!(stored[1].reasoning_content.is_none());
     }
 
     #[tokio::test]
@@ -349,6 +359,7 @@ mod tests {
         for content in ["Message 1", "Message 2"] {
             memory
                 .remember(&ChatMessage {
+                    reasoning_content: None,
                     role: ChatRole::User,
                     message_type: MessageType::Text,
                     content: content.to_string(),
@@ -442,12 +453,14 @@ impl MemoryAdapter {
         };
         let message = if let Some((mime, data)) = &task.image {
             ChatMessage {
+                reasoning_content: None,
                 role: ChatRole::User,
                 message_type: MessageType::Image(((*mime).into(), data.clone())),
                 content: task.prompt.clone(),
             }
         } else {
             ChatMessage {
+                reasoning_content: None,
                 role: ChatRole::User,
                 message_type: MessageType::Text,
                 content: task.prompt.clone(),
@@ -464,6 +477,7 @@ impl MemoryAdapter {
             return Ok(());
         };
         let message = ChatMessage {
+            reasoning_content: None,
             role: ChatRole::Assistant,
             message_type: MessageType::Text,
             content: response.to_string(),
@@ -477,6 +491,18 @@ impl MemoryAdapter {
         tool_results: &[ToolCallResult],
         response_text: &str,
     ) -> Result<(), LLMError> {
+        self.store_tool_interaction_with_reasoning(tool_calls, tool_results, response_text, None)
+            .await
+    }
+
+    /// Store tool calls, results, and optional assistant reasoning in memory.
+    pub async fn store_tool_interaction_with_reasoning(
+        &self,
+        tool_calls: &[ToolCall],
+        tool_results: &[ToolCallResult],
+        response_text: &str,
+        reasoning_content: Option<&str>,
+    ) -> Result<(), LLMError> {
         if !self.policy.store_tool_interactions {
             return Ok(());
         }
@@ -489,11 +515,15 @@ impl MemoryAdapter {
                 role: ChatRole::Assistant,
                 message_type: MessageType::ToolUse(tool_calls.to_vec()),
                 content: response_text.to_string(),
+                reasoning_content: reasoning_content
+                    .filter(|content| !content.is_empty())
+                    .map(str::to_owned),
             },
             ChatMessage {
                 role: ChatRole::Tool,
                 message_type: MessageType::ToolResult(result_tool_calls),
                 content: String::default(),
+                reasoning_content: None,
             },
         ];
 

--- a/crates/autoagents-core/src/agent/executor/turn_engine.rs
+++ b/crates/autoagents-core/src/agent/executor/turn_engine.rs
@@ -202,7 +202,12 @@ impl TurnEngine {
 
             turn_state
                 .memory
-                .store_tool_interaction(&tool_calls, &tool_results, &response_text)
+                .store_tool_interaction_with_reasoning(
+                    &tool_calls,
+                    &tool_results,
+                    &response_text,
+                    Some(&reasoning_content),
+                )
                 .await?;
             record_tool_calls_state(context, &tool_results);
 
@@ -491,7 +496,12 @@ impl TurnEngine {
         .await;
 
         memory
-            .store_tool_interaction(&tool_calls, &tool_results, &response_text)
+            .store_tool_interaction_with_reasoning(
+                &tool_calls,
+                &tool_results,
+                &response_text,
+                Some(&reasoning_content),
+            )
             .await?;
         record_tool_calls_state(context, &tool_results);
 
@@ -587,6 +597,7 @@ impl TurnEngine {
             .as_deref()
             .unwrap_or_else(|| &context.config().description);
         let mut messages = vec![ChatMessage {
+            reasoning_content: None,
             role: ChatRole::System,
             message_type: MessageType::Text,
             content: system_prompt.to_string(),
@@ -618,12 +629,14 @@ pub fn record_task_state(context: &Context, task: &Task) {
 fn user_message(task: &Task) -> ChatMessage {
     if let Some((mime, image_data)) = &task.image {
         ChatMessage {
+            reasoning_content: None,
             role: ChatRole::User,
             message_type: MessageType::Image(((*mime).into(), image_data.clone())),
             content: task.prompt.clone(),
         }
     } else {
         ChatMessage {
+            reasoning_content: None,
             role: ChatRole::User,
             message_type: MessageType::Text,
             content: task.prompt.clone(),
@@ -1224,7 +1237,7 @@ mod tests {
                 text: Some("Use tool".to_string()),
                 tool_calls: Some(vec![tool_call.clone()]),
                 usage: None,
-                thinking: None,
+                thinking: Some("inspect the workspace".to_string()),
             },
             ..ConfigurableLLMProvider::default()
         });
@@ -1236,9 +1249,11 @@ mod tests {
             output_schema: None,
         };
         let tool = LocalTool::new("tool_a", serde_json::json!({"ok": true}));
+        let memory: Box<dyn MemoryProvider> = Box::new(SlidingWindowMemory::new(20));
         let context = Context::new(llm, None)
             .with_config(config)
-            .with_tools(vec![Box::new(tool)]);
+            .with_tools(vec![Box::new(tool)])
+            .with_memory(Some(Arc::new(tokio::sync::Mutex::new(memory))));
 
         let engine = TurnEngine::new(TurnEngineConfig {
             max_turns: 2,
@@ -1268,6 +1283,16 @@ mod tests {
         if let Ok(state) = context.state().try_lock() {
             assert_eq!(state.tool_calls.len(), 1);
         }
+
+        let stored = recalled_messages(&context).await;
+        let assistant_tool_message = stored
+            .iter()
+            .find(|message| matches!(message.message_type, MessageType::ToolUse(_)))
+            .expect("assistant tool message should be stored");
+        assert_eq!(
+            assistant_tool_message.reasoning_content.as_deref(),
+            Some("inspect the workspace")
+        );
     }
 
     #[tokio::test]
@@ -1506,7 +1531,7 @@ mod tests {
 
         let llm = Arc::new(ConfigurableLLMProvider {
             stream_chunks: vec![
-                StreamChunk::Text("thinking".to_string()),
+                StreamChunk::ReasoningContent("inspect the workspace".to_string()),
                 StreamChunk::ToolUseComplete {
                     index: 0,
                     tool_call: tool_call.clone(),
@@ -1525,10 +1550,12 @@ mod tests {
             output_schema: None,
         };
         let tool = LocalTool::new("tool_a", serde_json::json!({"ok": true}));
+        let memory: Box<dyn MemoryProvider> = Box::new(SlidingWindowMemory::new(20));
         let context = Arc::new(
             Context::new(llm, None)
                 .with_config(config)
-                .with_tools(vec![Box::new(tool)]),
+                .with_tools(vec![Box::new(tool)])
+                .with_memory(Some(Arc::new(tokio::sync::Mutex::new(memory)))),
         );
         let engine = TurnEngine::new(TurnEngineConfig {
             max_turns: 1,
@@ -1541,7 +1568,7 @@ mod tests {
         let hooks = MockAgentImpl::new("test", "test");
 
         let mut stream = engine
-            .run_turn_stream(hooks, &task, context, &mut turn_state, 0, 1)
+            .run_turn_stream(hooks, &task, context.clone(), &mut turn_state, 0, 1)
             .await
             .unwrap();
 
@@ -1560,6 +1587,16 @@ mod tests {
             }
             _ => panic!("expected Continue(Some)"),
         }
+
+        let stored = recalled_messages(&context).await;
+        let assistant_tool_message = stored
+            .iter()
+            .find(|message| matches!(message.message_type, MessageType::ToolUse(_)))
+            .expect("assistant tool message should be stored");
+        assert_eq!(
+            assistant_tool_message.reasoning_content.as_deref(),
+            Some("inspect the workspace")
+        );
     }
 
     #[tokio::test]

--- a/crates/autoagents-core/src/agent/memory/mod.rs
+++ b/crates/autoagents-core/src/agent/memory/mod.rs
@@ -137,6 +137,7 @@ mod tests {
     fn test_message_condition_any() {
         let condition = MessageCondition::Any;
         let message = ChatMessage {
+            reasoning_content: None,
             role: ChatRole::User,
             message_type: MessageType::Text,
             content: "test message".to_string(),
@@ -152,6 +153,7 @@ mod tests {
     fn test_message_condition_eq() {
         let condition = MessageCondition::Eq("test message".to_string());
         let message = ChatMessage {
+            reasoning_content: None,
             role: ChatRole::User,
             message_type: MessageType::Text,
             content: "test message".to_string(),
@@ -163,6 +165,7 @@ mod tests {
         assert!(condition.matches(&event));
 
         let different_message = ChatMessage {
+            reasoning_content: None,
             role: ChatRole::User,
             message_type: MessageType::Text,
             content: "different message".to_string(),
@@ -178,6 +181,7 @@ mod tests {
     fn test_message_condition_contains() {
         let condition = MessageCondition::Contains("test".to_string());
         let message = ChatMessage {
+            reasoning_content: None,
             role: ChatRole::User,
             message_type: MessageType::Text,
             content: "this is a test message".to_string(),
@@ -189,6 +193,7 @@ mod tests {
         assert!(condition.matches(&event));
 
         let non_matching_message = ChatMessage {
+            reasoning_content: None,
             role: ChatRole::User,
             message_type: MessageType::Text,
             content: "this is different".to_string(),
@@ -204,6 +209,7 @@ mod tests {
     fn test_message_condition_not_contains() {
         let condition = MessageCondition::NotContains("error".to_string());
         let message = ChatMessage {
+            reasoning_content: None,
             role: ChatRole::User,
             message_type: MessageType::Text,
             content: "this is a test message".to_string(),
@@ -215,6 +221,7 @@ mod tests {
         assert!(condition.matches(&event));
 
         let error_message = ChatMessage {
+            reasoning_content: None,
             role: ChatRole::User,
             message_type: MessageType::Text,
             content: "this is an error message".to_string(),
@@ -230,6 +237,7 @@ mod tests {
     fn test_message_condition_role_is() {
         let condition = MessageCondition::RoleIs("user".to_string());
         let message = ChatMessage {
+            reasoning_content: None,
             role: ChatRole::User,
             message_type: MessageType::Text,
             content: "test message".to_string(),
@@ -243,6 +251,7 @@ mod tests {
         let assistant_event = MessageEvent {
             role: "assistant".to_string(),
             msg: ChatMessage {
+                reasoning_content: None,
                 role: ChatRole::Assistant,
                 message_type: MessageType::Text,
                 content: "test message".to_string(),
@@ -255,6 +264,7 @@ mod tests {
     fn test_message_condition_role_not() {
         let condition = MessageCondition::RoleNot("system".to_string());
         let message = ChatMessage {
+            reasoning_content: None,
             role: ChatRole::User,
             message_type: MessageType::Text,
             content: "test message".to_string(),
@@ -268,6 +278,7 @@ mod tests {
         let system_event = MessageEvent {
             role: "system".to_string(),
             msg: ChatMessage {
+                reasoning_content: None,
                 role: ChatRole::System,
                 message_type: MessageType::Text,
                 content: "test message".to_string(),
@@ -280,6 +291,7 @@ mod tests {
     fn test_message_condition_len_gt() {
         let condition = MessageCondition::LenGt(5);
         let long_message = ChatMessage {
+            reasoning_content: None,
             role: ChatRole::User,
             message_type: MessageType::Text,
             content: "this is a long message".to_string(),
@@ -291,6 +303,7 @@ mod tests {
         assert!(condition.matches(&long_event));
 
         let short_message = ChatMessage {
+            reasoning_content: None,
             role: ChatRole::User,
             message_type: MessageType::Text,
             content: "hi".to_string(),
@@ -306,6 +319,7 @@ mod tests {
     fn test_message_condition_custom() {
         let condition = MessageCondition::Custom(Arc::new(|msg| msg.content.starts_with("hello")));
         let hello_message = ChatMessage {
+            reasoning_content: None,
             role: ChatRole::User,
             message_type: MessageType::Text,
             content: "hello world".to_string(),
@@ -317,6 +331,7 @@ mod tests {
         assert!(condition.matches(&hello_event));
 
         let goodbye_message = ChatMessage {
+            reasoning_content: None,
             role: ChatRole::User,
             message_type: MessageType::Text,
             content: "goodbye world".to_string(),
@@ -332,6 +347,7 @@ mod tests {
     fn test_message_condition_empty() {
         let condition = MessageCondition::Empty;
         let empty_message = ChatMessage {
+            reasoning_content: None,
             role: ChatRole::User,
             message_type: MessageType::Text,
             content: "".to_string(),
@@ -343,6 +359,7 @@ mod tests {
         assert!(condition.matches(&empty_event));
 
         let non_empty_message = ChatMessage {
+            reasoning_content: None,
             role: ChatRole::User,
             message_type: MessageType::Text,
             content: "not empty".to_string(),
@@ -363,6 +380,7 @@ mod tests {
         ]);
 
         let matching_message = ChatMessage {
+            reasoning_content: None,
             role: ChatRole::User,
             message_type: MessageType::Text,
             content: "this is a test message".to_string(),
@@ -374,6 +392,7 @@ mod tests {
         assert!(condition.matches(&matching_event));
 
         let non_matching_message = ChatMessage {
+            reasoning_content: None,
             role: ChatRole::User,
             message_type: MessageType::Text,
             content: "hi".to_string(),
@@ -394,6 +413,7 @@ mod tests {
         ]);
 
         let hello_message = ChatMessage {
+            reasoning_content: None,
             role: ChatRole::User,
             message_type: MessageType::Text,
             content: "hello world".to_string(),
@@ -405,6 +425,7 @@ mod tests {
         assert!(condition.matches(&hello_event));
 
         let goodbye_message = ChatMessage {
+            reasoning_content: None,
             role: ChatRole::User,
             message_type: MessageType::Text,
             content: "goodbye world".to_string(),
@@ -416,6 +437,7 @@ mod tests {
         assert!(condition.matches(&goodbye_event));
 
         let empty_message = ChatMessage {
+            reasoning_content: None,
             role: ChatRole::User,
             message_type: MessageType::Text,
             content: "".to_string(),
@@ -427,6 +449,7 @@ mod tests {
         assert!(condition.matches(&empty_event));
 
         let non_matching_message = ChatMessage {
+            reasoning_content: None,
             role: ChatRole::User,
             message_type: MessageType::Text,
             content: "test message".to_string(),
@@ -442,6 +465,7 @@ mod tests {
     fn test_message_condition_regex() {
         let condition = MessageCondition::Regex(r"\d+".to_string());
         let number_message = ChatMessage {
+            reasoning_content: None,
             role: ChatRole::User,
             message_type: MessageType::Text,
             content: "there are 123 items".to_string(),
@@ -453,6 +477,7 @@ mod tests {
         assert!(condition.matches(&number_event));
 
         let no_number_message = ChatMessage {
+            reasoning_content: None,
             role: ChatRole::User,
             message_type: MessageType::Text,
             content: "no numbers here".to_string(),
@@ -468,6 +493,7 @@ mod tests {
     fn test_message_condition_regex_invalid() {
         let condition = MessageCondition::Regex("[invalid regex".to_string());
         let message = ChatMessage {
+            reasoning_content: None,
             role: ChatRole::User,
             message_type: MessageType::Text,
             content: "test message".to_string(),
@@ -482,6 +508,7 @@ mod tests {
     #[test]
     fn test_message_event_creation() {
         let message = ChatMessage {
+            reasoning_content: None,
             role: ChatRole::User,
             message_type: MessageType::Text,
             content: "test message".to_string(),
@@ -497,6 +524,7 @@ mod tests {
     #[test]
     fn test_message_event_clone() {
         let message = ChatMessage {
+            reasoning_content: None,
             role: ChatRole::User,
             message_type: MessageType::Text,
             content: "test message".to_string(),
@@ -513,6 +541,7 @@ mod tests {
     #[test]
     fn test_message_event_debug() {
         let message = ChatMessage {
+            reasoning_content: None,
             role: ChatRole::User,
             message_type: MessageType::Text,
             content: "test message".to_string(),
@@ -530,6 +559,7 @@ mod tests {
     async fn test_mock_memory_provider_remember() {
         let mut provider = MockMemoryProvider::new();
         let message = ChatMessage {
+            reasoning_content: None,
             role: ChatRole::User,
             message_type: MessageType::Text,
             content: "test message".to_string(),
@@ -544,6 +574,7 @@ mod tests {
     async fn test_mock_memory_provider_remember_failure() {
         let mut provider = MockMemoryProvider::with_failure();
         let message = ChatMessage {
+            reasoning_content: None,
             role: ChatRole::User,
             message_type: MessageType::Text,
             content: "test message".to_string(),
@@ -563,11 +594,13 @@ mod tests {
     async fn test_mock_memory_provider_recall() {
         let messages = vec![
             ChatMessage {
+                reasoning_content: None,
                 role: ChatRole::User,
                 message_type: MessageType::Text,
                 content: "first message".to_string(),
             },
             ChatMessage {
+                reasoning_content: None,
                 role: ChatRole::Assistant,
                 message_type: MessageType::Text,
                 content: "second message".to_string(),
@@ -587,11 +620,13 @@ mod tests {
     async fn test_mock_memory_provider_recall_with_limit() {
         let messages = vec![
             ChatMessage {
+                reasoning_content: None,
                 role: ChatRole::User,
                 message_type: MessageType::Text,
                 content: "first message".to_string(),
             },
             ChatMessage {
+                reasoning_content: None,
                 role: ChatRole::Assistant,
                 message_type: MessageType::Text,
                 content: "second message".to_string(),
@@ -623,6 +658,7 @@ mod tests {
     #[tokio::test]
     async fn test_mock_memory_provider_clear() {
         let messages = vec![ChatMessage {
+            reasoning_content: None,
             role: ChatRole::User,
             message_type: MessageType::Text,
             content: "first message".to_string(),
@@ -656,6 +692,7 @@ mod tests {
         assert_eq!(provider.size(), 0);
 
         let messages = vec![ChatMessage {
+            reasoning_content: None,
             role: ChatRole::User,
             message_type: MessageType::Text,
             content: "message".to_string(),
@@ -670,6 +707,7 @@ mod tests {
         assert!(provider.is_empty());
 
         let messages = vec![ChatMessage {
+            reasoning_content: None,
             role: ChatRole::User,
             message_type: MessageType::Text,
             content: "message".to_string(),
@@ -689,6 +727,7 @@ mod tests {
     async fn test_memory_provider_remember_with_role() {
         let mut provider = MockMemoryProvider::new();
         let message = ChatMessage {
+            reasoning_content: None,
             role: ChatRole::User,
             message_type: MessageType::Text,
             content: "test message".to_string(),

--- a/crates/autoagents-core/src/agent/memory/sliding_window.rs
+++ b/crates/autoagents-core/src/agent/memory/sliding_window.rs
@@ -271,6 +271,7 @@ mod tests {
     async fn test_remember_single_message() {
         let mut memory = SlidingWindowMemory::new(3);
         let message = ChatMessage {
+            reasoning_content: None,
             role: ChatRole::User,
             message_type: MessageType::Text,
             content: "Hello".to_string(),
@@ -291,6 +292,7 @@ mod tests {
 
         for i in 1..=3 {
             let message = ChatMessage {
+                reasoning_content: None,
                 role: ChatRole::User,
                 message_type: MessageType::Text,
                 content: format!("Message {i}"),
@@ -312,6 +314,7 @@ mod tests {
         // Add 3 messages to a window of size 2
         for i in 1..=3 {
             let message = ChatMessage {
+                reasoning_content: None,
                 role: ChatRole::User,
                 message_type: MessageType::Text,
                 content: format!("Message {i}"),
@@ -332,6 +335,7 @@ mod tests {
 
         // Add first message
         let message1 = ChatMessage {
+            reasoning_content: None,
             role: ChatRole::User,
             message_type: MessageType::Text,
             content: "First message".to_string(),
@@ -340,6 +344,7 @@ mod tests {
 
         // Add second message
         let message2 = ChatMessage {
+            reasoning_content: None,
             role: ChatRole::User,
             message_type: MessageType::Text,
             content: "Second message".to_string(),
@@ -348,6 +353,7 @@ mod tests {
 
         // Add third message - should trigger summarize flag
         let message3 = ChatMessage {
+            reasoning_content: None,
             role: ChatRole::User,
             message_type: MessageType::Text,
             content: "Third message".to_string(),
@@ -364,6 +370,7 @@ mod tests {
 
         for i in 1..=3 {
             let message = ChatMessage {
+                reasoning_content: None,
                 role: ChatRole::User,
                 message_type: MessageType::Text,
                 content: format!("Message {i}"),
@@ -372,6 +379,7 @@ mod tests {
         }
 
         let rejected = ChatMessage {
+            reasoning_content: None,
             role: ChatRole::User,
             message_type: MessageType::Text,
             content: "Message 4".to_string(),
@@ -392,6 +400,7 @@ mod tests {
 
         for i in 1..=3 {
             let message = ChatMessage {
+                reasoning_content: None,
                 role: ChatRole::User,
                 message_type: MessageType::Text,
                 content: format!("Message {i}"),
@@ -402,6 +411,7 @@ mod tests {
         memory.replace_with_summary("summary".to_string());
 
         let next = ChatMessage {
+            reasoning_content: None,
             role: ChatRole::User,
             message_type: MessageType::Text,
             content: "Message 4".to_string(),
@@ -421,6 +431,7 @@ mod tests {
 
         for i in 1..=3 {
             let message = ChatMessage {
+                reasoning_content: None,
                 role: ChatRole::User,
                 message_type: MessageType::Text,
                 content: format!("Message {i}"),
@@ -436,6 +447,7 @@ mod tests {
 
         for i in 4..=6 {
             let message = ChatMessage {
+                reasoning_content: None,
                 role: ChatRole::User,
                 message_type: MessageType::Text,
                 content: format!("Message {i}"),
@@ -453,6 +465,7 @@ mod tests {
 
         for i in 1..=2 {
             let message = ChatMessage {
+                reasoning_content: None,
                 role: ChatRole::User,
                 message_type: MessageType::Text,
                 content: format!("Message {i}"),
@@ -462,11 +475,13 @@ mod tests {
 
         let batch = [
             ChatMessage {
+                reasoning_content: None,
                 role: ChatRole::Assistant,
                 message_type: MessageType::Text,
                 content: "Message 3".to_string(),
             },
             ChatMessage {
+                reasoning_content: None,
                 role: ChatRole::Tool,
                 message_type: MessageType::Text,
                 content: "Message 4".to_string(),
@@ -488,6 +503,7 @@ mod tests {
 
         for i in 1..=3 {
             let message = ChatMessage {
+                reasoning_content: None,
                 role: ChatRole::User,
                 message_type: MessageType::Text,
                 content: format!("Message {i}"),
@@ -507,6 +523,7 @@ mod tests {
 
         for i in 1..=5 {
             let message = ChatMessage {
+                reasoning_content: None,
                 role: ChatRole::User,
                 message_type: MessageType::Text,
                 content: format!("Message {i}"),
@@ -525,6 +542,7 @@ mod tests {
         let mut memory = SlidingWindowMemory::new(3);
 
         let message = ChatMessage {
+            reasoning_content: None,
             role: ChatRole::User,
             message_type: MessageType::Text,
             content: "Test message".to_string(),
@@ -544,6 +562,7 @@ mod tests {
         // Add messages directly to the internal deque for testing
         for i in 1..=5 {
             let message = ChatMessage {
+                reasoning_content: None,
                 role: ChatRole::User,
                 message_type: MessageType::Text,
                 content: format!("Message {i}"),
@@ -564,6 +583,7 @@ mod tests {
         // Add only 2 messages
         for i in 1..=2 {
             let message = ChatMessage {
+                reasoning_content: None,
                 role: ChatRole::User,
                 message_type: MessageType::Text,
                 content: format!("Message {i}"),
@@ -593,6 +613,7 @@ mod tests {
         // Add some messages
         for i in 1..=3 {
             let message = ChatMessage {
+                reasoning_content: None,
                 role: ChatRole::User,
                 message_type: MessageType::Text,
                 content: format!("Message {i}"),

--- a/crates/autoagents-core/src/agent/prebuilt/executor/codeact.rs
+++ b/crates/autoagents-core/src/agent/prebuilt/executor/codeact.rs
@@ -479,6 +479,7 @@ impl CodeActEngine {
                 )
                 .await?;
             let response_text = response.text().unwrap_or_default();
+            let reasoning_content = response.thinking().unwrap_or_default();
             if should_store_user {
                 memory.store_user(task).await?;
                 stored_user = true;
@@ -522,7 +523,12 @@ impl CodeActEngine {
                 .await;
 
             memory
-                .store_tool_interaction(&tool_calls, &tool_results, &response_text)
+                .store_tool_interaction_with_reasoning(
+                    &tool_calls,
+                    &tool_results,
+                    &response_text,
+                    Some(&reasoning_content),
+                )
                 .await?;
 
             EventHelper::send_turn_completed(
@@ -616,6 +622,7 @@ impl CodeActEngine {
                     .await;
 
                 let mut response_text = String::default();
+                let mut reasoning_content = String::default();
                 let mut tool_calls = Vec::new();
                 let mut seen_tool_ids = HashSet::new();
 
@@ -656,7 +663,9 @@ impl CodeActEngine {
                                 }))
                                 .await;
                         }
-                        StreamChunk::ReasoningContent(_) => {}
+                        StreamChunk::ReasoningContent(content) => {
+                            reasoning_content.push_str(&content);
+                        }
                         StreamChunk::ToolUseComplete { tool_call, .. } => {
                             if seen_tool_ids.insert(tool_call.id.clone()) {
                                 tool_calls.push(tool_call.clone());
@@ -733,7 +742,12 @@ impl CodeActEngine {
                     .await;
 
                 if let Err(err) = memory
-                    .store_tool_interaction(&tool_calls, &tool_results, &response_text)
+                    .store_tool_interaction_with_reasoning(
+                        &tool_calls,
+                        &tool_results,
+                        &response_text,
+                        Some(&reasoning_content),
+                    )
                     .await
                     .map_err(CodeActExecutorError::from)
                 {
@@ -847,6 +861,7 @@ async fn build_messages(
         .as_deref()
         .unwrap_or_else(|| &context.config().description);
     let mut messages = vec![ChatMessage {
+        reasoning_content: None,
         role: ChatRole::System,
         message_type: MessageType::Text,
         content: build_codeact_system_prompt(system_prompt, tool_bindings),
@@ -2000,12 +2015,14 @@ fn should_store_user(memory: &MemoryAdapter, stored_user: bool) -> bool {
 fn user_message(task: &Task) -> ChatMessage {
     if let Some((mime, image_data)) = &task.image {
         ChatMessage {
+            reasoning_content: None,
             role: ChatRole::User,
             message_type: MessageType::Image(((*mime).into(), image_data.clone())),
             content: task.prompt.clone(),
         }
     } else {
         ChatMessage {
+            reasoning_content: None,
             role: ChatRole::User,
             message_type: MessageType::Text,
             content: task.prompt.clone(),
@@ -2802,7 +2819,7 @@ throw new Error("boom");
                             "return await external_lookup({});",
                         )]),
                         usage: None,
-                        thinking: None,
+                        thinking: Some("inspect the workspace".to_string()),
                     },
                     StaticChatResponse {
                         text: Some(r#"{"result":"complete"}"#.to_string()),
@@ -2852,6 +2869,14 @@ throw new Error("boom");
                 .filter(|message| message.role == ChatRole::User)
                 .count();
             assert_eq!(second_turn_user_messages, 1);
+            let assistant_tool_message = observed[1]
+                .iter()
+                .find(|message| matches!(message.message_type, MessageType::ToolUse(_)))
+                .expect("assistant tool message should be replayed");
+            assert_eq!(
+                assistant_tool_message.reasoning_content.as_deref(),
+                Some("inspect the workspace")
+            );
         });
     }
 
@@ -2910,6 +2935,7 @@ throw new Error("boom");
                 Vec::new(),
                 vec![
                     vec![
+                        StreamChunk::ReasoningContent("inspect the workspace".to_string()),
                         StreamChunk::Text("Working".to_string()),
                         StreamChunk::ToolUseComplete {
                             index: 0,
@@ -2931,7 +2957,7 @@ throw new Error("boom");
                 ],
             ));
             let context = test_context_with_llm(
-                provider,
+                provider.clone(),
                 vec![Box::new(LocalTool::new("lookup", json!({"answer": 42})))],
                 true,
             );
@@ -2975,6 +3001,16 @@ throw new Error("boom");
             assert_eq!(final_output.response, "All done");
             assert_eq!(final_output.executions.len(), 1);
             assert!(final_output.done);
+
+            let observed = provider.observed_messages().await;
+            let assistant_tool_message = observed[1]
+                .iter()
+                .find(|message| matches!(message.message_type, MessageType::ToolUse(_)))
+                .expect("assistant tool message should be replayed");
+            assert_eq!(
+                assistant_tool_message.reasoning_content.as_deref(),
+                Some("inspect the workspace")
+            );
         });
     }
 }

--- a/crates/autoagents-llamacpp/src/chat_template.rs
+++ b/crates/autoagents-llamacpp/src/chat_template.rs
@@ -1246,6 +1246,7 @@ mod tests {
 
     fn user_message(content: &str) -> ChatMessage {
         ChatMessage {
+            reasoning_content: None,
             role: ChatRole::User,
             message_type: MessageType::Text,
             content: content.to_string(),
@@ -1913,6 +1914,7 @@ mod tests {
             "{% for message in messages %}{{ message['role'] }}:{{ message['content'] }}\n{% endfor %}{% if add_generation_prompt %}assistant:{% endif %}",
         );
         let assistant = ChatMessage {
+            reasoning_content: None,
             role: ChatRole::Assistant,
             message_type: MessageType::Text,
             content: "partial".to_string(),
@@ -1944,6 +1946,7 @@ mod tests {
             "{% for message in messages %}{{ message['role'] }}:{{ message['content'] }}\n{% endfor %}{% if add_generation_prompt %}<|assistant|>{% endif %}{# <think></think> #}",
         );
         let assistant = ChatMessage {
+            reasoning_content: None,
             role: ChatRole::Assistant,
             message_type: MessageType::Text,
             content: "plan".to_string(),
@@ -1976,6 +1979,7 @@ mod tests {
             "{% for message in messages %}{{ message['role'] }}:{{ message['content'] }}\n{% endfor %}{% if add_generation_prompt %}<|assistant|>{% endif %}{# <think></think> #}",
         );
         let assistant = ChatMessage {
+            reasoning_content: None,
             role: ChatRole::Assistant,
             message_type: MessageType::Text,
             content: "plan".to_string(),
@@ -2276,6 +2280,7 @@ mod tests {
         let config = LlamaCppConfig::default();
         let template = explicit_template_source("{{ messages|tojson }}");
         let tool_result = ChatMessage {
+            reasoning_content: None,
             role: ChatRole::Tool,
             message_type: MessageType::ToolResult(vec![
                 ToolCall {

--- a/crates/autoagents-llamacpp/src/conversion.rs
+++ b/crates/autoagents-llamacpp/src/conversion.rs
@@ -141,6 +141,9 @@ fn build_openai_message_value(message: &ChatMessage) -> Result<Value, LlamaCppPr
         if !message.content.trim().is_empty() {
             obj.insert("content".to_string(), json!(message.content));
         }
+        if let Some(reasoning_content) = &message.reasoning_content {
+            obj.insert("reasoning_content".to_string(), json!(reasoning_content));
+        }
         obj.insert("tool_calls".to_string(), Value::Array(tool_values));
         return Ok(Value::Object(obj));
     }
@@ -255,5 +258,26 @@ mod tests {
         assert_eq!(arr[1]["role"], "tool");
         assert_eq!(arr[1]["tool_call_id"], "tool_1");
         assert_eq!(arr[1]["content"], "{\"x\":1}");
+    }
+
+    #[test]
+    fn test_build_openai_messages_json_preserves_tool_reasoning() {
+        let tool_call = ToolCall {
+            id: "tool_1".to_string(),
+            call_type: "function".to_string(),
+            function: FunctionCall {
+                name: "do_work".to_string(),
+                arguments: "{\"x\":1}".to_string(),
+            },
+        };
+        let tool_use = ChatMessage::assistant()
+            .reasoning_content("Inspect the inputs first")
+            .tool_use(vec![tool_call])
+            .build();
+
+        let json = build_openai_messages_json(&[tool_use]).unwrap();
+        let value: Value = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(value[0]["reasoning_content"], "Inspect the inputs first");
     }
 }

--- a/crates/autoagents-llamacpp/src/provider.rs
+++ b/crates/autoagents-llamacpp/src/provider.rs
@@ -1043,8 +1043,6 @@ impl LlamaCppProvider {
         messages: &[ChatMessage],
     ) -> Result<(String, Vec<Vec<u8>>, String), LLMError> {
         let template = self.resolve_chat_template_source(false)?;
-        let mut chat = Vec::new();
-        let mut images = Vec::new();
         let default_marker = mtmd_default_marker().to_string();
         let marker = self
             .config
@@ -1052,15 +1050,46 @@ impl LlamaCppProvider {
             .as_deref()
             .unwrap_or(&default_marker)
             .to_string();
+        let (chat, images) =
+            Self::prepare_mtmd_chat(self.prepare_fallback_messages(messages, None), &marker)?;
 
-        for message in self.prepare_fallback_messages(messages, None) {
-            let mut content = message.content.clone();
-            match message.message_type {
+        let prompt = render_chat_template(
+            &self.config,
+            &template,
+            &chat,
+            None,
+            None,
+            None,
+            &self.template_tokens()?,
+        )
+        .map_err(LLMError::from)?
+        .prompt;
+
+        Ok((prompt, images, marker))
+    }
+
+    #[cfg(feature = "mtmd")]
+    fn prepare_mtmd_chat(
+        messages: Vec<ChatMessage>,
+        marker: &str,
+    ) -> Result<(Vec<ChatMessage>, Vec<Vec<u8>>), LLMError> {
+        let mut chat = Vec::with_capacity(messages.len());
+        let mut images = Vec::new();
+
+        for message in messages {
+            let ChatMessage {
+                reasoning_content,
+                role,
+                message_type,
+                mut content,
+            } = message;
+
+            match message_type {
                 MessageType::Text => {}
                 MessageType::Image((_, bytes)) => {
                     images.push(bytes);
-                    if !content.contains(&marker) {
-                        content.push_str(&marker);
+                    if !content.contains(marker) {
+                        content.push_str(marker);
                     }
                 }
                 MessageType::ToolUse(_) | MessageType::ToolResult(_) => {
@@ -1076,25 +1105,14 @@ impl LlamaCppProvider {
             }
 
             chat.push(ChatMessage {
-                role: message.role,
+                reasoning_content,
+                role,
                 message_type: MessageType::Text,
                 content,
             });
         }
 
-        let prompt = render_chat_template(
-            &self.config,
-            &template,
-            &chat,
-            None,
-            None,
-            None,
-            &self.template_tokens()?,
-        )
-        .map_err(LLMError::from)?
-        .prompt;
-
-        Ok((prompt, images, marker))
+        Ok((chat, images))
     }
 
     fn template_tokens(&self) -> Result<TemplateTokens, LLMError> {
@@ -2104,6 +2122,7 @@ fn prepare_messages_with_system(
 
         if !has_system_message {
             all_messages.push(ChatMessage {
+                reasoning_content: None,
                 role: autoagents_llm::chat::ChatRole::System,
                 message_type: autoagents_llm::chat::MessageType::Text,
                 content: system_prompt.clone(),
@@ -2131,6 +2150,7 @@ fn prepare_fallback_messages_with_schema(
             schema_hint.push_str(&format!(" Schema: {json_schema}"));
         }
         all_messages.push(ChatMessage {
+            reasoning_content: None,
             role: autoagents_llm::chat::ChatRole::System,
             message_type: autoagents_llm::chat::MessageType::Text,
             content: schema_hint,
@@ -7513,6 +7533,55 @@ mod tests {
         assert!(!marker.is_empty());
     }
 
+    #[cfg(feature = "mtmd")]
+    #[test]
+    fn test_prepare_mtmd_chat_preserves_reasoning_and_collects_images() {
+        let messages = vec![
+            ChatMessage::assistant()
+                .content("answer")
+                .reasoning_content("inspect the image")
+                .build(),
+            ChatMessage::user()
+                .content("caption")
+                .image(ImageMime::PNG, vec![1, 2, 3])
+                .build(),
+        ];
+
+        let (chat, images) = LlamaCppProvider::prepare_mtmd_chat(messages, "<image>").unwrap();
+
+        assert_eq!(chat.len(), 2);
+        assert_eq!(
+            chat[0].reasoning_content.as_deref(),
+            Some("inspect the image")
+        );
+        assert_eq!(chat[1].content, "caption<image>");
+        assert_eq!(images, vec![vec![1, 2, 3]]);
+    }
+
+    #[cfg(feature = "mtmd")]
+    #[test]
+    fn test_prepare_mtmd_chat_rejects_unsupported_messages() {
+        let tool_message = ChatMessage::assistant().tool_use(Vec::new()).build();
+        let tool_error =
+            LlamaCppProvider::prepare_mtmd_chat(vec![tool_message], "<image>").unwrap_err();
+        assert!(
+            tool_error
+                .to_string()
+                .contains("does not support tool calls")
+        );
+
+        let url_message = ChatMessage::user()
+            .image_url("https://example.com/image.png")
+            .build();
+        let url_error =
+            LlamaCppProvider::prepare_mtmd_chat(vec![url_message], "<image>").unwrap_err();
+        assert!(
+            url_error
+                .to_string()
+                .contains("only supports raw image inputs")
+        );
+    }
+
     #[test]
     fn test_chat_template_result_parses_content_and_tool_json() {
         let content_result = ChatTemplateResult {
@@ -9417,6 +9486,7 @@ content
         assert_eq!(prepared[1].content, "hi");
 
         let messages = vec![ChatMessage {
+            reasoning_content: None,
             role: autoagents_llm::chat::ChatRole::System,
             message_type: autoagents_llm::chat::MessageType::Text,
             content: "existing".to_string(),
@@ -10315,6 +10385,7 @@ content
         assert!(ok.is_ok());
 
         let image_msg = ChatMessage {
+            reasoning_content: None,
             role: autoagents_llm::chat::ChatRole::User,
             message_type: autoagents_llm::chat::MessageType::Image((ImageMime::PNG, vec![1, 2, 3])),
             content: "img".to_string(),
@@ -10323,6 +10394,7 @@ content
         assert!(err.to_string().contains("does not support image inputs"));
 
         let url_msg = ChatMessage {
+            reasoning_content: None,
             role: autoagents_llm::chat::ChatRole::User,
             message_type: autoagents_llm::chat::MessageType::ImageURL(
                 "https://example.com/img.png".to_string(),

--- a/crates/autoagents-llamacpp/src/server_chat.rs
+++ b/crates/autoagents-llamacpp/src/server_chat.rs
@@ -520,6 +520,7 @@ fn base_message(message: &ChatMessage) -> ServerChatMessage {
     ServerChatMessage {
         role: role.to_string(),
         content,
+        reasoning_content: message.reasoning_content.clone().unwrap_or_default(),
         ..Default::default()
     }
 }
@@ -693,6 +694,7 @@ mod tests {
     #[test]
     fn converts_tool_calls_to_server_messages() {
         let message = ChatMessage {
+            reasoning_content: Some("inspect the workspace".to_string()),
             role: ChatRole::Assistant,
             message_type: MessageType::ToolUse(vec![tool_call()]),
             content: String::default(),
@@ -703,6 +705,7 @@ mod tests {
         assert_eq!(messages[0].role, "assistant");
         assert_eq!(messages[0].tool_calls[0].name, "lookup");
         assert_eq!(messages[0].tool_calls[0].arguments, "{\"q\":\"rust\"}");
+        assert_eq!(messages[0].reasoning_content, "inspect the workspace");
     }
 
     #[test]
@@ -738,6 +741,7 @@ mod tests {
     #[test]
     fn renders_caps_driven_typed_or_string_content() {
         let message = ChatMessage {
+            reasoning_content: None,
             role: ChatRole::User,
             message_type: MessageType::ImageURL("<image>".to_string()),
             content: "caption".to_string(),

--- a/crates/autoagents-llamacpp/tests/grammar_no_tools_integration.rs
+++ b/crates/autoagents-llamacpp/tests/grammar_no_tools_integration.rs
@@ -149,6 +149,7 @@ async fn chat_with_tools_grammar_no_envelope_returns_schema_conforming_json() {
         .expect("provider should load");
 
     let messages = vec![ChatMessage {
+        reasoning_content: None,
         role: ChatRole::User,
         message_type: MessageType::Text,
         content: PROMPT.to_string(),

--- a/crates/autoagents-llm/src/backends/anthropic.rs
+++ b/crates/autoagents-llm/src/backends/anthropic.rs
@@ -1456,6 +1456,7 @@ data: {"type": "ping"}
     #[test]
     fn test_convert_messages_to_anthropic_tool_result() {
         let msg = ChatMessage {
+            reasoning_content: None,
             role: ChatRole::Assistant,
             message_type: MessageType::ToolResult(vec![ToolCall {
                 id: "tool_1".to_string(),
@@ -1481,6 +1482,7 @@ data: {"type": "ping"}
     #[test]
     fn test_convert_messages_to_anthropic_tool_use_parses_input() {
         let msg = ChatMessage {
+            reasoning_content: None,
             role: ChatRole::Assistant,
             message_type: MessageType::ToolUse(vec![ToolCall {
                 id: "tool_call".to_string(),
@@ -1557,11 +1559,13 @@ data: {"type": "ping"}
     #[test]
     fn test_convert_messages_to_anthropic_image_and_pdf() {
         let image = ChatMessage {
+            reasoning_content: None,
             role: ChatRole::User,
             message_type: MessageType::Image((ImageMime::PNG, vec![1, 2, 3])),
             content: "img".to_string(),
         };
         let pdf = ChatMessage {
+            reasoning_content: None,
             role: ChatRole::User,
             message_type: MessageType::Pdf(vec![9, 8, 7]),
             content: "doc".to_string(),
@@ -1674,16 +1678,19 @@ data: {"type": "ping"}
     fn test_convert_messages_to_anthropic_filters_system_and_covers_url_and_invalid_tool_json() {
         let messages = vec![
             ChatMessage {
+                reasoning_content: None,
                 role: ChatRole::System,
                 message_type: MessageType::Text,
                 content: "system".to_string(),
             },
             ChatMessage {
+                reasoning_content: None,
                 role: ChatRole::User,
                 message_type: MessageType::ImageURL("https://example.com/image.png".to_string()),
                 content: "remote image".to_string(),
             },
             ChatMessage {
+                reasoning_content: None,
                 role: ChatRole::Assistant,
                 message_type: MessageType::ToolUse(vec![ToolCall {
                     id: "tool_1".to_string(),
@@ -1747,6 +1754,7 @@ data: {"type": "ping"}
     #[test]
     fn test_convert_messages_to_anthropic_rejects_system_only() {
         let messages = [ChatMessage {
+            reasoning_content: None,
             role: ChatRole::System,
             message_type: MessageType::Text,
             content: "system only".to_string(),
@@ -1777,6 +1785,7 @@ data: {"type": "ping"}
             None,
         );
         let messages = [ChatMessage {
+            reasoning_content: None,
             role: ChatRole::User,
             message_type: MessageType::Pdf(vec![1, 2, 3]),
             content: "doc".to_string(),
@@ -1851,6 +1860,7 @@ data: {"type": "ping"}
         let invalid = Anthropic::new("key", None, None, None, None, None, None, None, None, None)
             .chat_with_tools(
                 &[ChatMessage {
+                    reasoning_content: None,
                     role: ChatRole::System,
                     message_type: MessageType::Text,
                     content: "system only".to_string(),
@@ -1876,6 +1886,7 @@ data: {"type": "ping"}
             match Anthropic::new("key", None, None, None, None, None, None, None, None, None)
                 .chat_stream(
                     &[ChatMessage {
+                        reasoning_content: None,
                         role: ChatRole::System,
                         message_type: MessageType::Text,
                         content: "system only".to_string(),
@@ -2097,6 +2108,7 @@ data: {"type": "ping"}
         );
 
         let messages = vec![ChatMessage {
+            reasoning_content: None,
             role: ChatRole::User,
             message_type: crate::chat::MessageType::Text,
             content: "Classify the sentiment of: 'I love sunny days!'".to_string(),

--- a/crates/autoagents-llm/src/backends/azure_openai.rs
+++ b/crates/autoagents-llm/src/backends/azure_openai.rs
@@ -705,6 +705,7 @@ mod tests {
     #[test]
     fn test_build_azure_chat_messages_rejects_raw_image() {
         let messages = [ChatMessage {
+            reasoning_content: None,
             role: ChatRole::User,
             message_type: MessageType::Image((ImageMime::PNG, vec![1, 2, 3])),
             content: "describe".to_string(),
@@ -722,6 +723,7 @@ mod tests {
     #[test]
     fn test_azure_chat_message_from_text() {
         let msg = ChatMessage {
+            reasoning_content: None,
             role: ChatRole::User,
             message_type: MessageType::Text,
             content: "hello".to_string(),
@@ -735,6 +737,7 @@ mod tests {
     #[test]
     fn test_azure_chat_message_from_image_url() {
         let msg = ChatMessage {
+            reasoning_content: None,
             role: ChatRole::User,
             message_type: MessageType::ImageURL("https://example.com/img.png".to_string()),
             content: "describe".to_string(),
@@ -752,6 +755,7 @@ mod tests {
     #[test]
     fn test_azure_chat_message_rejects_raw_image() {
         let msg = ChatMessage {
+            reasoning_content: None,
             role: ChatRole::User,
             message_type: MessageType::Image((ImageMime::PNG, vec![1, 2, 3])),
             content: "describe".to_string(),
@@ -769,6 +773,7 @@ mod tests {
     #[test]
     fn test_azure_chat_message_rejects_pdf() {
         let msg = ChatMessage {
+            reasoning_content: None,
             role: ChatRole::User,
             message_type: MessageType::Pdf(vec![1, 2, 3]),
             content: "doc".to_string(),
@@ -786,6 +791,7 @@ mod tests {
     #[test]
     fn test_azure_chat_message_from_tool_use() {
         let msg = ChatMessage {
+            reasoning_content: None,
             role: ChatRole::Assistant,
             message_type: MessageType::ToolUse(vec![ToolCall {
                 id: "call_1".to_string(),

--- a/crates/autoagents-llm/src/backends/google.rs
+++ b/crates/autoagents-llm/src/backends/google.rs
@@ -1300,11 +1300,13 @@ mod tests {
         };
         let messages = vec![
             ChatMessage {
+                reasoning_content: None,
                 role: ChatRole::Assistant,
                 message_type: MessageType::ToolUse(vec![tool_call.clone()]),
                 content: "call".to_string(),
             },
             ChatMessage {
+                reasoning_content: None,
                 role: ChatRole::Tool,
                 message_type: MessageType::ToolResult(vec![tool_call]),
                 content: "result".to_string(),
@@ -1344,11 +1346,13 @@ mod tests {
         };
         let messages = vec![
             ChatMessage {
+                reasoning_content: None,
                 role: ChatRole::Assistant,
                 message_type: MessageType::ToolUse(vec![tool_call.clone()]),
                 content: "call".to_string(),
             },
             ChatMessage {
+                reasoning_content: None,
                 role: ChatRole::Tool,
                 message_type: MessageType::ToolResult(vec![tool_call]),
                 content: "result".to_string(),
@@ -1380,6 +1384,7 @@ mod tests {
     #[test]
     fn test_build_google_chat_contents_rejects_image_url() {
         let messages = [ChatMessage {
+            reasoning_content: None,
             role: ChatRole::User,
             message_type: MessageType::ImageURL("https://example.com/image.png".to_string()),
             content: "describe".to_string(),
@@ -1400,6 +1405,7 @@ mod tests {
     #[test]
     fn test_build_google_stream_contents_rejects_image_url() {
         let messages = [ChatMessage {
+            reasoning_content: None,
             role: ChatRole::User,
             message_type: MessageType::ImageURL("https://example.com/image.png".to_string()),
             content: "describe".to_string(),

--- a/crates/autoagents-llm/src/backends/openai.rs
+++ b/crates/autoagents-llm/src/backends/openai.rs
@@ -2452,6 +2452,7 @@ mod tests {
         let msg = OpenAIChatMessage {
             role: "user",
             content: Some(Right("hello".to_string())),
+            reasoning_content: None,
             tool_calls: None,
             tool_call_id: None,
         };
@@ -2516,11 +2517,13 @@ mod tests {
 
         let messages = vec![
             ChatMessage {
+                reasoning_content: None,
                 role: ChatRole::System,
                 message_type: MessageType::Text,
                 content: "You are helpful.".to_string(),
             },
             ChatMessage {
+                reasoning_content: None,
                 role: ChatRole::User,
                 message_type: MessageType::Text,
                 content: "hello".to_string(),
@@ -2582,6 +2585,7 @@ mod tests {
         .unwrap();
 
         let messages = vec![ChatMessage {
+            reasoning_content: None,
             role: ChatRole::User,
             message_type: MessageType::Text,
             content: "Jane, 54 years old".to_string(),
@@ -2707,6 +2711,7 @@ mod tests {
 
         let messages = vec![
             ChatMessage {
+                reasoning_content: None,
                 role: ChatRole::Assistant,
                 message_type: MessageType::ToolUse(vec![ToolCall {
                     id: "call_1".to_string(),
@@ -2719,6 +2724,7 @@ mod tests {
                 content: "Checking...".to_string(),
             },
             ChatMessage {
+                reasoning_content: None,
                 role: ChatRole::Tool,
                 message_type: MessageType::ToolResult(vec![ToolCall {
                     id: "call_1".to_string(),
@@ -2941,26 +2947,31 @@ mod tests {
         };
         let messages = vec![
             ChatMessage {
+                reasoning_content: None,
                 role: ChatRole::System,
                 message_type: MessageType::Text,
                 content: "Be precise".to_string(),
             },
             ChatMessage {
+                reasoning_content: None,
                 role: ChatRole::User,
                 message_type: MessageType::Image((ImageMime::PNG, vec![1, 2, 3])),
                 content: "caption".to_string(),
             },
             ChatMessage {
+                reasoning_content: None,
                 role: ChatRole::User,
                 message_type: MessageType::ImageURL("https://example.com/image.png".to_string()),
                 content: "describe".to_string(),
             },
             ChatMessage {
+                reasoning_content: None,
                 role: ChatRole::Assistant,
                 message_type: MessageType::ToolUse(vec![tool_call.clone()]),
                 content: "calling tool".to_string(),
             },
             ChatMessage {
+                reasoning_content: None,
                 role: ChatRole::Tool,
                 message_type: MessageType::ToolResult(vec![tool_call]),
                 content: String::new(),
@@ -2993,6 +3004,7 @@ mod tests {
         assert_eq!(input[4]["type"], json!("function_call_output"));
 
         let pdf_messages = vec![ChatMessage {
+            reasoning_content: None,
             role: ChatRole::User,
             message_type: MessageType::Pdf(vec![1, 2, 3]),
             content: "doc".to_string(),

--- a/crates/autoagents-llm/src/backends/phind.rs
+++ b/crates/autoagents-llm/src/backends/phind.rs
@@ -344,6 +344,7 @@ mod tests {
     #[test]
     fn test_validate_text_only_messages_rejects_multimodal() {
         let messages = [ChatMessage {
+            reasoning_content: None,
             role: ChatRole::User,
             message_type: MessageType::ImageURL("https://example.com/image.png".to_string()),
             content: "describe".to_string(),
@@ -361,6 +362,7 @@ mod tests {
     #[test]
     fn test_validate_text_only_messages_rejects_tool_messages() {
         let messages = [ChatMessage {
+            reasoning_content: None,
             role: ChatRole::Assistant,
             message_type: MessageType::ToolUse(vec![ToolCall {
                 id: "call_1".to_string(),

--- a/crates/autoagents-llm/src/backends/xai.rs
+++ b/crates/autoagents-llm/src/backends/xai.rs
@@ -809,6 +809,7 @@ mod tests {
     #[test]
     fn test_try_build_chat_messages_rejects_multimodal() {
         let messages = [ChatMessage {
+            reasoning_content: None,
             role: ChatRole::User,
             message_type: MessageType::ImageURL("https://example.com/image.png".to_string()),
             content: "describe".to_string(),
@@ -829,6 +830,7 @@ mod tests {
     #[test]
     fn test_try_build_chat_messages_rejects_tool_messages() {
         let messages = [ChatMessage {
+            reasoning_content: None,
             role: ChatRole::Assistant,
             message_type: MessageType::ToolUse(vec![ToolCall {
                 id: "call_1".to_string(),

--- a/crates/autoagents-llm/src/chat/mod.rs
+++ b/crates/autoagents-llm/src/chat/mod.rs
@@ -222,6 +222,9 @@ pub struct ChatMessage {
     pub message_type: MessageType,
     /// The text content of the message
     pub content: String,
+    /// Reasoning content associated with the message, if any
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reasoning_content: Option<String>,
 }
 
 /// Represents a parameter in a function tool
@@ -722,6 +725,7 @@ pub struct ChatMessageBuilder {
     role: ChatRole,
     message_type: MessageType,
     content: String,
+    reasoning_content: Option<String>,
 }
 
 impl ChatMessageBuilder {
@@ -731,12 +735,19 @@ impl ChatMessageBuilder {
             role,
             message_type: MessageType::default(),
             content: String::default(),
+            reasoning_content: None,
         }
     }
 
     /// Set the message content
     pub fn content<S: Into<String>>(mut self, content: S) -> Self {
         self.content = content.into();
+        self
+    }
+
+    /// Set the message reasoning content
+    pub fn reasoning_content<S: Into<String>>(mut self, reasoning_content: S) -> Self {
+        self.reasoning_content = Some(reasoning_content.into());
         self
     }
 
@@ -776,6 +787,7 @@ impl ChatMessageBuilder {
             role: self.role,
             message_type: self.message_type,
             content: self.content,
+            reasoning_content: self.reasoning_content,
         }
     }
 }
@@ -907,6 +919,30 @@ mod tests {
             .tool_use(vec![tc])
             .build();
         assert!(matches!(msg.message_type, MessageType::ToolUse(_)));
+    }
+
+    #[test]
+    fn test_chat_message_builder_reasoning_content() {
+        let msg = ChatMessage::assistant()
+            .content("calling tool")
+            .reasoning_content("inspect the workspace")
+            .build();
+
+        assert_eq!(
+            msg.reasoning_content.as_deref(),
+            Some("inspect the workspace")
+        );
+    }
+
+    #[test]
+    fn test_chat_message_reasoning_content_is_serde_backward_compatible() {
+        let message = ChatMessage::user().content("hello").build();
+        let serialized = serde_json::to_value(&message).unwrap();
+
+        assert!(serialized.get("reasoning_content").is_none());
+
+        let deserialized: ChatMessage = serde_json::from_value(serialized).unwrap();
+        assert!(deserialized.reasoning_content.is_none());
     }
 
     #[test]

--- a/crates/autoagents-llm/src/evaluator/mod.rs
+++ b/crates/autoagents-llm/src/evaluator/mod.rs
@@ -276,6 +276,7 @@ mod tests {
         let evaluator = LLMEvaluator::new(vec![llm]).scoring(|response| response.len() as f32);
 
         let messages = vec![ChatMessage {
+            reasoning_content: None,
             role: ChatRole::User,
             message_type: MessageType::Text,
             content: "test message".to_string(),
@@ -296,6 +297,7 @@ mod tests {
             LLMEvaluator::new(vec![llm1, llm2]).scoring(|response| response.len() as f32);
 
         let messages = vec![ChatMessage {
+            reasoning_content: None,
             role: ChatRole::User,
             message_type: MessageType::Text,
             content: "test message".to_string(),
@@ -316,6 +318,7 @@ mod tests {
         let evaluator = LLMEvaluator::new(vec![llm]);
 
         let messages = vec![ChatMessage {
+            reasoning_content: None,
             role: ChatRole::User,
             message_type: MessageType::Text,
             content: "test message".to_string(),
@@ -337,6 +340,7 @@ mod tests {
         let evaluator = LLMEvaluator::new(vec![llm]);
 
         let messages = vec![ChatMessage {
+            reasoning_content: None,
             role: ChatRole::User,
             message_type: MessageType::Text,
             content: "test message".to_string(),
@@ -355,6 +359,7 @@ mod tests {
             .scoring(|response| if response.is_empty() { -1.0 } else { 1.0 });
 
         let messages = vec![ChatMessage {
+            reasoning_content: None,
             role: ChatRole::User,
             message_type: MessageType::Text,
             content: "test message".to_string(),
@@ -373,16 +378,19 @@ mod tests {
 
         let messages = vec![
             ChatMessage {
+                reasoning_content: None,
                 role: ChatRole::System,
                 message_type: MessageType::Text,
                 content: "You are a helpful assistant".to_string(),
             },
             ChatMessage {
+                reasoning_content: None,
                 role: ChatRole::User,
                 message_type: MessageType::Text,
                 content: "Hello, how are you?".to_string(),
             },
             ChatMessage {
+                reasoning_content: None,
                 role: ChatRole::Assistant,
                 message_type: MessageType::Text,
                 content: "I'm doing well, thank you!".to_string(),
@@ -453,6 +461,7 @@ mod tests {
             LLMEvaluator::new(vec![llm1, llm2, llm3]).scoring(|response| response.len() as f32);
 
         let messages = vec![ChatMessage {
+            reasoning_content: None,
             role: ChatRole::User,
             message_type: MessageType::Text,
             content: "test message".to_string(),
@@ -474,6 +483,7 @@ mod tests {
         let evaluator = LLMEvaluator::new(vec![]);
 
         let messages = vec![ChatMessage {
+            reasoning_content: None,
             role: ChatRole::User,
             message_type: MessageType::Text,
             content: "test message".to_string(),

--- a/crates/autoagents-llm/src/evaluator/parallel_tests.rs
+++ b/crates/autoagents-llm/src/evaluator/parallel_tests.rs
@@ -251,6 +251,7 @@ mod tests {
         let evaluator = ParallelEvaluator::new(providers);
         let messages = vec![
             ChatMessage {
+                reasoning_content: None,
                 role: ChatRole::System,
                 message_type: MessageType::Text,
                 content: "You are a helpful assistant".to_string(),

--- a/crates/autoagents-llm/src/optim/cache.rs
+++ b/crates/autoagents-llm/src/optim/cache.rs
@@ -1188,6 +1188,7 @@ mod tests {
         let msg_b = vec![
             ChatMessage::user().content("repeat prompt").build(),
             ChatMessage {
+                reasoning_content: None,
                 role: ChatRole::Tool,
                 message_type: MessageType::ToolResult(vec![crate::ToolCall {
                     id: "call_1".to_string(),

--- a/crates/autoagents-llm/src/providers/openai_compatible.rs
+++ b/crates/autoagents-llm/src/providers/openai_compatible.rs
@@ -161,6 +161,8 @@ pub struct OpenAIChatMessage<'a> {
     )]
     pub content: Option<Either<Vec<OpenAIMessageContent<'a>>, String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub reasoning_content: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub tool_calls: Option<Vec<ToolCall>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tool_call_id: Option<String>,
@@ -476,6 +478,7 @@ impl<T: OpenAIProviderConfig> OpenAICompatibleProvider<T> {
                     role: "tool",
                     tool_call_id: Some(result.id.clone()),
                     tool_calls: None,
+                    reasoning_content: None,
                     content: Some(Right(result.function.arguments.clone())),
                 }));
             } else {
@@ -1085,6 +1088,7 @@ pub fn chat_message_to_openai_message(
             ChatRole::Tool => "user",
         },
         tool_call_id: None,
+        reasoning_content: chat_msg.reasoning_content.clone(),
         content: match &chat_msg.message_type {
             MessageType::Text => Some(Right(chat_msg.content.clone())),
             MessageType::Image((mime, bytes)) => {
@@ -1794,6 +1798,7 @@ mod tests {
             },
         }];
         let messages = vec![ChatMessage {
+            reasoning_content: None,
             role: ChatRole::Assistant,
             message_type: MessageType::ToolResult(tool_calls.clone()),
             content: "tool result".to_string(),
@@ -1819,6 +1824,7 @@ mod tests {
     #[test]
     fn test_chat_message_to_openai_message_image_url() {
         let msg = ChatMessage {
+            reasoning_content: None,
             role: ChatRole::User,
             message_type: MessageType::ImageURL("https://example.com/image.png".to_string()),
             content: "describe".to_string(),
@@ -1842,6 +1848,7 @@ mod tests {
     #[test]
     fn test_chat_message_to_openai_message_tool_use() {
         let msg = ChatMessage {
+            reasoning_content: Some("inspect the workspace".to_string()),
             role: ChatRole::Assistant,
             message_type: MessageType::ToolUse(vec![ToolCall {
                 id: "call_1".to_string(),
@@ -1856,6 +1863,12 @@ mod tests {
         let openai_msg = chat_message_to_openai_message(msg).expect("tool use should convert");
         assert!(openai_msg.content.is_none());
         assert!(openai_msg.tool_calls.is_some());
+        assert_eq!(
+            openai_msg.reasoning_content.as_deref(),
+            Some("inspect the workspace")
+        );
+        let serialized = serde_json::to_value(&openai_msg).unwrap();
+        assert_eq!(serialized["reasoning_content"], "inspect the workspace");
         let calls = openai_msg.tool_calls.unwrap();
         assert_eq!(calls.len(), 1);
         assert_eq!(calls[0].function.name, "lookup");
@@ -1866,6 +1879,7 @@ mod tests {
         use crate::chat::ImageMime;
 
         let msg = ChatMessage {
+            reasoning_content: None,
             role: ChatRole::User,
             message_type: MessageType::Image((ImageMime::PNG, vec![1, 2, 3, 4])),
             content: "caption".to_string(),
@@ -1894,6 +1908,7 @@ mod tests {
         };
 
         let tool_use_msg = ChatMessage {
+            reasoning_content: None,
             role: ChatRole::Assistant,
             message_type: MessageType::ToolUse(vec![tool_call.clone()]),
             content: "call".to_string(),
@@ -1906,6 +1921,7 @@ mod tests {
         assert_eq!(calls[0].function.name, "lookup");
 
         let tool_result_msg = ChatMessage {
+            reasoning_content: None,
             role: ChatRole::Tool,
             message_type: MessageType::ToolResult(vec![tool_call]),
             content: "result".to_string(),
@@ -1923,6 +1939,7 @@ mod tests {
             None, None,
         );
         let messages = vec![ChatMessage {
+            reasoning_content: None,
             role: ChatRole::User,
             message_type: MessageType::Pdf(vec![1, 2, 3]),
             content: "doc".to_string(),

--- a/crates/autoagents-mistral-rs/src/conversion.rs
+++ b/crates/autoagents-mistral-rs/src/conversion.rs
@@ -250,11 +250,13 @@ mod tests {
 
         let messages = vec![
             ChatMessage {
+                reasoning_content: None,
                 role: ChatRole::Assistant,
                 message_type: MessageType::ToolUse(vec![tool_call.clone()]),
                 content: "call".to_string(),
             },
             ChatMessage {
+                reasoning_content: None,
                 role: ChatRole::Tool,
                 message_type: MessageType::ToolResult(vec![tool_call]),
                 content: "result".to_string(),

--- a/crates/autoagents-mistral-rs/src/provider.rs
+++ b/crates/autoagents-mistral-rs/src/provider.rs
@@ -217,18 +217,26 @@ impl MistralRsProvider {
     }
 
     fn prepare_messages_with_system(&self, messages: &[ChatMessage]) -> Vec<ChatMessage> {
+        Self::prepare_messages_with_system_prompt(self.config.system_prompt.as_deref(), messages)
+    }
+
+    fn prepare_messages_with_system_prompt(
+        system_prompt: Option<&str>,
+        messages: &[ChatMessage],
+    ) -> Vec<ChatMessage> {
         let mut all_messages = Vec::new();
 
-        if let Some(system_prompt) = &self.config.system_prompt {
+        if let Some(system_prompt) = system_prompt {
             let has_system_message = messages
                 .iter()
                 .any(|msg| msg.role == autoagents_llm::chat::ChatRole::System);
 
             if !has_system_message {
                 all_messages.push(ChatMessage {
+                    reasoning_content: None,
                     role: autoagents_llm::chat::ChatRole::System,
                     message_type: autoagents_llm::chat::MessageType::Text,
-                    content: system_prompt.clone(),
+                    content: system_prompt.to_string(),
                 });
             }
         }
@@ -828,25 +836,10 @@ impl ChatProvider for MistralRsProvider {
         tools: Option<&[Tool]>,
         json_schema: Option<StructuredOutputFormat>,
     ) -> Result<Box<dyn ChatResponse>, LLMError> {
-        // Prepare messages with system prompt if needed
-        let mut all_messages = Vec::new();
-
-        // If a system_prompt is configured and there's no system message in messages,
-        // prepend it as the first system message
-        if let Some(system_prompt) = &self.config.system_prompt {
-            let has_system_message = messages
-                .iter()
-                .any(|msg| msg.role == autoagents_llm::chat::ChatRole::System);
-
-            if !has_system_message {
-                all_messages.push(ChatMessage {
-                    role: autoagents_llm::chat::ChatRole::System,
-                    message_type: autoagents_llm::chat::MessageType::Text,
-                    content: system_prompt.clone(),
-                });
-            }
-        }
-        all_messages.extend_from_slice(messages);
+        let all_messages = Self::prepare_messages_with_system_prompt(
+            self.config.system_prompt.as_deref(),
+            messages,
+        );
 
         // Detect if this is a vision model by checking model type
         let is_vision_model = self.config.model_source.detect_model_type() == ModelType::Vision;
@@ -1099,6 +1092,38 @@ mod tests {
     }
 
     #[test]
+    fn test_prepare_messages_with_system_prompt() {
+        let user_message = ChatMessage::user().content("hello").build();
+
+        let prepared = MistralRsProvider::prepare_messages_with_system_prompt(
+            Some("system instructions"),
+            &[user_message],
+        );
+        assert_eq!(prepared.len(), 2);
+        assert_eq!(prepared[0].role, autoagents_llm::chat::ChatRole::System);
+        assert_eq!(prepared[0].content, "system instructions");
+        assert!(prepared[0].reasoning_content.is_none());
+
+        let existing_system =
+            autoagents_llm::chat::ChatMessageBuilder::new(autoagents_llm::chat::ChatRole::System)
+                .content("existing")
+                .build();
+        let prepared = MistralRsProvider::prepare_messages_with_system_prompt(
+            Some("ignored"),
+            std::slice::from_ref(&existing_system),
+        );
+        assert_eq!(prepared.len(), 1);
+        assert_eq!(prepared[0].content, "existing");
+
+        let prepared = MistralRsProvider::prepare_messages_with_system_prompt(
+            None,
+            std::slice::from_ref(&existing_system),
+        );
+        assert_eq!(prepared.len(), 1);
+        assert_eq!(prepared[0].content, "existing");
+    }
+
+    #[test]
     fn test_convert_role_for_request() {
         assert!(matches!(
             convert_role_for_request(&autoagents_llm::chat::ChatRole::System),
@@ -1144,16 +1169,19 @@ mod tests {
 
         let messages = vec![
             ChatMessage {
+                reasoning_content: None,
                 role: autoagents_llm::chat::ChatRole::User,
                 message_type: autoagents_llm::chat::MessageType::Text,
                 content: "hello".to_string(),
             },
             ChatMessage {
+                reasoning_content: None,
                 role: autoagents_llm::chat::ChatRole::Assistant,
                 message_type: autoagents_llm::chat::MessageType::ToolUse(tool_calls.clone()),
                 content: "call tool".to_string(),
             },
             ChatMessage {
+                reasoning_content: None,
                 role: autoagents_llm::chat::ChatRole::Tool,
                 message_type: autoagents_llm::chat::MessageType::ToolResult(tool_calls),
                 content: "tool result".to_string(),
@@ -1171,6 +1199,7 @@ mod tests {
     #[test]
     fn test_build_request_builder_sets_json_schema_constraint() {
         let messages = vec![ChatMessage {
+            reasoning_content: None,
             role: autoagents_llm::chat::ChatRole::User,
             message_type: autoagents_llm::chat::MessageType::Text,
             content: "hello".to_string(),


### PR DESCRIPTION
**Summary**

This PR fixes #305 by preserving assistant `reasoning_content` across tool-call turns.

Previously, reasoning returned by the model was available for the current turn but was discarded when the assistant tool-call message was stored in memory. Subsequent requests therefore replayed tool-call history without reasoning, which could produce blank historical reasoning blocks in reasoning-model chat templates.

**What changed**

- Added optional `reasoning_content` support to `ChatMessage` and `ChatMessageBuilder`.
- Stored non-empty assistant reasoning alongside tool-use messages.
- Preserved reasoning in ReAct and CodeAct execution:
  - non-streaming responses use `ChatResponse::thinking()`
  - streaming responses concatenate `ReasoningContent` chunks
- Forwarded historical reasoning through OpenAI-compatible request serialization.
- Forwarded reasoning into native llama.cpp server-template messages.
- Preserved reasoning in Python message and memory conversion paths.
- Kept the existing `store_tool_interaction` API for callers that do not provide reasoning.
- Added regression coverage for streaming and non-streaming tool turns.

Messages without reasoning continue to omit `reasoning_content` during serialization.

**Why**

Reasoning models such as Qwen require the assistant reasoning associated with a tool call to remain attached to that historical assistant message. Dropping it can generate malformed or blank reasoning blocks when the next request is rendered.
This issue was identified during real-world testing with Qwen3.8-27B, where missing historical reasoning_content caused blank reasoning blocks across tool-call turns.

**Testing**

- `cargo fmt --all -- --check`
- `cargo check --workspace --all-targets --no-default-features`
- `cargo clippy --workspace --all-targets --features full -- -D warnings`
- `cargo test -p autoagents-llm`
- `cargo test -p autoagents-core --features codeact`
- Focused Python and native llama.cpp conversion tests

Closes #305

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR preserves assistant reasoning across tool-call turns so subsequent model requests can replay complete history.
- Adds optional reasoning content to the shared chat-message model and builder.
- Captures non-streaming and streaming reasoning when tool interactions are stored.
- Forwards historical reasoning through OpenAI-compatible, llama.cpp, mistral.rs, and Python conversion layers.
- Adds regression coverage for memory storage, request serialization, and multi-turn replay.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| crates/autoagents-llm/src/chat/mod.rs | Adds backward-compatible optional reasoning content to the shared ChatMessage model and builder. |
| crates/autoagents-core/src/agent/executor/turn_engine.rs | Captures response reasoning and stores it with assistant tool-use messages in streaming and non-streaming turns. |
| crates/autoagents-core/src/agent/prebuilt/executor/codeact.rs | Preserves reasoning through CodeAct tool interactions and verifies replay on subsequent turns. |
| crates/autoagents-llm/src/providers/openai_compatible.rs | Forwards optional historical reasoning through OpenAI-compatible request serialization. |
| crates/autoagents-llamacpp/src/server_chat.rs | Adds reasoning content to native llama.cpp server-template message conversion. |
| bindings/python/autoagents/src/memory/mod.rs | Preserves optional reasoning when Python message dictionaries are converted into Rust chat messages. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Model
  participant Engine as TurnEngine / CodeAct
  participant Memory
  participant Provider
  Model-->>Engine: reasoning + tool call
  Engine->>Memory: store assistant tool-use with reasoning
  Engine->>Memory: store tool result
  Memory-->>Engine: recall conversation history
  Engine->>Provider: next request with historical reasoning
  Provider->>Model: render complete tool-call turn
```
</details>

<sub>Reviews (2): Last reviewed commit: ["reasoning content in tool-call history"](https://github.com/liquidos-ai/autoagents/commit/e9e5d804105a2b87fc19f966ed628e6b1195cbed) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54260567)</sub>

<details><summary><h4>Context used (4)</h4></summary>

- Knowledge Base — [Core Agent Runtime](https://app.greptile.com/liquidos/-/custom-context/knowledge-base/liquidos-ai/autoagents/-/docs/core-agent-runtime.md)
- Knowledge Base — [autoagents-llm: Unified LLM Provider Abstraction](https://app.greptile.com/liquidos/-/custom-context/knowledge-base/liquidos-ai/autoagents/-/docs/llm-crate.md)
- Knowledge Base — [Local Inference Providers: llama.cpp and mistral.rs](https://app.greptile.com/liquidos/-/custom-context/knowledge-base/liquidos-ai/autoagents/-/docs/llamacpp-mistralrs-providers.md)
- Knowledge Base — [Umbrella Crate and Python Bindings](https://app.greptile.com/liquidos/-/custom-context/knowledge-base/liquidos-ai/autoagents/-/docs/main-crate-bindings.md)
</details>

<!-- /greptile_comment -->